### PR TITLE
fix(disclaimer): Add toast id to avoid duplicates

### DIFF
--- a/apps/web/src/app/components/home/about-toast.tsx
+++ b/apps/web/src/app/components/home/about-toast.tsx
@@ -44,6 +44,7 @@ const AboutToast = () => {
           </div>
         ),
         {
+          id: "disclaimer-toast",
           duration: 10000,
           position: "bottom-right",
           style: {


### PR DESCRIPTION
Navigating to the home page from other pages displays stacked disclaimer toasts. This PR fix this behaviour by adding a id to the toast.