### PR TITLE
feat(api): degraded state check in /api/health

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   ],
   webServer: {
     command: "NODE_ENV=test ENABLE_TEST_AUTH=true pnpm dev",
-    url: "http://localhost:3000/api/health",
+    url: "http://localhost:3000",
     reuseExistingServer: true,
     timeout: 120 * 1000,
     stdout: "pipe",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,8 +1,25 @@
 import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
 
 export async function GET() {
-  return NextResponse.json({
-    status: "ok",
-    timestamp: new Date().toISOString(),
+  const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+  const latestUpdate = await prisma.dataset.findFirst({
+    where: { isActive: true },
+    orderBy: { lastChecked: "desc" },
+    select: { lastChecked: true },
   });
+
+  const isDegraded =
+    !latestUpdate?.lastChecked ||
+    latestUpdate.lastChecked < twoHoursAgo;
+
+  return NextResponse.json(
+    {
+      status: isDegraded ? "degraded" : "ok",
+      timestamp: new Date().toISOString(),
+      ...(isDegraded && { reason: "datasets not updating" }),
+    },
+    { status: isDegraded ? 503 : 200 }
+  );
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -4,22 +4,33 @@ import { prisma } from "@/lib/db";
 export async function GET() {
   const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
 
-  const latestUpdate = await prisma.dataset.findFirst({
-    where: { isActive: true },
-    orderBy: { lastChecked: "desc" },
-    select: { lastChecked: true },
-  });
+  try {
+    const latestUpdate = await prisma.dataset.findFirst({
+      where: { isActive: true, lastChecked: { not: null } },
+      orderBy: { lastChecked: "desc" },
+      select: { lastChecked: true },
+    });
 
-  const isDegraded =
-    !latestUpdate?.lastChecked ||
-    latestUpdate.lastChecked < twoHoursAgo;
+    const isDegraded =
+      !latestUpdate?.lastChecked ||
+      latestUpdate.lastChecked < twoHoursAgo;
 
-  return NextResponse.json(
-    {
-      status: isDegraded ? "degraded" : "ok",
-      timestamp: new Date().toISOString(),
-      ...(isDegraded && { reason: "datasets not updating" }),
-    },
-    { status: isDegraded ? 503 : 200 }
-  );
+    return NextResponse.json(
+      {
+        status: isDegraded ? "degraded" : "ok",
+        timestamp: new Date().toISOString(),
+        ...(isDegraded && { reason: "datasets not updating" }),
+      },
+      { status: isDegraded ? 503 : 200 }
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        status: "degraded",
+        reason: "database unavailable",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 503 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- `/api/health` now queries `MAX(lastChecked)` across active datasets (excluding null values)
- Returns `503 {"status":"degraded","reason":"datasets not updating"}` when no dataset was updated in the last 2h
- Returns `503 {"status":"degraded","reason":"database unavailable"}` on DB errors
- Returns `200 {"status":"ok"}` otherwise
- `timestamp` preserved in all responses

Enables UptimeRobot (and any other monitor) to detect cron failures or Overpass outages without relying on error logs.

## Test

```bash
curl https://staging.osmforcities.org/api/health
# 200 {"status":"ok","timestamp":"..."} under normal conditions
# 503 {"status":"degraded","reason":"datasets not updating","timestamp":"..."} if cron is broken
# 503 {"status":"degraded","reason":"database unavailable","timestamp":"..."} if DB is down
```

Closes #212