### PR TITLE
chore: set workspace root to avoid inferred path

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,12 @@
+import path from "path";
+import { fileURLToPath } from "url";
 import createNextIntlPlugin from "next-intl/plugin";
 
-const nextConfig = {};
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const nextConfig = {
+  outputFileTracingRoot: __dirname,
+};
 
 const withNextIntl = createNextIntlPlugin({
   experimental: {


### PR DESCRIPTION
This fix this warning:

```sh
> osmforcities@1.6.2 dev /Users/vgeorge/osmforcities/osmforcities
> COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null || echo 'unknown') next dev

 ⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
 We detected multiple lockfiles and selected the directory of /Users/vgeorge/pnpm-lock.yaml as the root directory.
 To silence this warning, set `outputFileTracingRoot` in your Next.js config, or consider removing one of the lockfiles if it's not needed.
   See https://nextjs.org/docs/app/api-reference/config/next-config-js/output#caveats for more information.
 Detected additional lockfiles: 
   * /Users/vgeorge/osmforcities/osmforcities/pnpm-lock.yaml
```