### PR TITLE
feat(dataset): add featured toggle and badge to dataset detail page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -168,6 +168,11 @@
     "refreshing": "Refreshing...",
     "watch": "Watch",
     "unwatch": "Unwatch",
+    "featured": "Featured",
+    "feature": "Feature",
+    "unfeature": "Unfeature",
+    "featureTitle": "Feature this dataset on homepage",
+    "unfeatureTitle": "Remove from featured",
     "dataMetrics": "Data Metrics",
     "actions": "Actions"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -167,6 +167,11 @@
     "refreshing": "Actualizando...",
     "watch": "Seguir",
     "unwatch": "Dejar de Seguir",
+    "featured": "Destacado",
+    "feature": "Destacar",
+    "unfeature": "Quitar destacado",
+    "featureTitle": "Destacar este conjunto en la página principal",
+    "unfeatureTitle": "Quitar de destacados",
     "dataMetrics": "Métricas de Datos",
     "actions": "Acciones"
   },

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -167,6 +167,11 @@
     "refreshing": "Atualizando...",
     "watch": "Seguir",
     "unwatch": "Parar de Seguir",
+    "featured": "Destacado",
+    "feature": "Destacar",
+    "unfeature": "Remover destaque",
+    "featureTitle": "Destacar este conjunto na página inicial",
+    "unfeatureTitle": "Remover dos destaques",
     "dataMetrics": "Métricas dos Dados",
     "actions": "Ações"
   },

--- a/src/app/[locale]/dataset/[id]/page.tsx
+++ b/src/app/[locale]/dataset/[id]/page.tsx
@@ -62,6 +62,8 @@ async function getDataset(id: string, locale: string): Promise<Dataset | null> {
       isWatched: user ? rawDataset.watchers.length > 0 : false,
       watchersCount: rawDataset._count.watchers,
       canDelete: false,
+      isFeatured: rawDataset.isFeatured ?? false,
+      canFeature: user?.isAdmin ?? false,
     });
   } catch (error) {
     console.error("Error fetching dataset:", error);

--- a/src/components/dataset/dataset-actions-section.tsx
+++ b/src/components/dataset/dataset-actions-section.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { Download, RefreshCw, Eye, EyeOff } from "lucide-react";
+import { Download, RefreshCw, Eye, EyeOff, Star } from "lucide-react";
 import type { Dataset } from "@/schemas/dataset";
 import { useDatasetDownload } from "@/hooks/useDatasetDownload";
 import { useDatasetActions } from "@/hooks/useDatasetActions";
@@ -20,6 +20,8 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
 
   const [isWatched, setIsWatched] = useState(dataset.isWatched || false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isFeatured, setIsFeatured] = useState(dataset.isFeatured ?? false);
+  const [isFeaturingLoading, setIsFeaturingLoading] = useState(false);
 
   const handleToggleWatch = async () => {
     try {
@@ -43,13 +45,27 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
     }
   };
 
+  const handleToggleFeatured = async () => {
+    setIsFeaturingLoading(true);
+    try {
+      const res = await fetch(`/api/datasets/${dataset.id}/feature`, {
+        method: "PUT",
+      });
+      if (!res.ok) throw new Error("Failed to toggle featured status");
+      const data = await res.json();
+      setIsFeatured(data.isFeatured);
+    } catch (error) {
+      console.error("Error toggling featured status:", error);
+    } finally {
+      setIsFeaturingLoading(false);
+    }
+  };
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
       const result = await refreshDataset(dataset.id);
-      if (result.success) {
-        // Optionally show success message or update UI
-      } else {
+      if (!result.success) {
         console.error("Failed to refresh dataset:", result.error);
       }
     } catch (error) {
@@ -63,6 +79,26 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
     <div className="pt-4 pb-2">
       <div className="border-t border-gray-300 mb-4"></div>
       <div className="flex flex-col gap-3">
+        {isFeatured && !dataset.canFeature && (
+          <div className="flex items-center gap-1.5 text-sm font-medium text-amber-600">
+            <Star className="h-4 w-4 fill-current" />
+            {t("featured")}
+          </div>
+        )}
+
+        {dataset.canFeature && (
+          <Button
+            onClick={handleToggleFeatured}
+            disabled={isFeaturingLoading}
+            className="flex items-center gap-2 w-full h-10"
+            variant={isFeatured ? "default" : "outline"}
+            title={isFeatured ? t("unfeatureTitle") : t("featureTitle")}
+          >
+            <Star className={`h-4 w-4 ${isFeatured ? "fill-current" : ""}`} />
+            {isFeatured ? t("unfeature") : t("feature")}
+          </Button>
+        )}
+
         {/* Refresh Button */}
         <Button
           onClick={handleRefresh}
@@ -99,23 +135,23 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
 
         {/* Watch/Unwatch Button */}
         <Button
-            onClick={handleToggleWatch}
-            disabled={isLoading}
-            className="flex items-center gap-2 w-full h-10"
-            variant={isWatched ? "default" : "outline"}
-            title={
-              isWatched
-                ? "Stop receiving updates about this dataset"
-                : "Get notified when this dataset is updated"
-            }
-            data-testid={isWatched ? "dataset-unwatch-button" : "dataset-watch-button"}
-          >
-            {isWatched ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-            {isWatched ? t("unwatch") : t("watch")}
+          onClick={handleToggleWatch}
+          disabled={isLoading}
+          className="flex items-center gap-2 w-full h-10"
+          variant={isWatched ? "default" : "outline"}
+          title={
+            isWatched
+              ? "Stop receiving updates about this dataset"
+              : "Get notified when this dataset is updated"
+          }
+          data-testid={isWatched ? "dataset-unwatch-button" : "dataset-watch-button"}
+        >
+          {isWatched ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+          {isWatched ? t("unwatch") : t("watch")}
         </Button>
       </div>
     </div>

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -87,6 +87,8 @@ export const DatasetSchema = z.object({
   isWatched: z.boolean().optional(),
   watchersCount: z.number().optional(),
   canDelete: z.boolean().optional(),
+  isFeatured: z.boolean().optional(),
+  canFeature: z.boolean().optional(),
 });
 
 export type Dataset = z.infer<typeof DatasetSchema>;


### PR DESCRIPTION
## Issue #251: Add featured toggle to dataset detail page

**Problem:** No way for admins to mark a dataset as featured from the UI. The `isFeatured` DB column (#249) and toggle API (#250) exist but are not surfaced on the dataset detail page.

**Acceptance Criteria:**
- [x] Toggle visible only to admins on /dataset/[id] page
- [x] Featured badge visible to all when featured
- [x] Toggling works without page refresh
- [x] Errors handled gracefully

**Changes:**
- `DatasetSchema` — added `isFeatured` and `canFeature` optional boolean fields
- `getDataset()` — populates `isFeatured` from DB, `canFeature` from `user.isAdmin`
- `DatasetActionsSection` — admin-only Feature/Unfeature button with optimistic UI calling `PUT /api/datasets/[id]/feature`; Featured badge shown to non-admins when `isFeatured` is true
- Translations added for featured/feature/unfeature strings (en, es, pt-BR)