### PR TITLE
fix: require email verification for user reports

### DIFF
--- a/src/lib/tasks/user-report.ts
+++ b/src/lib/tasks/user-report.ts
@@ -198,6 +198,7 @@ export async function generateNextUserReport(): Promise<{
   const user = await prisma.user.findFirst({
     where: {
       reportsEnabled: true,
+      emailVerified: { not: null },
       OR: [
         { lastReportSent: null },
         {


### PR DESCRIPTION
## Summary
Add email verification requirement to user reports system to prevent sending reports to unverified users who bypass email confirmation.