### PR TITLE
feat(dataset): add isFeatured field and toggle API

### DIFF
--- a/prisma/migrations/20260523165655_add_is_featured_to_dataset/migration.sql
+++ b/prisma/migrations/20260523165655_add_is_featured_to_dataset/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "datasets_userId_templateId_areaId_key";
+
+-- AlterTable
+ALTER TABLE "dataset_watches" ALTER COLUMN "id" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "datasets" ADD COLUMN     "isFeatured" BOOLEAN NOT NULL DEFAULT false;
+
+-- RenameIndex
+ALTER INDEX "Dataset_templateId_areaId_key" RENAME TO "datasets_templateId_areaId_key";

--- a/prisma/migrations/20260523165655_add_is_featured_to_dataset/migration.sql
+++ b/prisma/migrations/20260523165655_add_is_featured_to_dataset/migration.sql
@@ -1,11 +1,2 @@
--- DropIndex
-DROP INDEX "datasets_userId_templateId_areaId_key";
-
 -- AlterTable
-ALTER TABLE "dataset_watches" ALTER COLUMN "id" DROP DEFAULT;
-
--- AlterTable
-ALTER TABLE "datasets" ADD COLUMN     "isFeatured" BOOLEAN NOT NULL DEFAULT false;
-
--- RenameIndex
-ALTER INDEX "Dataset_templateId_areaId_key" RENAME TO "datasets_templateId_areaId_key";
+ALTER TABLE "datasets" ADD COLUMN "isFeatured" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,7 @@ model Dataset {
   templateId  String
   cityName    String
   isActive    Boolean        @default(true)
+  isFeatured  Boolean        @default(false)
   lastChecked DateTime?
   dataCount   Int            @default(0)
   geojson     Json?

--- a/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PUT } from "../route";
+import { prisma } from "@/lib/db";
+
+describe("PUT /api/datasets/[id]/feature", () => {
+  let testDatasetId: string;
+  let originalIsFeaturedValue: boolean | undefined;
+
+  beforeAll(async () => {
+    // Find an existing dataset
+    const datasets = await prisma.dataset.findMany({
+      take: 1,
+      select: { id: true, isFeatured: true },
+    });
+
+    if (datasets.length === 0) {
+      throw new Error("No datasets found in test database");
+    }
+
+    testDatasetId = datasets[0].id;
+    originalIsFeaturedValue = datasets[0].isFeatured;
+  });
+
+  afterAll(async () => {
+    // Restore original value
+    if (testDatasetId && originalIsFeaturedValue !== undefined) {
+      await prisma.dataset.update({
+        where: { id: testDatasetId },
+        data: { isFeatured: originalIsFeaturedValue },
+      });
+    }
+  });
+
+  it("should return 403 for non-admin users", async () => {
+    // Mock non-admin session
+    const request = new Request("http://localhost:3000/api/datasets/" + testDatasetId + "/feature", {
+      method: "PUT",
+    });
+
+    // @ts-expect-error - mock session
+    const response = await PUT(request, {
+      params: { id: testDatasetId },
+    });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("should return 404 for non-existent dataset", async () => {
+    const request = new Request("http://localhost:3000/api/datasets/invalid-id/feature", {
+      method: "PUT",
+    });
+
+    // @ts-expect-error - mock params
+    const response = await PUT(request, {
+      params: { id: "invalid-id" },
+    });
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Dataset not found");
+  });
+
+  it("should toggle isFeatured field successfully", async () => {
+    // Get current value
+    const beforeUpdate = await prisma.dataset.findUnique({
+      where: { id: testDatasetId },
+      select: { isFeatured: true },
+    });
+
+    const request = new Request("http://localhost:3000/api/datasets/" + testDatasetId + "/feature", {
+      method: "PUT",
+    });
+
+    // @ts-expect-error - mock params and session
+    const response = await PUT(request, {
+      params: { id: testDatasetId },
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.isFeatured).toBe(!beforeUpdate?.isFeatured);
+    expect(body.id).toBe(testDatasetId);
+  });
+});

--- a/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
@@ -37,9 +37,8 @@ describe("PUT /api/datasets/[id]/feature", () => {
       method: "PUT",
     });
 
-    // @ts-expect-error - mock session
     const response = await PUT(request, {
-      params: { id: testDatasetId },
+      params: Promise.resolve({ id: testDatasetId }),
     });
 
     expect(response.status).toBe(403);
@@ -52,9 +51,8 @@ describe("PUT /api/datasets/[id]/feature", () => {
       method: "PUT",
     });
 
-    // @ts-expect-error - mock params
     const response = await PUT(request, {
-      params: { id: "invalid-id" },
+      params: Promise.resolve({ id: "invalid-id" }),
     });
 
     expect(response.status).toBe(404);
@@ -73,9 +71,8 @@ describe("PUT /api/datasets/[id]/feature", () => {
       method: "PUT",
     });
 
-    // @ts-expect-error - mock params and session
     const response = await PUT(request, {
-      params: { id: testDatasetId },
+      params: Promise.resolve({ id: testDatasetId }),
     });
 
     expect(response.status).toBe(200);

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/auth";
 
 export async function PUT(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     // Get current session
@@ -19,9 +19,12 @@ export async function PUT(
       );
     }
 
+    // Resolve params
+    const { id } = await params;
+
     // Get current dataset
     const dataset = await prisma.dataset.findUnique({
-      where: { id: params.id }
+      where: { id }
     });
 
     if (!dataset) {
@@ -33,7 +36,7 @@ export async function PUT(
 
     // Toggle isFeatured
     const updatedDataset = await prisma.dataset.update({
-      where: { id: params.id },
+      where: { id },
       data: { isFeatured: !dataset.isFeatured }
     });
 

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { auth } from "@/auth";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Get current session
+    const session = await auth();
+    const user = session?.user || null;
+
+    // Check admin authorization
+    if (!user?.isAdmin) {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: 403 }
+      );
+    }
+
+    // Get current dataset
+    const dataset = await prisma.dataset.findUnique({
+      where: { id: params.id }
+    });
+
+    if (!dataset) {
+      return NextResponse.json(
+        { error: "Dataset not found" },
+        { status: 404 }
+      );
+    }
+
+    // Toggle isFeatured
+    const updatedDataset = await prisma.dataset.update({
+      where: { id: params.id },
+      data: { isFeatured: !dataset.isFeatured }
+    });
+
+    return NextResponse.json(updatedDataset);
+  } catch (error) {
+    console.error("Error toggling featured status:", error);
+    return NextResponse.json(
+      { error: "Failed to toggle featured status" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -22,21 +22,8 @@ export async function PUT(
     // Resolve params
     const { id } = await params;
 
-    // Check dataset exists before toggling
-    const existing = await prisma.dataset.findUnique({
-      where: { id },
-      select: { id: true },
-    });
-
-    if (!existing) {
-      return NextResponse.json(
-        { error: "Dataset not found" },
-        { status: 404 }
-      );
-    }
-
     // Toggle isFeatured atomically using a raw update expression
-    const [result] = await prisma.$queryRaw<
+    const rows = await prisma.$queryRaw<
       { id: string; isFeatured: boolean }[]
     >`
       UPDATE "datasets"
@@ -45,6 +32,14 @@ export async function PUT(
       RETURNING id, "isFeatured"
     `;
 
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Dataset not found" },
+        { status: 404 }
+      );
+    }
+
+    const [result] = rows;
     return NextResponse.json({ id: result.id, isFeatured: result.isFeatured });
   } catch (error) {
     console.error("Error toggling featured status:", error);

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -40,7 +40,7 @@ export async function PUT(
       data: { isFeatured: !dataset.isFeatured }
     });
 
-    return NextResponse.json(updatedDataset);
+    return NextResponse.json({ id: updatedDataset.id, isFeatured: updatedDataset.isFeatured });
   } catch (error) {
     console.error("Error toggling featured status:", error);
     return NextResponse.json(

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -24,7 +24,8 @@ export async function PUT(
 
     // Get current dataset
     const dataset = await prisma.dataset.findUnique({
-      where: { id }
+      where: { id },
+      select: { id: true, isFeatured: true },
     });
 
     if (!dataset) {

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -22,26 +22,30 @@ export async function PUT(
     // Resolve params
     const { id } = await params;
 
-    // Get current dataset
-    const dataset = await prisma.dataset.findUnique({
+    // Check dataset exists before toggling
+    const existing = await prisma.dataset.findUnique({
       where: { id },
-      select: { id: true, isFeatured: true },
+      select: { id: true },
     });
 
-    if (!dataset) {
+    if (!existing) {
       return NextResponse.json(
         { error: "Dataset not found" },
         { status: 404 }
       );
     }
 
-    // Toggle isFeatured
-    const updatedDataset = await prisma.dataset.update({
-      where: { id },
-      data: { isFeatured: !dataset.isFeatured }
-    });
+    // Toggle isFeatured atomically using a raw update expression
+    const [result] = await prisma.$queryRaw<
+      { id: string; isFeatured: boolean }[]
+    >`
+      UPDATE "datasets"
+      SET "isFeatured" = NOT "isFeatured"
+      WHERE id = ${id}
+      RETURNING id, "isFeatured"
+    `;
 
-    return NextResponse.json({ id: updatedDataset.id, isFeatured: updatedDataset.isFeatured });
+    return NextResponse.json({ id: result.id, isFeatured: result.isFeatured });
   } catch (error) {
     console.error("Error toggling featured status:", error);
     return NextResponse.json(

--- a/src/lib/prisma/__tests__/is-featured.test.ts
+++ b/src/lib/prisma/__tests__/is-featured.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { prisma } from "@/lib/db";
+
+describe("Dataset.isFeatured field", () => {
+  let testDatasetId: string;
+  let originalIsFeaturedValue: boolean | undefined;
+
+  beforeAll(async () => {
+    // Find an existing dataset
+    const datasets = await prisma.dataset.findMany({
+      take: 1,
+      select: { id: true, isFeatured: true },
+    });
+
+    if (datasets.length === 0) {
+      throw new Error("No datasets found in test database");
+    }
+
+    testDatasetId = datasets[0].id;
+    originalIsFeaturedValue = datasets[0].isFeatured;
+  });
+
+  afterAll(async () => {
+    // Restore original value
+    if (testDatasetId && originalIsFeaturedValue !== undefined) {
+      await prisma.dataset.update({
+        where: { id: testDatasetId },
+        data: { isFeatured: originalIsFeaturedValue },
+      });
+    }
+  });
+
+  it("should have isFeatured field on Dataset model", async () => {
+    const dataset = await prisma.dataset.findUnique({
+      where: { id: testDatasetId },
+    });
+
+    expect(dataset).not.toBeNull();
+    expect(dataset?.isFeatured).toBeDefined();
+    expect(typeof dataset?.isFeatured).toBe("boolean");
+  });
+
+  it("should allow toggling isFeatured field", async () => {
+    // Get current value
+    const current = await prisma.dataset.findUnique({
+      where: { id: testDatasetId },
+      select: { isFeatured: true },
+    });
+
+    // Toggle to opposite
+    const toggled = await prisma.dataset.update({
+      where: { id: testDatasetId },
+      data: { isFeatured: !current?.isFeatured },
+    });
+
+    expect(toggled.isFeatured).toBe(!current?.isFeatured);
+
+    // Toggle back
+    const restored = await prisma.dataset.update({
+      where: { id: testDatasetId },
+      data: { isFeatured: current?.isFeatured ?? false },
+    });
+
+    expect(restored.isFeatured).toBe(current?.isFeatured ?? false);
+  });
+});


### PR DESCRIPTION
## Featured Datasets: Add isFeatured field and toggle API

**Related Issues:** #249, #250

**Issue #249:** Add isFeatured field to Dataset model
- Add isFeatured Boolean @default(false) to Dataset model
- Run migration: pnpm prisma migrate dev
- Verify column exists in database
- Prisma Client types updated

**Issue #250:** API endpoint for toggling featured status
- Create PUT /api/datasets/[id]/feature endpoint
- Implement PUT endpoint to toggle isFeatured
- Require isAdmin: true (return 403 for non-admins)
- Return updated dataset with isFeatured field

**Problem:**
Datasets need a way to be marked as "featured" so they can be publicly accessible without login. This requires (1) a database field to track featured status and (2) an admin API to toggle it.

**Acceptance Criteria:**
- [ ] Migration runs successfully
- [ ] Dataset table has isFeatured column (boolean, default false)
- [ ] Prisma Client types updated
- [ ] Admin can toggle featured status via API
- [ ] Non-admins get 403
- [ ] Returns updated dataset with isFeatured field

**Changes:**
- Added `isFeatured Boolean @default(false)` to Dataset model in prisma/schema.prisma
- Created migration to add isFeatured column to datasets table
- Created PUT /api/datasets/[id]/feature endpoint for admin-only toggle
- Endpoint validates admin session via NextAuth, returns 403 for non-admins
- Updated route signature for Next.js 15 (params is now Promise)
- Added integration tests for database field (TDD approach)
- Manual testing confirmed toggle works correctly (true ↔ false)