### PR TITLE
fix(ci): remove cross-workflow dependencies from deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,43 @@ on:
 
 jobs:
   deploy:
-    needs: [checks, tests]
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
 
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Read .nvmrc
+        id: node-version
+        run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node-version.outputs.version }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Generate Prisma Client
+        run: pnpm prisma generate
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: i18n check
+        run: pnpm i18n:check
+
+      - name: Build
+        run: pnpm build
+
       - name: Determine deployment target
         id: target
         run: |


### PR DESCRIPTION
Remove `needs: [checks, tests]` from deploy workflow. GitHub Actions doesn't support cross-workflow job dependencies. Run checks directly in deploy workflow instead.