### PR TITLE
refactor: remove unnecessary magic links section from preferences page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -195,9 +195,7 @@
   "PreferencesPage": {
     "emailPreferences": "Email Preferences",
     "reports": "Reports",
-    "reportsDescription": "Get a summary of your monitors and their activity.",
-    "magicLinks": "Magic Links",
-    "magicLinksDescription": "Magic links for signing in are always enabled and cannot be disabled."
+    "reportsDescription": "Get a summary of your monitors and their activity."
   },
   "PreferencesForm": {
     "enableReports": "Enable reports",

--- a/messages/es.json
+++ b/messages/es.json
@@ -194,9 +194,7 @@
   "PreferencesPage": {
     "emailPreferences": "Preferencias de Email",
     "reports": "Reportes",
-    "reportsDescription": "Recibe un resumen de tus monitores y su actividad.",
-    "magicLinks": "Enlaces Mágicos",
-    "magicLinksDescription": "Los enlaces mágicos para iniciar sesión siempre están habilitados y no se pueden deshabilitar."
+    "reportsDescription": "Recibe un resumen de tus monitores y su actividad."
   },
   "PreferencesForm": {
     "enableReports": "Habilitar reportes",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -216,9 +216,7 @@
   "PreferencesPage": {
     "emailPreferences": "Preferências de Email",
     "reports": "Relatórios",
-    "reportsDescription": "Receba um resumo de seus monitores e suas atividades.",
-    "magicLinks": "Links Mágicos",
-    "magicLinksDescription": "Links mágicos para entrar estão sempre habilitados e não podem ser desabilitados."
+    "reportsDescription": "Receba um resumo de seus monitores e suas atividades."
   },
   "PreferencesForm": {
     "enableReports": "Habilitar relatórios",

--- a/src/app/[locale]/preferences/page.tsx
+++ b/src/app/[locale]/preferences/page.tsx
@@ -42,11 +42,6 @@ export default async function PreferencesPage() {
             initialLanguage={userPreferences.language}
           />
         </div>
-
-        <div className="border rounded-lg p-6 bg-gray-50">
-          <h2 className="text-lg font-semibold mb-4">{t("magicLinks")}</h2>
-          <p className="text-gray-600 mb-4">{t("magicLinksDescription")}</p>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Removes the unnecessary magic links explanation section from the preferences page and cleans up related translation keys from all language files.