### PR TITLE
feat: add consistent User-Agent headers for OSM API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ POSTMARK_FROM_EMAIL="noreply@mail.osmforcities.org"
 
 # Task Configuration
 DATASET_UPDATE_LIMIT="1" # Number of datasets to update per cron job run
+
+# OSM API Configuration
+# Optional: Custom User-Agent string (if not set, will auto-generate with app URL)
+# Example: OSM_USER_AGENT="OSMForCities (+https://osmforcities.org)"
+# OSM_USER_AGENT=""

--- a/src/app/[locale]/my-datasets/create/area-selector.tsx
+++ b/src/app/[locale]/my-datasets/create/area-selector.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Area } from "@/types/area";
 import { useTranslations } from "next-intl";
+import { getUserAgent } from "@/lib/osm";
 
 type NominatimResult = {
   place_id: number;
@@ -105,7 +106,7 @@ export default function AreaSelector({
         {
           headers: {
             "Accept-Language": "en",
-            "User-Agent": "OSMForCities/1.0",
+            "User-Agent": getUserAgent(),
           },
         }
       );

--- a/src/lib/nominatim.ts
+++ b/src/lib/nominatim.ts
@@ -3,6 +3,7 @@ import {
   type NominatimResult,
 } from "@/schemas/nominatim";
 import { Area } from "@/types/area";
+import { getUserAgent } from "./osm";
 
 // Safeguard to prevent external API calls in test mode
 function preventExternalCallsInTests() {
@@ -37,7 +38,7 @@ export async function searchAreasWithNominatim(
       {
         headers: {
           "Accept-Language": language,
-          "User-Agent": "OSMForCities/1.0",
+          "User-Agent": getUserAgent(),
         },
       }
     );
@@ -108,7 +109,7 @@ export async function getAreaDetailsById(
       {
         headers: {
           "Accept-Language": language,
-          "User-Agent": "OSMForCities/1.0",
+          "User-Agent": getUserAgent(),
         },
       }
     );

--- a/src/lib/osm.ts
+++ b/src/lib/osm.ts
@@ -12,6 +12,22 @@ import { GeoJSONFeatureCollectionSchema } from "@/types/geojson";
 const OVERPASS_API_URL =
   process.env.OVERPASS_API_URL || "https://overpass-api.de/api/interpreter";
 
+/**
+ * Get the User-Agent string for OSM API requests
+ * @returns The User-Agent string to use in API requests
+ */
+export function getUserAgent(): string {
+  // Use environment variable if provided, otherwise generate default
+  if (process.env.OSM_USER_AGENT) {
+    return process.env.OSM_USER_AGENT;
+  }
+
+  // Generate default User-Agent with app URL
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://osmforcities.org";
+  const url = baseUrl.replace(/^https?:\/\//, ''); // Remove protocol
+  return `OSMForCities (+https://${url})`;
+}
+
 // Safeguard to prevent external API calls in test mode
 function preventExternalCallsInTests() {
   if (process.env.NODE_ENV === "test") {
@@ -32,7 +48,10 @@ export async function fetchOsmRelationData(relationId: number) {
 
   const res = await fetch(OVERPASS_API_URL, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": getUserAgent(),
+    },
     body: `data=${encodeURIComponent(query)}`,
   });
 
@@ -73,6 +92,7 @@ export async function executeOverpassQuery(
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": getUserAgent(),
     },
     body: `data=${encodeURIComponent(queryString)}`,
   });


### PR DESCRIPTION
Implements request signatures for Nominatim and Overpass API calls with centralized getUserAgent() function that auto-generates with app URL and is configurable via OSM_USER_AGENT environment variable.

Contributes to #98