### PR TITLE
refactor: migrate navbar to React Aria with Design Atlas tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,9 +3,44 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Design Atlas Colors - TODO: Import directly from @design-atlas/tokens when published */
+:root {
+  --core-global-colors-olive-100: #edf6eb;
+  --core-global-colors-olive-200: #cce4c6;
+  --core-global-colors-olive-300: #a6d19c;
+  --core-global-colors-olive-400: #82bf71;
+  --core-global-colors-olive-500: #57814c;
+  --core-global-colors-olive-600: #3f5c39;
+  --core-global-colors-olive-700: #293f25;
+  --core-global-colors-blue-100: #e2eafd;
+  --core-global-colors-blue-200: #b8cbf7;
+  --core-global-colors-blue-300: #90adee;
+  --core-global-colors-blue-400: #4b82ff;
+  --core-global-colors-blue-500: #0b4ad8;
+  --core-global-colors-blue-600: #06256d;
+  --core-global-colors-blue-700: #041b4e;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  
+  /* Design Atlas token mapping for Tailwind */
+  --color-olive-50: #f6faf5;
+  --color-olive-100: var(--core-global-colors-olive-100);
+  --color-olive-200: var(--core-global-colors-olive-200);
+  --color-olive-300: var(--core-global-colors-olive-300);
+  --color-olive-400: var(--core-global-colors-olive-400);
+  --color-olive-500: var(--core-global-colors-olive-500);
+  --color-olive-600: var(--core-global-colors-olive-600);
+  --color-olive-700: var(--core-global-colors-olive-700);
+  --color-blue-100: var(--core-global-colors-blue-100);
+  --color-blue-200: var(--core-global-colors-blue-200);
+  --color-blue-300: var(--core-global-colors-blue-300);
+  --color-blue-400: var(--core-global-colors-blue-400);
+  --color-blue-500: var(--core-global-colors-blue-500);
+  --color-blue-600: var(--core-global-colors-blue-600);
+  --color-blue-700: var(--core-global-colors-blue-700);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/src/components/nav-actions.tsx
+++ b/src/components/nav-actions.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Link } from "@/i18n/navigation";
+import NavButton from "@/components/ui/nav-button";
+
+interface NavActionsProps {
+  isLoggedIn: boolean;
+  translations: {
+    about: string;
+    preferences: string;
+    signOut: string;
+    signIn: string;
+  };
+}
+
+export default function NavActions({ isLoggedIn, translations }: NavActionsProps) {
+  if (isLoggedIn) {
+    return (
+      <>
+        <NavButton variant="ghost">
+          <Link href="/about">{translations.about}</Link>
+        </NavButton>
+        <NavButton variant="ghost">
+          <Link href="/preferences">{translations.preferences}</Link>
+        </NavButton>
+        <form action="/api/auth/logout" method="POST">
+          <NavButton type="submit" variant="secondary">
+            {translations.signOut}
+          </NavButton>
+        </form>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <NavButton variant="ghost">
+        <Link href="/about">{translations.about}</Link>
+      </NavButton>
+      <NavButton variant="default">
+        <Link href="/enter">{translations.signIn}</Link>
+      </NavButton>
+    </>
+  );
+}

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@/i18n/navigation";
-import { Button } from "@/components/ui/button";
 import { auth } from "@/auth";
 import { getTranslations } from "next-intl/server";
+import NavActions from "@/components/nav-actions";
 
 export default async function NavBar() {
   const session = await auth();
@@ -9,58 +9,29 @@ export default async function NavBar() {
   const t = await getTranslations("Navigation");
 
   return (
-    <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <nav className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 shadow-sm">
       <div className="container mx-auto px-4">
         <div className="flex h-16 items-center justify-between">
           <Link
             href="/"
-            className="flex items-center space-x-2 text-xl font-bold transition-colors hover:text-foreground/80"
+            className="flex items-center text-xl font-bold text-gray-900 transition-colors hover:text-gray-700"
           >
             <span>{t("brandName")}</span>
           </Link>
 
           <div className="flex items-center gap-4">
-            {user ? <LoggedInNav /> : <LoggedOutNav />}
+            <NavActions 
+              isLoggedIn={!!user}
+              translations={{
+                about: t("about"),
+                preferences: t("preferences"),
+                signOut: t("signOut"),
+                signIn: t("signIn")
+              }}
+            />
           </div>
         </div>
       </div>
     </nav>
-  );
-}
-
-async function LoggedInNav() {
-  const t = await getTranslations("Navigation");
-
-  return (
-    <>
-      <Button variant="ghost" asChild>
-        <Link href="/about">{t("about")}</Link>
-      </Button>
-      <Button variant="ghost" asChild>
-        <Link href="/preferences" className="flex items-center gap-2">
-          {t("preferences")}
-        </Link>
-      </Button>
-      <form action="/api/auth/logout" method="POST">
-        <Button type="submit" variant="outline" size="sm">
-          {t("signOut")}
-        </Button>
-      </form>
-    </>
-  );
-}
-
-async function LoggedOutNav() {
-  const t = await getTranslations("Navigation");
-
-  return (
-    <>
-      <Button variant="ghost" asChild>
-        <Link href="/about">{t("about")}</Link>
-      </Button>
-      <Button asChild>
-        <Link href="/enter">{t("signIn")}</Link>
-      </Button>
-    </>
   );
 }

--- a/src/components/ui/nav-button.tsx
+++ b/src/components/ui/nav-button.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Button as ReactAriaButton, type ButtonProps } from "react-aria-components";
+import { cn } from "@/lib/utils";
+
+interface AriaButtonProps extends ButtonProps {
+  variant?: "default" | "secondary" | "ghost";
+  size?: "default" | "sm" | "lg";
+}
+
+const buttonVariants = {
+  variant: {
+    default: "bg-blue-500 text-white hover:bg-blue-600 focus:ring-blue-500",
+    secondary: "bg-white border border-olive-200 text-olive-700 hover:bg-olive-50 hover:text-olive-600 focus:ring-blue-500",
+    ghost: "text-olive-700 hover:text-olive-600 hover:bg-olive-100 focus:ring-blue-500"
+  },
+  size: {
+    default: "px-4 py-2 text-sm",
+    sm: "px-3 py-1.5 text-xs",
+    lg: "px-6 py-3 text-base"
+  }
+};
+
+export default function NavButton({ 
+  className, 
+  variant = "default", 
+  size = "default", 
+  children, 
+  ...props 
+}: AriaButtonProps) {
+  return (
+    <ReactAriaButton
+      className={cn(
+        "font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
+        buttonVariants.variant[variant],
+        buttonVariants.size[size],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ReactAriaButton>
+  );
+}


### PR DESCRIPTION
Migrates navbar from shadcn/ui to React Aria with Design Atlas colors.

Split into server (auth/translations) + client (interactions) components. Added NavButton with React Aria accessibility and olive/blue Design Atlas tokens.

Better accessibility and design consistency for future React Aria adoption.