### PR TITLE
fix: avoid exposing Overpass errors on dataset page

### DIFF
--- a/src/components/ui/dataset-error-states.tsx
+++ b/src/components/ui/dataset-error-states.tsx
@@ -124,7 +124,9 @@ export function DatasetCreationError({
   onRetry?: () => void;
 }) {
   const t = useTranslations("DatasetErrors");
-  const isTimeout = error.toLowerCase().includes("timeout");
+  const isTimeout =
+    error.toLowerCase().includes("timeout") ||
+    error.toLowerCase().includes("timed out");
   const isTooLarge =
     error.toLowerCase().includes("too large") ||
     error.toLowerCase().includes("memory");
@@ -170,12 +172,6 @@ export function DatasetCreationError({
             </>
           )}
         </p>
-
-        {error && (
-          <div className="bg-gray-50 rounded-lg p-4 mb-6 text-left">
-            <p className="text-sm text-gray-600 font-mono">{error}</p>
-          </div>
-        )}
 
         <div className="space-y-3">
           {onRetry && (

--- a/src/lib/__tests__/dataset-operations.test.ts
+++ b/src/lib/__tests__/dataset-operations.test.ts
@@ -1,0 +1,117 @@
+// app/src/lib/__tests__/dataset-operations.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    dataset: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn(),
+    },
+    area: {
+      findUnique: vi.fn().mockResolvedValue({
+        id: 1,
+        name: "Test Area",
+        countryCode: "US",
+        bounds: null,
+        geojson: null,
+      }),
+    },
+  },
+}));
+
+vi.mock("@/lib/template-resolver", () => ({
+  resolveTemplate: vi.fn().mockResolvedValue({
+    id: "tmpl-1",
+    isActive: true,
+    deprecatesAt: null,
+    overpassQuery: "[out:json]; node; out;",
+    name: "Test Template",
+    description: "",
+    category: "test",
+    tags: [],
+    translations: [],
+  }),
+}));
+
+vi.mock("@/lib/osm", () => ({
+  fetchDatasetSnapshot: vi.fn(),
+  fetchOsmRelationData: vi.fn(),
+}));
+
+vi.mock("@/lib/umami", () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/template-locale", () => ({
+  resolveTemplateForLocale: vi.fn((t) => t),
+}));
+
+vi.mock("@/lib/nominatim", () => ({
+  getAreaDetailsById: vi.fn(),
+}));
+
+import { getOrCreateDataset } from "@/lib/dataset-operations";
+import { fetchDatasetSnapshot } from "@/lib/osm";
+
+const mockFetchDatasetSnapshot = vi.mocked(fetchDatasetSnapshot);
+
+describe("getOrCreateDataset — error sanitization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not expose raw Overpass API errors to callers", async () => {
+    mockFetchDatasetSnapshot.mockRejectedValue(
+      new Error("Overpass API error: Database error: relation 12345 not found")
+    );
+
+    let caughtError: Error | null = null;
+    try {
+      await getOrCreateDataset(1, "test-template", "en");
+    } catch (e) {
+      caughtError = e as Error;
+    }
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.message).not.toContain("Database error");
+    expect(caughtError!.message).not.toContain("relation 12345");
+    expect(caughtError!.message).not.toContain("Overpass API error");
+  });
+
+  it("does not expose raw error messages from unknown failures", async () => {
+    mockFetchDatasetSnapshot.mockRejectedValue(
+      new Error("Internal server error: stack overflow in query parser")
+    );
+
+    let caughtError: Error | null = null;
+    try {
+      await getOrCreateDataset(1, "test-template", "en");
+    } catch (e) {
+      caughtError = e as Error;
+    }
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.message).not.toContain("stack overflow");
+    expect(caughtError!.message).not.toContain("query parser");
+  });
+
+  it("preserves timeout error as user-friendly message", async () => {
+    mockFetchDatasetSnapshot.mockRejectedValue(
+      new Error("Overpass API timeout exceeded")
+    );
+
+    await expect(getOrCreateDataset(1, "test-template", "en")).rejects.toThrow(
+      "Request timed out"
+    );
+  });
+
+  it("preserves too-large error as user-friendly message", async () => {
+    mockFetchDatasetSnapshot.mockRejectedValue(
+      new Error("Response too large for query")
+    );
+
+    await expect(getOrCreateDataset(1, "test-template", "en")).rejects.toThrow(
+      "Dataset too large"
+    );
+  });
+});

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -236,16 +236,9 @@ async function createDatasetOnDemand(
           "Dataset too large - try a smaller area or more specific template"
         );
       }
-      if (error.message.includes("Overpass API error")) {
-        throw new Error(`Overpass API error: ${error.message}`);
-      }
     }
 
-    throw new Error(
-      `Failed to fetch dataset data: ${
-        error instanceof Error ? error.message : "Unknown error"
-      }`
-    );
+    throw new Error("Failed to load dataset data. Please try again later.");
   }
 }
 


### PR DESCRIPTION
## Summary

- Sanitize error re-throws in `createDatasetOnDemand`: remove the Overpass-specific re-throw and replace the generic fallback with a fixed message — raw Overpass error text no longer propagates to callers
- Remove raw error string display from `DatasetCreationError` component — users see only categorized user-friendly messages (timeout / too-large / generic)
- Add 4 unit tests covering error sanitization behavior

Fixes #132

## Test Plan

- [ ] Unit tests pass: `pnpm test:unit run --project unit` (80 tests, all pass)
- [ ] Trigger a dataset creation failure (invalid Overpass query or timeout) and confirm no internal error details appear on the page