### PR TITLE
refactor: remove hardcoded Overpass API URL

### DIFF
--- a/src/lib/osm.ts
+++ b/src/lib/osm.ts
@@ -16,7 +16,8 @@ export async function fetchOsmRelationData(relationId: number) {
     out bb tags;
   `;
 
-  const res = await fetch("https://overpass-api.de/api/interpreter", {
+  const overpassUrl = process.env.OVERPASS_API_URL || "https://overpass-api.de/api/interpreter";
+  const res = await fetch(overpassUrl, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: `data=${encodeURIComponent(query)}`,
@@ -53,7 +54,8 @@ export async function fetchOsmRelationData(relationId: number) {
 export async function executeOverpassQuery(
   queryString: string
 ): Promise<OverpassResponse> {
-  const response = await fetch("https://overpass-api.de/api/interpreter", {
+  const overpassUrl = process.env.OVERPASS_API_URL || "https://overpass-api.de/api/interpreter";
+  const response = await fetch(overpassUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/src/lib/osm.ts
+++ b/src/lib/osm.ts
@@ -9,6 +9,9 @@ import {
 import { OSMElementSchema, type OSMRelation } from "@/types/osm";
 import { GeoJSONFeatureCollectionSchema } from "@/types/geojson";
 
+const OVERPASS_API_URL =
+  process.env.OVERPASS_API_URL || "https://overpass-api.de/api/interpreter";
+
 export async function fetchOsmRelationData(relationId: number) {
   const query = `
     [out:json][timeout:25];
@@ -16,8 +19,7 @@ export async function fetchOsmRelationData(relationId: number) {
     out bb tags;
   `;
 
-  const overpassUrl = process.env.OVERPASS_API_URL || "https://overpass-api.de/api/interpreter";
-  const res = await fetch(overpassUrl, {
+  const res = await fetch(OVERPASS_API_URL, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: `data=${encodeURIComponent(query)}`,
@@ -54,8 +56,7 @@ export async function fetchOsmRelationData(relationId: number) {
 export async function executeOverpassQuery(
   queryString: string
 ): Promise<OverpassResponse> {
-  const overpassUrl = process.env.OVERPASS_API_URL || "https://overpass-api.de/api/interpreter";
-  const response = await fetch(overpassUrl, {
+  const response = await fetch(OVERPASS_API_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
Contributes to #64

- Replace hardcoded Overpass URLs with OVERPASS_API_URL env var
- Maintains backward compatibility with default URL (https://overpass-api.de/api/interpreter)
- Refactored to use constant at top of file to avoid repetition