### PR TITLE
fix: ensure next build passes in ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,3 +47,6 @@ jobs:
 
       - name: i18n check
         run: pnpm i18n:check
+
+      - name: Build (Next.js production build)
+        run: pnpm build

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -32,17 +32,18 @@ export default async function LocaleLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ locale: Locale }>;
+  params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  if (!hasLocale(routing.locales, locale)) {
+  const typedLocale = locale as Locale;
+  if (!hasLocale(routing.locales, typedLocale)) {
     notFound();
   }
 
   const messages = await getMessages();
 
   return (
-    <html lang={locale}>
+    <html lang={typedLocale}>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
Adds a Next.js production build step to the shared checks workflow and adjusts the [locale] layout type signature so it matches Next 15.5.9 expectations.

This ensures layout/type-level build issues (like the one seen after the RSC security bump) are caught in the Checks workflow, before deployment.