### PR TITLE
feat(seo): reposition from "monitor" to "browse and download" focus

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -564,12 +564,12 @@
   },
   "SEO": {
     "home": {
-      "title": "OSM for Cities - Monitor OpenStreetMap Datasets",
-      "description": "Track changes in OpenStreetMap datasets across cities worldwide."
+      "title": "OSM for Cities - Browse and Download City Data",
+      "description": "Search any city, browse 200+ urban infrastructure categories, and download data as GeoJSON. Built on OpenStreetMap."
     },
     "about": {
       "title": "About - OSM for Cities",
-      "description": "Learn about OSM for Cities - Daily updated datasets from OpenStreetMap"
+      "description": "OSM for Cities makes OpenStreetMap data accessible. Browse 200+ categories and download city data."
     },
     "dataset": {
       "title": "{template} in {area} - OSM for Cities",

--- a/messages/es.json
+++ b/messages/es.json
@@ -571,12 +571,12 @@
   },
   "SEO": {
     "home": {
-      "title": "OSM for Cities - Monitorear Conjuntos de Datos de OpenStreetMap",
-      "description": "Rastrea cambios en conjuntos de datos de OpenStreetMap en ciudades de todo el mundo."
+      "title": "OSM for Cities - Explorar y Descargar Datos de Ciudades",
+      "description": "Busca cualquier ciudad, explora 200+ categorías de infraestructura urbana y descarga datos como GeoJSON. Construido sobre OpenStreetMap."
     },
     "about": {
       "title": "Acerca de - OSM for Cities",
-      "description": "Conoce OSM for Cities - Conjuntos de datos actualizados diariamente de OpenStreetMap"
+      "description": "OSM for Cities hace accesibles los datos de OpenStreetMap. Explora 200+ categorías y descarga datos de ciudades."
     },
     "dataset": {
       "title": "{template} en {area} - OSM for Cities",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -571,12 +571,12 @@
   },
   "SEO": {
     "home": {
-      "title": "OSM for Cities - Monitorar Conjuntos de Dados do OpenStreetMap",
-      "description": "Acompanhe mudanças em conjuntos de dados do OpenStreetMap em cidades do mundo todo."
+      "title": "OSM for Cities - Navegar e Baixar Dados de Cidades",
+      "description": "Pesquise qualquer cidade, navegue por 200+ categorias de infraestrutura urbana e baixe dados como GeoJSON. Baseado em OpenStreetMap."
     },
     "about": {
       "title": "Sobre - OSM for Cities",
-      "description": "Saiba mais sobre OSM for Cities - Conjuntos de dados atualizados diariamente do OpenStreetMap"
+      "description": "OSM for Cities torna dados do OpenStreetMap acessíveis. Navegue por 200+ categorias e baixe dados de cidades."
     },
     "dataset": {
       "title": "{template} em {area} - OSM for Cities",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "OSM for Cities",
-  "short_name": "OSM4Cities",
-  "description": "Monitor OpenStreetMap datasets across cities",
+  "short_name": "OSMforCities",
+  "description": "Browse and download OpenStreetMap city data",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -13,7 +13,7 @@ export interface PageMetadata {
 
 export const DEFAULT_SEO = {
   title: "OSM for Cities",
-  description: "Monitor OpenStreetMap datasets across cities",
+  description: "Search any city, browse 200+ urban infrastructure categories, and download data as GeoJSON. Built on OpenStreetMap.",
   siteUrl: process.env.NEXT_PUBLIC_APP_URL || "https://osmforcities.org",
   ogImage: "/og-image.png",
 };

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -10,7 +10,7 @@ test.describe("SEO Implementation", () => {
       const metaDescription = page
         .locator('meta[name="description"]')
         ;
-      await expect(metaDescription).toHaveAttribute("content", );
+      await expect(metaDescription).toHaveAttribute("content", /Search any city, browse 200\+ urban infrastructure categories/);
 
       // Canonical URL with locale prefix (may have trailing slash)
       const canonical = await page.locator('link[rel="canonical"]').getAttribute("href");
@@ -68,7 +68,7 @@ test.describe("SEO Implementation", () => {
       const metaDescription = page
         .locator('meta[name="description"]')
         ;
-      await expect(metaDescription).toHaveAttribute("content", );
+      await expect(metaDescription).toHaveAttribute("content", /Pesquise qualquer cidade, navegue por 200\+ categorias de infraestrutura urbana/);
 
       // Canonical URL with locale prefix (may have trailing slash)
       const canonical = await page.locator('link[rel="canonical"]').getAttribute("href");


### PR DESCRIPTION
## Summary

- Update DEFAULT_SEO description to emphasize "browse 200+ categories, download GeoJSON"
- Update SEO namespace (en, pt-BR, es) home/about descriptions
- Update PWA manifest description and short_name

## Changes

- `src/lib/metadata.ts` - DEFAULT_SEO description
- `messages/en.json` - SEO namespace for home/about
- `messages/pt-BR.json` - SEO namespace for home/about  
- `messages/es.json` - SEO namespace for home/about
- `public/site.webmanifest` - description and short_name
- `tests/seo.spec.ts` - update test assertions for new descriptions