### PR TITLE
Apply revalidation to dynamic pages, add page render timestamp, 

### DIFF
--- a/apps/web/src/app/[countrySlug]/[regionSlug]/[citySlug]/[presetSlug]/page.tsx
+++ b/apps/web/src/app/[countrySlug]/[regionSlug]/[citySlug]/[presetSlug]/page.tsx
@@ -9,6 +9,9 @@ import { ExternalLink } from "@/app/components/common";
 import { formatDistanceToNow } from "date-fns";
 import { getCityPresetGeojsonGitUrl } from "@/app/utils/git-url";
 import { formatToPercent } from "../../page";
+import { GLOBAL_REVALIDATION_TIME } from "@/constants";
+
+export const revalidate = GLOBAL_REVALIDATION_TIME;
 
 type CityPagePageProps = {
   params: {

--- a/apps/web/src/app/[countrySlug]/[regionSlug]/[citySlug]/page.tsx
+++ b/apps/web/src/app/[countrySlug]/[regionSlug]/[citySlug]/page.tsx
@@ -9,6 +9,9 @@ import { getCity } from "@/app/utils/get-city";
 import { getCountry } from "@/app/utils/get-country";
 import { getRegion } from "@/app/utils/get-region";
 import { CityPresetStatsWithPreset, fetchCityPresetsStats } from "./fetch";
+import { GLOBAL_REVALIDATION_TIME } from "@/constants";
+
+export const revalidate = GLOBAL_REVALIDATION_TIME;
 
 type CityPageProps = {
   params: {

--- a/apps/web/src/app/[countrySlug]/[regionSlug]/page.tsx
+++ b/apps/web/src/app/[countrySlug]/[regionSlug]/page.tsx
@@ -4,6 +4,9 @@ import { fetchRegion } from "./fetch";
 import Breadcrumbs from "../../components/breadcrumbs";
 import Table, { Column } from "@/app/components/table";
 import { CityStats } from "@prisma/client";
+import { GLOBAL_REVALIDATION_TIME } from "@/constants";
+
+export const revalidate = GLOBAL_REVALIDATION_TIME;
 
 type RegionPageProps = {
   params: {

--- a/apps/web/src/app/[countrySlug]/page.tsx
+++ b/apps/web/src/app/[countrySlug]/page.tsx
@@ -3,6 +3,9 @@ import { notFound } from "next/navigation";
 import { RegionWithCounts, fetchCountryRegions } from "./fetch";
 import Breadcrumbs from "../components/breadcrumbs";
 import Table, { Column } from "../components/table";
+import { GLOBAL_REVALIDATION_TIME } from "@/constants";
+
+export const revalidate = GLOBAL_REVALIDATION_TIME;
 
 type CountryPageProps = {
   params: {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,12 +4,23 @@ import { Analytics } from "@vercel/analytics/react";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import GlobalNav from "./components/global-nav";
+import { format } from "date-fns";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "OSM for Cities",
   description: "OpenStreetMap data for cities",
+};
+
+const Footer = () => {
+  const renderTimestamp = format(new Date(), "yyyy-MM-dd'T'HH:mm:ss");
+
+  return (
+    <footer className="italic text-sm font-thin pt-5">
+      <div>Page generated at {renderTimestamp} UTC</div>
+    </footer>
+  );
 };
 
 export default function RootLayout({
@@ -23,6 +34,7 @@ export default function RootLayout({
         <div role="main" className="max-w-4xl mx-auto p-4">
           <GlobalNav />
           {children}
+          <Footer />
         </div>
         <Analytics />
       </body>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,9 @@ import { SearchInput } from "./components/search";
 import { fetchLatestChanges } from "./fetch";
 import { formatDistanceToNow } from "date-fns";
 import { InternalLink } from "./components/common";
+import { GLOBAL_REVALIDATION_TIME } from "@/constants";
+
+export const revalidate = GLOBAL_REVALIDATION_TIME;
 
 const LatestChangesSection = async () => {
   const latestChanges = await fetchLatestChanges();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -101,7 +101,7 @@ const HeroSection = () => {
 const HomePage = () => {
   return (
     <div role="main" aria-label="home">
-      <div className="flex flex-col mx-auto max-w-2xl">
+      <div className="flex flex-col mx-auto">
         <HeroSection />
         <LatestChangesSection />
         <SearchSection />

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -1,0 +1,2 @@
+export const ONE_HOUR = 3600;
+export const GLOBAL_REVALIDATION_TIME = ONE_HOUR;


### PR DESCRIPTION
It looks like Next.js defaults to disable page revalidation. In this PR I added a revalidation time of one hour to all pages that shouldn't be static. If this works we can adjust the revalidation time once the platform is more stable. I also added a footer that displays the page render timestamp to better inspect if the page is cached for a long time.

