### PR TITLE
feat: add API metadata endpoint with version and commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.3.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null || echo 'unknown') next dev",
     "dev:test": "NODE_ENV=test next dev",
-    "build": "next build",
+    "build": "COMMIT_HASH=$(git rev-parse HEAD) next build",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/src/app/api/metadata/route.ts
+++ b/src/app/api/metadata/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import packageJson from "../../../../package.json";
+
+export async function GET() {
+  const version = packageJson.version;
+  const commitHash = process.env.COMMIT_HASH || "unknown";
+  const timestamp = new Date().toISOString();
+
+  return NextResponse.json({
+    version,
+    commitHash,
+    timestamp,
+  });
+}
+


### PR DESCRIPTION
Adds  endpoint returning version, commit hash, and timestamp.

- New endpoint:  
- Build script sets COMMIT_HASH from git during build
- Dev script updated for local testing

Tested locally. Ready for staging deployment.