### PR TITLE
fix: add Prisma generate step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+
       - name: Run type check
         run: pnpm type-check
 


### PR DESCRIPTION
Fix release workflow TypeScript errors by generating Prisma client