### PR TITLE
fix: prevent email reports when no recent dataset activity

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -270,7 +270,7 @@
   "PreferencesPage": {
     "emailPreferences": "Email Preferences",
     "reports": "Reports",
-    "reportsDescription": "Get a summary of your monitors and their activity."
+    "reportsDescription": "Receive email updates when your followed datasets have changes."
   },
   "PreferencesForm": {
     "enableReports": "Enable reports",

--- a/messages/es.json
+++ b/messages/es.json
@@ -269,7 +269,7 @@
   "PreferencesPage": {
     "emailPreferences": "Preferencias de Email",
     "reports": "Reportes",
-    "reportsDescription": "Recibe un resumen de tus monitores y su actividad."
+    "reportsDescription": "Recibe actualizaciones por correo electrónico cuando tus datasets monitoreados tengan cambios."
   },
   "PreferencesForm": {
     "enableReports": "Habilitar reportes",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -270,7 +270,7 @@
   "PreferencesPage": {
     "emailPreferences": "Preferências de Email",
     "reports": "Relatórios",
-    "reportsDescription": "Receba um resumo de seus monitores e suas atividades."
+    "reportsDescription": "Receba atualizações por e-mail quando seus datasets monitorados tiverem alterações."
   },
   "PreferencesForm": {
     "enableReports": "Habilitar relatórios",

--- a/src/lib/tasks/user-report.ts
+++ b/src/lib/tasks/user-report.ts
@@ -294,6 +294,11 @@ export async function generateNextUserReport(): Promise<{
     }),
   };
 
+  // Don't send email if user has no watched datasets or no recent updates
+  if (datasetsWithRecentChanges.length === 0) {
+    return null;
+  }
+
   const emailContent = generateEmailContent(datasetStats);
   const latestChangeDate =
     datasetsWithRecentChanges.length > 0


### PR DESCRIPTION
Prevent sending empty email reports by only sending emails when users have watched datasets with recent changes.

Changes:
- Modified generateNextUserReport to return null when no datasets have changes
- Updated UI text in all languages to clarify emails are sent only for dataset changes