### PR TITLE
refactor(analytics): centralize event constants and enhance umami tracking

### DIFF
--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -22,6 +22,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import type { TranslationFunction } from "@/lib/types";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 
 type DatasetPageProps = {
@@ -131,7 +132,7 @@ async function AreaTemplateDatasetView({
     });
 
     trackEvent(
-      "dataset_detail_view",
+      ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
       `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`
     );
 

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -21,7 +21,7 @@ import { DatasetUpsellPage } from "@/components/dataset/dataset-upsell-page";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import type { TranslationFunction } from "@/lib/types";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 
@@ -61,7 +61,8 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
 
     trackEvent(
       ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`
+      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
+      await getClientInfoFromHeaders()
     );
 
     return (

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -60,7 +60,7 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
     }
 
     trackEvent(
-      "dataset_upsell_view",
+      ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
       `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`
     );
 

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -134,7 +134,8 @@ async function AreaTemplateDatasetView({
 
     trackEvent(
       ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`
+      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
+      await getClientInfoFromHeaders()
     );
 
     const boundary = await getAreaBoundary(areaId);

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -6,7 +6,7 @@ import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { DatasetGrid } from "@/components/ui/template-grid";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
 import { Link } from "@/components/ui/link";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { auth } from "@/auth";
 
@@ -61,7 +61,8 @@ export default async function AreaPage({ params }: AreaPageProps) {
     session?.user
       ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
       : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
-    `/area/${areaId}/view`
+    `/area/${areaId}/view`,
+    await getClientInfoFromHeaders()
   );
 
   const breadcrumbItems = [

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -7,6 +7,7 @@ import { DatasetGrid } from "@/components/ui/template-grid";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
 import { Link } from "@/components/ui/link";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { auth } from "@/auth";
 
 type AreaPageProps = {
@@ -57,7 +58,9 @@ export default async function AreaPage({ params }: AreaPageProps) {
   }
 
   trackEvent(
-    session?.user ? "area_view_logged_in" : "area_view_logged_out",
+    session?.user
+      ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
+      : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
     `/area/${areaId}/view`
   );
 

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { prisma } from "@/lib/db";
 import { DashboardGrid } from "@/components/dashboard/dashboard-grid";
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export const dynamic = "force-dynamic";
 
@@ -55,7 +56,7 @@ export default async function Dashboard() {
   const tabT = await getTranslations("TabLayout");
   const watchedDatasets = await getWatchedDatasets(user.id);
 
-  trackEvent("watched_datasets_view", "/datasets/watched/view");
+  trackEvent(ANALYTICS_EVENTS.WATCHED_DATASETS_VIEW, "/datasets/watched/view");
 
   return (
     <div className="min-h-screen bg-white dark:bg-black">

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -10,7 +10,7 @@ import { getTranslations, getLocale } from "next-intl/server";
 import { prisma } from "@/lib/db";
 import { DashboardGrid } from "@/components/dashboard/dashboard-grid";
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export const dynamic = "force-dynamic";
@@ -56,7 +56,7 @@ export default async function Dashboard() {
   const tabT = await getTranslations("TabLayout");
   const watchedDatasets = await getWatchedDatasets(user.id);
 
-  trackEvent(ANALYTICS_EVENTS.WATCHED_DATASETS_VIEW, "/datasets/watched/view");
+  trackEvent(ANALYTICS_EVENTS.WATCHED_DATASETS_VIEW, "/datasets/watched/view", await getClientInfoFromHeaders());
 
   return (
     <div className="min-h-screen bg-white dark:bg-black">

--- a/src/app/[locale]/dataset/[id]/page.tsx
+++ b/src/app/[locale]/dataset/[id]/page.tsx
@@ -10,7 +10,7 @@ import { DatasetInfoPanel } from "@/components/dataset/dataset-info-panel";
 import { DatasetStatsTable } from "@/components/dataset/dataset-stats-table";
 import { DatasetActionsSection } from "@/components/dataset/dataset-actions-section";
 import { DatasetLayout } from "@/components/dataset/dataset-layout";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 
@@ -84,7 +84,7 @@ export default async function DatasetPage({
 
   const boundary = await getAreaBoundary(dataset.area.id);
 
-  trackEvent(ANALYTICS_EVENTS.DATASET_DETAIL_VIEW, `/datasets/${id}/view`);
+  trackEvent(ANALYTICS_EVENTS.DATASET_DETAIL_VIEW, `/datasets/${id}/view`, await getClientInfoFromHeaders());
 
   return (
     <DatasetLayout

--- a/src/app/[locale]/dataset/[id]/page.tsx
+++ b/src/app/[locale]/dataset/[id]/page.tsx
@@ -11,6 +11,7 @@ import { DatasetStatsTable } from "@/components/dataset/dataset-stats-table";
 import { DatasetActionsSection } from "@/components/dataset/dataset-actions-section";
 import { DatasetLayout } from "@/components/dataset/dataset-layout";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 
 async function getDataset(id: string, locale: string): Promise<Dataset | null> {
@@ -83,7 +84,7 @@ export default async function DatasetPage({
 
   const boundary = await getAreaBoundary(dataset.area.id);
 
-  trackEvent("dataset_detail_view", `/datasets/${id}/view`);
+  trackEvent(ANALYTICS_EVENTS.DATASET_DETAIL_VIEW, `/datasets/${id}/view`);
 
   return (
     <DatasetLayout

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -3,6 +3,7 @@ import { verifyToken, signIn } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
 import { prisma } from "@/lib/db";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
@@ -23,7 +24,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (!verificationResult.user.emailVerified) {
-      trackEvent("sign_up", "/sign-up");
+      trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up");
     }
 
     await prisma.user.update({

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -24,7 +24,10 @@ export async function GET(request: NextRequest) {
     }
 
     if (!verificationResult.user.emailVerified) {
-      trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up");
+      const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
+      const userAgent = request.headers.get("user-agent") || undefined;
+
+      trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up", { ip, userAgent });
     }
 
     await prisma.user.update({

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { verifyToken, signIn } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
 import { prisma } from "@/lib/db";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(request: NextRequest) {
@@ -24,10 +24,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (!verificationResult.user.emailVerified) {
-      const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
-      const userAgent = request.headers.get("user-agent") || undefined;
-
-      trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up", { ip, userAgent });
+      trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up", getClientInfo(request));
     }
 
     await prisma.user.update({

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(
@@ -27,10 +27,7 @@ export async function GET(
       );
     }
 
-    const ip = _request.headers.get("x-forwarded-for") || _request.headers.get("x-real-ip") || undefined;
-    const userAgent = _request.headers.get("user-agent") || undefined;
-
-    trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, { ip, userAgent });
+    trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request));
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -27,7 +27,10 @@ export async function GET(
       );
     }
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`);
+    const ip = _request.headers.get("x-forwarded-for") || _request.headers.get("x-real-ip") || undefined;
+    const userAgent = _request.headers.get("user-agent") || undefined;
+
+    trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, { ip, userAgent });
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(
   _request: NextRequest,
@@ -26,7 +27,7 @@ export async function GET(
       );
     }
 
-    trackEvent("dataset_download", `/datasets/${id}/download`);
+    trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`);
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -82,7 +82,10 @@ export async function POST(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`);
+    const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
+    const userAgent = request.headers.get("user-agent") || undefined;
+
+    trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`, { ip, userAgent });
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/osm";
 import { calculateBbox } from "@/lib/utils";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(
   request: NextRequest,
@@ -81,7 +82,7 @@ export async function POST(
       },
     });
 
-    trackEvent("dataset_refresh", `/datasets/${datasetId}/refresh`);
+    trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -7,7 +7,7 @@ import {
   extractDatasetStats,
 } from "@/lib/osm";
 import { calculateBbox } from "@/lib/utils";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(
@@ -82,10 +82,7 @@ export async function POST(
       },
     });
 
-    const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
-    const userAgent = request.headers.get("user-agent") || undefined;
-
-    trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`, { ip, userAgent });
+    trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`, getClientInfo(request));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/datasets/[id]/watch/route.ts
+++ b/src/app/api/datasets/[id]/watch/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import { WatchDatasetSchema, UnwatchDatasetSchema } from "@/schemas/dataset";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { MAX_FOLLOWS_PER_USER } from "@/lib/constants";
 
 export async function POST(
@@ -65,7 +66,7 @@ export async function POST(
       );
     }
 
-    trackEvent("dataset_follow", `/datasets/${datasetId}/follow`);
+    trackEvent(ANALYTICS_EVENTS.DATASET_FOLLOW, `/datasets/${datasetId}/follow`);
 
     return NextResponse.json({ success: true, watch });
   } catch (error) {
@@ -118,7 +119,7 @@ export async function DELETE(
       },
     });
 
-    trackEvent("dataset_unfollow", `/datasets/${datasetId}/unfollow`);
+    trackEvent(ANALYTICS_EVENTS.DATASET_UNFOLLOW, `/datasets/${datasetId}/unfollow`);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/datasets/[id]/watch/route.ts
+++ b/src/app/api/datasets/[id]/watch/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import { WatchDatasetSchema, UnwatchDatasetSchema } from "@/schemas/dataset";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { MAX_FOLLOWS_PER_USER } from "@/lib/constants";
 
@@ -66,10 +66,7 @@ export async function POST(
       );
     }
 
-    const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
-    const userAgent = request.headers.get("user-agent") || undefined;
-
-    trackEvent(ANALYTICS_EVENTS.DATASET_FOLLOW, `/datasets/${datasetId}/follow`, { ip, userAgent });
+    trackEvent(ANALYTICS_EVENTS.DATASET_FOLLOW, `/datasets/${datasetId}/follow`, getClientInfo(request));
 
     return NextResponse.json({ success: true, watch });
   } catch (error) {
@@ -122,10 +119,7 @@ export async function DELETE(
       },
     });
 
-    const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
-    const userAgent = request.headers.get("user-agent") || undefined;
-
-    trackEvent(ANALYTICS_EVENTS.DATASET_UNFOLLOW, `/datasets/${datasetId}/unfollow`, { ip, userAgent });
+    trackEvent(ANALYTICS_EVENTS.DATASET_UNFOLLOW, `/datasets/${datasetId}/unfollow`, getClientInfo(request));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/datasets/[id]/watch/route.ts
+++ b/src/app/api/datasets/[id]/watch/route.ts
@@ -66,7 +66,10 @@ export async function POST(
       );
     }
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_FOLLOW, `/datasets/${datasetId}/follow`);
+    const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
+    const userAgent = request.headers.get("user-agent") || undefined;
+
+    trackEvent(ANALYTICS_EVENTS.DATASET_FOLLOW, `/datasets/${datasetId}/follow`, { ip, userAgent });
 
     return NextResponse.json({ success: true, watch });
   } catch (error) {
@@ -119,7 +122,10 @@ export async function DELETE(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_UNFOLLOW, `/datasets/${datasetId}/unfollow`);
+    const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined;
+    const userAgent = request.headers.get("user-agent") || undefined;
+
+    trackEvent(ANALYTICS_EVENTS.DATASET_UNFOLLOW, `/datasets/${datasetId}/unfollow`, { ip, userAgent });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -94,7 +94,10 @@ export async function POST(req: NextRequest) {
       include: { template: true },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`);
+    const ip = req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || undefined;
+    const userAgent = req.headers.get("user-agent") || undefined;
+
+    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`, { ip, userAgent });
 
     return NextResponse.json(dataset, { status: 201 });
   } catch (err) {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/osm";
 import { calculateBbox } from "@/lib/utils";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(req: NextRequest) {
   const session = await auth();
@@ -93,7 +94,7 @@ export async function POST(req: NextRequest) {
       include: { template: true },
     });
 
-    trackEvent("dataset_create", `/datasets/${dataset.id}/create`);
+    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`);
 
     return NextResponse.json(dataset, { status: 201 });
   } catch (err) {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -10,7 +10,7 @@ import {
   extractDatasetStats,
 } from "@/lib/osm";
 import { calculateBbox } from "@/lib/utils";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(req: NextRequest) {
@@ -94,10 +94,7 @@ export async function POST(req: NextRequest) {
       include: { template: true },
     });
 
-    const ip = req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || undefined;
-    const userAgent = req.headers.get("user-agent") || undefined;
-
-    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`, { ip, userAgent });
+    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`, getClientInfo(req));
 
     return NextResponse.json(dataset, { status: 201 });
   } catch (err) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/osm";
 import { calculateBbox } from "@/lib/utils";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(req: NextRequest) {
   const authHeader = req.headers.get("authorization");
@@ -96,7 +97,7 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        trackEvent("dataset_refresh_job", `/jobs/datasets/${dataset.id}/refresh`);
+        trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
 
         results.successful++;
       } catch (error) {

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,26 @@
+/**
+ * Centralized analytics event name constants.
+ * All Umami events must be defined here.
+ */
+
+export const ANALYTICS_EVENTS = {
+  // Dataset events
+  DATASET_CREATE: "dataset_create",
+  DATASET_DETAIL_VIEW: "dataset_detail_view",
+  DATASET_DOWNLOAD: "dataset_download",
+  DATASET_FOLLOW: "dataset_follow",
+  DATASET_UNFOLLOW: "dataset_unfollow",
+  DATASET_REFRESH: "dataset_refresh",
+  DATASET_REFRESH_JOB: "dataset_refresh_job",
+  DATASET_UPSELL_VIEW: "dataset_upsell_view",
+
+  // User events
+  SIGN_UP: "sign_up",
+  WATCHED_DATASETS_VIEW: "watched_datasets_view",
+
+  // Area events
+  AREA_VIEW_LOGGED_IN: "area_view_logged_in",
+  AREA_VIEW_LOGGED_OUT: "area_view_logged_out",
+} as const;
+
+export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -11,6 +11,7 @@ import {
 import { calculateBbox } from "@/lib/utils";
 import { Prisma } from "@prisma/client";
 import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export type DatasetCreationResult = {
   dataset: NonNullable<Awaited<ReturnType<typeof getDatasetWithDetails>>>;
@@ -223,7 +224,7 @@ async function createDatasetOnDemand(
       },
     });
 
-    trackEvent("dataset_create", `/datasets/${dataset.id}/create`);
+    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`);
 
     // Resolve template translations for the given locale
     const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -28,7 +28,7 @@ export function trackEvent(
       hostname: appUrl ? new URL(appUrl).hostname : "",
       url,
       name,
-      language: options?.language || "en",
+      ...(options?.language ? { language: options.language } : {}),
       referrer: options?.referrer,
     },
   };

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,29 +1,56 @@
 import { logger } from "@/lib/logger";
 
+export interface UmamiEventOptions {
+  userAgent?: string;
+  ip?: string;
+  language?: string;
+  referrer?: string;
+}
+
 /**
  * Fire-and-forget server-side event tracking via Umami.
  * No-ops if NEXT_PUBLIC_UMAMI_URL or NEXT_PUBLIC_UMAMI_WEBSITE_ID are unset.
  */
-export function trackEvent(name: string, url: string) {
+export function trackEvent(
+  name: string,
+  url: string,
+  options?: UmamiEventOptions
+) {
   const umamiUrl = process.env.NEXT_PUBLIC_UMAMI_URL;
   const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
   const appUrl = process.env.NEXT_PUBLIC_APP_URL;
   if (!umamiUrl || !websiteId) return;
 
+  const payload = {
+    type: "event",
+    payload: {
+      website: websiteId,
+      hostname: appUrl ? new URL(appUrl).hostname : "",
+      url,
+      name,
+      userAgent: options?.userAgent || "osmforcities-server/1.0",
+      language: options?.language || "en",
+      referrer: options?.referrer,
+    },
+  };
+
+  logger.debug("Umami event", { name, payload });
+
   fetch(`${umamiUrl}/api/send`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "User-Agent": "osmforcities-server/1.0",
+      "User-Agent": options?.userAgent || "osmforcities-server/1.0",
     },
-    body: JSON.stringify({
-      type: "event",
-      payload: {
-        website: websiteId,
-        hostname: appUrl ? new URL(appUrl).hostname : "",
-        url,
-        name,
-      },
-    }),
-  }).catch((err) => logger.warn("Umami event failed", { name, err }));
+    body: JSON.stringify(payload),
+  })
+    .then(async (res) => {
+      const data = await res.json().catch(() => ({ status: res.status }));
+      if (!res.ok) {
+        logger.warn("Umami event failed", { name, status: res.status, data });
+      } else {
+        logger.debug("Umami event sent", { name, data });
+      }
+    })
+    .catch((err) => logger.warn("Umami event error", { name, err }));
 }

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -8,10 +8,12 @@ export interface UmamiEventOptions {
   referrer?: string;
 }
 
-export function getClientInfo(request: NextRequest): Pick<UmamiEventOptions, "ip" | "userAgent"> {
+export function getClientInfo(request: NextRequest): Pick<UmamiEventOptions, "ip" | "userAgent" | "language" | "referrer"> {
   return {
     ip: request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined,
     userAgent: request.headers.get("user-agent") || undefined,
+    language: request.headers.get("accept-language") || undefined,
+    referrer: request.headers.get("referer") || undefined,
   };
 }
 

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,10 +1,18 @@
 import { logger } from "@/lib/logger";
+import type { NextRequest } from "next/server";
 
 export interface UmamiEventOptions {
   userAgent?: string;
   ip?: string;
   language?: string;
   referrer?: string;
+}
+
+export function getClientInfo(request: NextRequest): Pick<UmamiEventOptions, "ip" | "userAgent"> {
+  return {
+    ip: request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined,
+    userAgent: request.headers.get("user-agent") || undefined,
+  };
 }
 
 /**
@@ -29,7 +37,7 @@ export function trackEvent(
       url,
       name,
       ...(options?.language ? { language: options.language } : {}),
-      referrer: options?.referrer,
+      ...(options?.referrer ? { referrer: options.referrer } : {}),
     },
   };
 

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -28,7 +28,6 @@ export function trackEvent(
       hostname: appUrl ? new URL(appUrl).hostname : "",
       url,
       name,
-      userAgent: options?.userAgent || "osmforcities-server/1.0",
       language: options?.language || "en",
       referrer: options?.referrer,
     },
@@ -36,12 +35,18 @@ export function trackEvent(
 
   logger.debug("Umami event", { name, payload });
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "User-Agent": options?.userAgent || "osmforcities-server/1.0",
+  };
+
+  if (options?.ip) {
+    headers["X-Forwarded-For"] = options.ip;
+  }
+
   fetch(`${umamiUrl}/api/send`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "User-Agent": options?.userAgent || "osmforcities-server/1.0",
-    },
+    headers,
     body: JSON.stringify(payload),
   })
     .then(async (res) => {

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,5 +1,6 @@
 import { logger } from "@/lib/logger";
 import type { NextRequest } from "next/server";
+import { headers } from "next/headers";
 
 export interface UmamiEventOptions {
   userAgent?: string;
@@ -8,12 +9,30 @@ export interface UmamiEventOptions {
   referrer?: string;
 }
 
-export function getClientInfo(request: NextRequest): Pick<UmamiEventOptions, "ip" | "userAgent" | "language" | "referrer"> {
+type ClientInfo = Pick<UmamiEventOptions, "ip" | "userAgent" | "language" | "referrer">;
+
+export function getClientInfo(request: NextRequest): ClientInfo {
+  const acceptLanguage = request.headers.get("accept-language");
+  const language = acceptLanguage?.split(",")[0]?.split(";")[0]?.trim();
+
   return {
     ip: request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || undefined,
     userAgent: request.headers.get("user-agent") || undefined,
-    language: request.headers.get("accept-language") || undefined,
+    language: language || undefined,
     referrer: request.headers.get("referer") || undefined,
+  };
+}
+
+export async function getClientInfoFromHeaders(): Promise<ClientInfo> {
+  const headersList = await headers();
+  const acceptLanguage = headersList.get("accept-language");
+  const language = acceptLanguage?.split(",")[0]?.split(";")[0]?.trim();
+
+  return {
+    ip: headersList.get("x-forwarded-for") || headersList.get("x-real-ip") || undefined,
+    userAgent: headersList.get("user-agent") || undefined,
+    language: language || undefined,
+    referrer: headersList.get("referer") || undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- Centralize all Umami event names to `src/lib/analytics/events.ts`
- Enhance `trackEvent()` to accept `userAgent`, `ip`, `language`, `referrer` for proper session fingerprinting
- Add response logging for debugging (both success and failure cases)

## Context

Events like `dataset_upsell_view` weren't appearing in Umami dashboard. Root cause: Umami requires `ip` + `userAgent` for session attribution.

## Files Changed

- `src/lib/umami.ts` - Enhanced with UmamiEventOptions interface and response logging
- `src/lib/analytics/events.ts` - NEW: 12 event constants
- 11 files refactored to use constants instead of hardcoded strings

## Verification Needed

After deployment, check server logs for "Umami event sent" confirmations and verify events appear in dashboard.