### PR TITLE
refactor(search): cleaner placeholder behavior

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,4 @@ AUTH_URL="http://localhost:3000"
 CRON_ROUTE_SECRET="test-cron-secret"
 ENABLE_TEST_AUTH=true
 OVERPASS_API_URL="http://localhost:3000/api/mock-overpass"
+NEXT_PUBLIC_APP_URL="https://osmforcities.org"

--- a/messages/en.json
+++ b/messages/en.json
@@ -201,7 +201,7 @@
     "viewOnOpenStreetMap": "View on OpenStreetMap →"
   },
   "NavSearch": {
-    "searchPlaceholder": "Search cities and areas (min. 3 characters)...",
+    "searchPlaceholder": "Search cities and areas...",
     "noAreasFound": "No areas found",
     "searching": "Searching...",
     "typeMoreChars": "Type {count} more character{count, plural, one {} other {s}} to search",

--- a/messages/es.json
+++ b/messages/es.json
@@ -199,7 +199,7 @@
     "viewOnOpenStreetMap": "Ver en OpenStreetMap →"
   },
   "NavSearch": {
-    "searchPlaceholder": "Buscar ciudades y áreas (mín. 3 caracteres)...",
+    "searchPlaceholder": "Buscar ciudades y áreas...",
     "noAreasFound": "No se encontraron áreas",
     "searching": "Buscando...",
     "typeMoreChars": "Escribe {count} carácter{count, plural, one {} other {es}} más para buscar",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -199,7 +199,7 @@
     "viewOnOpenStreetMap": "Ver no OpenStreetMap →"
   },
   "NavSearch": {
-    "searchPlaceholder": "Buscar cidades e áreas (mín. 3 caracteres)...",
+    "searchPlaceholder": "Buscar cidades e áreas...",
     "noAreasFound": "Nenhuma área encontrada",
     "searching": "Buscando...",
     "typeMoreChars": "Digite {count} caractere{count, plural, one {} other {s}} a mais para buscar",

--- a/src/components/nav-search.tsx
+++ b/src/components/nav-search.tsx
@@ -60,6 +60,7 @@ function NavSearch() {
 
   const [inputValue, setInputValue] = useState("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Debounce the search term with 500ms delay
@@ -198,9 +199,11 @@ function NavSearch() {
       >
         <div className="relative flex rounded border border-border focus-within:border-olive-500 focus-within:ring-2 focus-within:ring-olive-500/20">
           <Input
-            placeholder={t("searchPlaceholder")}
+            placeholder={isFocused ? t("searchPlaceholder") : ""}
             aria-label={t("searchPlaceholder")}
             data-testid="nav-search-input"
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
             onKeyDown={handleKeyDown}
             className={`w-full px-3 py-1.5 text-sm border-0 rounded-l focus:outline-none bg-white transition-all duration-150 ${
               inputValue.length > 0 && inputValue.length < MIN_SEARCH_CHARS

--- a/tests/authenticated-features.spec.ts
+++ b/tests/authenticated-features.spec.ts
@@ -24,7 +24,7 @@ test.describe("Authenticated Features", () => {
       await page.waitForLoadState("domcontentloaded");
 
       // Search input should be visible for authenticated users
-      const searchInput = page.getByPlaceholder("Search cities and areas (min. 3 characters)...");
+      const searchInput = page.getByTestId("nav-search-input");
       await expect(searchInput).toBeVisible();
       await expect(searchInput).toHaveAttribute("role", "combobox");
 
@@ -91,7 +91,7 @@ test.describe("Authenticated Features", () => {
 
       await page.goto(getLocalizedPath("/"));
 
-      const searchInput = page.getByPlaceholder("Search cities and areas (min. 3 characters)...");
+      const searchInput = page.getByTestId("nav-search-input");
       await searchInput.click();
       await searchInput.fill("são paulo");
 

--- a/tests/navbar.spec.ts
+++ b/tests/navbar.spec.ts
@@ -44,9 +44,7 @@ test.describe("Navbar", () => {
       await expect(page.getByText("Sign Out")).toBeVisible();
 
       // Search input should be visible for authenticated users
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
       await expect(searchInput).toBeVisible();
       await expect(searchInput).toHaveAttribute("role", "combobox");
     } finally {
@@ -77,9 +75,7 @@ test.describe("Navbar", () => {
     test("should show helpful message for queries less than 3 characters", async ({
       page,
     }) => {
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("sa");
@@ -135,9 +131,7 @@ test.describe("Navbar", () => {
         }
       });
 
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("são");
@@ -153,9 +147,7 @@ test.describe("Navbar", () => {
     });
 
     test("should show search results for valid query", async ({ page }) => {
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("são");
@@ -181,9 +173,7 @@ test.describe("Navbar", () => {
     test("should show no results message for empty response", async ({
       page,
     }) => {
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("xyz");
@@ -198,9 +188,7 @@ test.describe("Navbar", () => {
     test("should navigate through results with arrow keys", async ({
       page,
     }) => {
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("são");
@@ -299,9 +287,7 @@ test.describe("Navbar", () => {
     test("should close dropdown and clear search when pressing Escape", async ({
       page,
     }) => {
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("são");
@@ -320,9 +306,7 @@ test.describe("Navbar", () => {
     });
 
     test("should close dropdown when clicking outside", async ({ page }) => {
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("são");
@@ -342,9 +326,7 @@ test.describe("Navbar", () => {
 
     test("should handle API errors gracefully", async ({ page }) => {
       // Global mock already handles "error" query with 500 response
-      const searchInput = page.getByPlaceholder(
-        "Search cities and areas (min. 3 characters)..."
-      );
+      const searchInput = page.getByTestId("nav-search-input");
 
       await searchInput.click();
       await searchInput.fill("error");

--- a/tests/user-registration.spec.ts
+++ b/tests/user-registration.spec.ts
@@ -23,7 +23,7 @@ test.describe("User Registration and Authentication", () => {
       await page.waitForLoadState("domcontentloaded");
 
       // Search input should be visible for authenticated users
-      const searchInput = page.getByPlaceholder("Search cities and areas (min. 3 characters)...");
+      const searchInput = page.getByTestId("nav-search-input");
       await expect(searchInput).toBeVisible();
 
       // Sign in button should NOT be visible (should show user menu instead)
@@ -45,7 +45,7 @@ test.describe("User Registration and Authentication", () => {
       await page.goto(getLocalizedPath("/"));
       await page.waitForLoadState("domcontentloaded");
 
-      const searchInput = page.getByPlaceholder("Search cities and areas (min. 3 characters)...");
+      const searchInput = page.getByTestId("nav-search-input");
       await expect(searchInput).toBeVisible();
 
       const signInButton = page.getByText("Sign In");


### PR DESCRIPTION
## Changes

- Placeholder only shows when input is focused (cleaner unfocused state)
- Removed "(min. 3 characters)" from placeholder text
- Min chars requirement still shown naturally when typing
- Tests use test-id instead of placeholder (more robust)
- Fixed SEO tests locally with production URL in .env.test