### PR TITLE
feat(hero): add responsive mobile layout with scaled typography

### DIFF
--- a/src/components/home/hero/hero-content.tsx
+++ b/src/components/home/hero/hero-content.tsx
@@ -23,7 +23,7 @@ export function HeroContent() {
           {t("hero.title")}
         </h1>
         <p
-          className="text-neutral-600 dark:text-neutral-400 md:mb-8 mb-4"
+          className="text-neutral-600 dark:text-neutral-400"
           style={{
             fontSize: 'clamp(13px, 2.5vw, 15px)',
             lineHeight: '1.5',

--- a/src/components/home/hero/hero-content.tsx
+++ b/src/components/home/hero/hero-content.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { ArrowDown } from "lucide-react";
+import { scrollToSection } from "../shared/scroll-to-section";
+
+export function HeroContent() {
+  const t = useTranslations("Home");
+
+  return (
+    <div className="flex flex-col justify-center border-r border-neutral-200 dark:border-neutral-800 bg-white dark:bg-black relative md:py-16 md:px-14 py-4 px-3 md:flex-shrink-0 flex-auto md:min-h-0">
+      <div style={{ maxWidth: '480px' }}>
+        <h1
+          className="font-medium text-neutral-900 dark:text-neutral-100 md:mb-6 mb-1"
+          style={{
+            fontSize: 'clamp(18px, 5vw, 32px)',
+            lineHeight: '1.1',
+            letterSpacing: '-0.025em',
+            textWrap: 'balance',
+          }}
+        >
+          {t("hero.title")}
+        </h1>
+        <p
+          className="text-neutral-600 dark:text-neutral-400 md:mb-8 mb-4"
+          style={{
+            fontSize: 'clamp(13px, 2.5vw, 15px)',
+            lineHeight: '1.5',
+            textWrap: 'pretty',
+          }}
+        >
+          {t("hero.description")}
+        </p>
+        <div className="mt-6 flex flex-wrap items-center gap-4 md:mt-8">
+          <Button
+            size="lg"
+            variant="primary"
+            onClick={() => scrollToSection("features")}
+            className="gap-2"
+          >
+            {t("hero.seeHowItWorks")}
+            <ArrowDown className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/hero/hero-content.tsx
+++ b/src/components/home/hero/hero-content.tsx
@@ -9,7 +9,7 @@ export function HeroContent() {
   const t = useTranslations("Home");
 
   return (
-    <div className="flex flex-col justify-center md:border-r border-neutral-200 dark:border-neutral-800 bg-white dark:bg-black relative md:py-16 md:px-14 py-4 px-3 md:flex-shrink-0 flex-auto md:min-h-0">
+    <div className="flex flex-col justify-center md:border-r border-neutral-200 dark:border-neutral-800 bg-white dark:bg-black relative md:py-16 md:px-14 py-4 px-3 md:flex-shrink-0 md:min-h-0">
       <div style={{ maxWidth: '480px' }}>
         <h1
           className="font-medium text-neutral-900 dark:text-neutral-100 md:mb-6 mb-1"

--- a/src/components/home/hero/hero-content.tsx
+++ b/src/components/home/hero/hero-content.tsx
@@ -9,7 +9,7 @@ export function HeroContent() {
   const t = useTranslations("Home");
 
   return (
-    <div className="flex flex-col justify-center border-r border-neutral-200 dark:border-neutral-800 bg-white dark:bg-black relative md:py-16 md:px-14 py-4 px-3 md:flex-shrink-0 flex-auto md:min-h-0">
+    <div className="flex flex-col justify-center md:border-r border-neutral-200 dark:border-neutral-800 bg-white dark:bg-black relative md:py-16 md:px-14 py-4 px-3 md:flex-shrink-0 flex-auto md:min-h-0">
       <div style={{ maxWidth: '480px' }}>
         <h1
           className="font-medium text-neutral-900 dark:text-neutral-100 md:mb-6 mb-1"

--- a/src/components/home/hero/hero-layout.tsx
+++ b/src/components/home/hero/hero-layout.tsx
@@ -1,7 +1,9 @@
-export function HeroLayout({ children }: { children: React.ReactNode }) {
+import type { ReactNode } from "react";
+
+export function HeroLayout({ children }: { children: ReactNode }) {
   return (
     <section
-      className="border-b border-neutral-200 dark:border-neutral-800 relative h-screen lg:min-h-[640px] xl:min-h-[700px] 2xl:min-h-[750px]"
+      className="border-b border-neutral-200 dark:border-neutral-800 relative lg:min-h-[640px] xl:min-h-[700px] 2xl:min-h-[750px]"
       style={{ height: 'calc(100vh - var(--nav-height))' }}
     >
       <div className="grid grid-rows-[auto_1fr] md:grid-rows-1 md:grid-cols-[minmax(380px,42%)_1fr] h-full md:[&>*]:h-full [&>*]:flex [&>*]:flex-col">

--- a/src/components/home/hero/hero-layout.tsx
+++ b/src/components/home/hero/hero-layout.tsx
@@ -1,0 +1,12 @@
+export function HeroLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <section
+      className="border-b border-neutral-200 dark:border-neutral-800 relative h-screen lg:min-h-[640px] xl:min-h-[700px] 2xl:min-h-[750px]"
+      style={{ height: 'calc(100vh - var(--nav-height))' }}
+    >
+      <div className="grid grid-rows-[auto_1fr] md:grid-rows-1 md:grid-cols-[minmax(380px,42%)_1fr] h-full md:[&>*]:h-full [&>*]:flex [&>*]:flex-col">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/hero/index.ts
+++ b/src/components/home/hero/index.ts
@@ -1,0 +1,2 @@
+export { HeroLayout } from "./hero-layout";
+export { HeroContent } from "./hero-content";

--- a/src/components/home/sections/hero.tsx
+++ b/src/components/home/sections/hero.tsx
@@ -1,41 +1,13 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { Button } from "@/components/ui/button";
-import { Heading } from "@/components/ui/heading";
-import { ArrowDown } from "lucide-react";
-import { scrollToSection } from "../shared/scroll-to-section";
+import { HeroLayout, HeroContent } from "../hero";
 import { HeroMap } from "../shared/hero-map";
 
 export function Hero() {
-  const t = useTranslations("Home");
-
   return (
-    <section className="min-h-screen flex items-center px-4 py-12 md:py-16 lg:py-20">
-      <div className="container mx-auto w-full">
-        <div className="grid grid-cols-1 border border-gray-200 dark:border-gray-800 lg:grid-cols-2">
-          <div className="flex flex-col justify-center p-8 md:p-12">
-            <Heading as="h1" level="h1">
-              {t("hero.title")}
-            </Heading>
-            <p className="text-lg text-gray-600 dark:text-gray-400">
-              {t("hero.description")}
-            </p>
-            <div className="mt-6 flex flex-wrap items-center gap-4 md:mt-8">
-              <Button
-                size="lg"
-                variant="primary"
-                onClick={() => scrollToSection("features")}
-                className="gap-2"
-              >
-                {t("hero.seeHowItWorks")}
-                <ArrowDown className="size-4" />
-              </Button>
-            </div>
-          </div>
-          <HeroMap />
-        </div>
-      </div>
-    </section>
+    <HeroLayout>
+      <HeroContent />
+      <HeroMap />
+    </HeroLayout>
   );
 }

--- a/src/components/home/sections/hero.tsx
+++ b/src/components/home/sections/hero.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { HeroLayout, HeroContent } from "../hero";
 import { HeroMap } from "../shared/hero-map";
 


### PR DESCRIPTION
Mobile: content shrinks to fit, map fills remaining (grid-rows-[auto_1fr])
Desktop: 2-column layout at md breakpoint (768px)
Typography: H1 clamp(18-32px), description clamp(13-15px)