### PR TITLE
refactor(dataset): extract DatasetSchema.parse() into transformDataset service

### DIFF
--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -1,8 +1,7 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
-import { DatasetSchema } from "@/schemas/dataset";
-import type { FeatureCollection } from "geojson";
+import { transformDataset } from "@/lib/dataset/transform";
 import { DatasetInteractiveSection } from "@/components/dataset/dataset-interactive-section";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
 import { getOrCreateDataset } from "@/lib/dataset-operations";
@@ -119,18 +118,7 @@ async function AreaTemplateDatasetView({
       isWatched = !!watchRecord;
     }
 
-    const dataset = DatasetSchema.parse({
-      ...result.dataset,
-      geojson: result.dataset.geojson as FeatureCollection | null,
-      bbox: result.dataset.bbox as number[] | null,
-      area: {
-        ...result.dataset.area,
-        geojson: result.dataset.area.geojson as FeatureCollection | null,
-      },
-      isWatched,
-      watchersCount: result.dataset.watchers?.length || 0,
-      canDelete: false,
-    });
+    const dataset = transformDataset(result.dataset, session?.user || null, locale, { isWatched });
 
     trackEvent(
       ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -118,7 +118,7 @@ async function AreaTemplateDatasetView({
       isWatched = !!watchRecord;
     }
 
-    const dataset = transformDataset(result.dataset, session?.user || null, locale, { isWatched });
+    const dataset = transformDataset(result.dataset, session?.user || null, locale, { isWatched, skipTemplateResolution: true });
 
     trackEvent(
       ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,

--- a/src/app/[locale]/dataset/[id]/page.tsx
+++ b/src/app/[locale]/dataset/[id]/page.tsx
@@ -2,9 +2,8 @@ import { prisma } from "@/lib/db";
 import { notFound } from "next/navigation";
 import { auth } from "@/auth";
 import { getLocale } from "next-intl/server";
-import { resolveTemplateForLocale } from "@/lib/template-locale";
-import { DatasetSchema, type Dataset } from "@/schemas/dataset";
-import type { FeatureCollection } from "geojson";
+import { type Dataset } from "@/schemas/dataset";
+import { transformDataset } from "@/lib/dataset/transform";
 import { DatasetMapWrapper } from "@/components/dataset/map-wrapper";
 import { DatasetInfoPanel } from "@/components/dataset/dataset-info-panel";
 import { DatasetStatsTable } from "@/components/dataset/dataset-stats-table";
@@ -45,26 +44,7 @@ async function getDataset(id: string, locale: string): Promise<Dataset | null> {
 
     if (!rawDataset) return null;
 
-    const resolvedTemplate = resolveTemplateForLocale(
-      rawDataset.template,
-      locale,
-    );
-
-    return DatasetSchema.parse({
-      ...rawDataset,
-      template: resolvedTemplate,
-      geojson: rawDataset.geojson as FeatureCollection | null,
-      bbox: rawDataset.bbox as number[] | null,
-      area: {
-        ...rawDataset.area,
-        geojson: rawDataset.area.geojson as FeatureCollection | null,
-      },
-      isWatched: user ? rawDataset.watchers.length > 0 : false,
-      watchersCount: rawDataset._count.watchers,
-      canDelete: false,
-      isFeatured: rawDataset.isFeatured ?? false,
-      canFeature: user?.isAdmin ?? false,
-    });
+    return transformDataset(rawDataset, user, locale);
   } catch (error) {
     console.error("Error fetching dataset:", error);
     return null;

--- a/src/app/api/datasets/watched/route.ts
+++ b/src/app/api/datasets/watched/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import { transformDataset } from "@/lib/dataset/transform";
 
 export async function GET() {
+  const headersList = await headers();
   try {
     const session = await auth();
     const user = session?.user || null;
@@ -39,8 +41,12 @@ export async function GET() {
       },
     });
 
+    // Derive locale from Accept-Language header (default to 'en' if not specified)
+    const acceptLanguage = headersList.get("accept-language") || "en";
+    const locale = acceptLanguage.split(",")[0].split("-")[0];
+
     const datasets = watchedDatasets.map((watch) =>
-      transformDataset(watch.dataset, user, "en", { isWatched: true })
+      transformDataset(watch.dataset, user, locale, { isWatched: true })
     );
 
     return NextResponse.json(datasets);

--- a/src/app/api/datasets/watched/route.ts
+++ b/src/app/api/datasets/watched/route.ts
@@ -43,7 +43,7 @@ export async function GET() {
 
     // Derive locale from Accept-Language header (default to 'en' if not specified)
     const acceptLanguage = headersList.get("accept-language") || "en";
-    const locale = acceptLanguage.split(",")[0].split("-")[0];
+    const locale = acceptLanguage.split(",")[0].trim();
 
     const datasets = watchedDatasets.map((watch) =>
       transformDataset(watch.dataset, user, locale, { isWatched: true })

--- a/src/app/api/datasets/watched/route.ts
+++ b/src/app/api/datasets/watched/route.ts
@@ -5,8 +5,8 @@ import { prisma } from "@/lib/db";
 import { transformDataset } from "@/lib/dataset/transform";
 
 export async function GET() {
-  const headersList = await headers();
   try {
+    const headersList = await headers();
     const session = await auth();
     const user = session?.user || null;
 
@@ -41,9 +41,9 @@ export async function GET() {
       },
     });
 
-    // Derive locale from Accept-Language header (default to 'en' if not specified)
+    // Derive locale from Accept-Language header, preserving full tag (e.g., 'pt-BR', not 'pt')
     const acceptLanguage = headersList.get("accept-language") || "en";
-    const locale = acceptLanguage.split(",")[0].trim();
+    const locale = acceptLanguage.split(",")[0].split(";")[0].trim();
 
     const datasets = watchedDatasets.map((watch) =>
       transformDataset(watch.dataset, user, locale, { isWatched: true })

--- a/src/app/api/datasets/watched/route.ts
+++ b/src/app/api/datasets/watched/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
-import { DatasetSchema } from "@/schemas/dataset";
-import type { FeatureCollection } from "geojson";
+import { transformDataset } from "@/lib/dataset/transform";
 
 export async function GET() {
   try {
@@ -40,20 +39,9 @@ export async function GET() {
       },
     });
 
-    const datasets = watchedDatasets.map((watch) => {
-      const dataset = watch.dataset;
-      return DatasetSchema.parse({
-        ...dataset,
-        geojson: dataset.geojson as FeatureCollection | null,
-        bbox: dataset.bbox as number[] | null,
-        area: {
-          ...dataset.area,
-          geojson: dataset.area.geojson as FeatureCollection | null,
-        },
-        isWatched: true,
-        watchersCount: dataset._count.watchers,
-      });
-    });
+    const datasets = watchedDatasets.map((watch) =>
+      transformDataset(watch.dataset, user, "en", { isWatched: true })
+    );
 
     return NextResponse.json(datasets);
   } catch (error) {

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -54,7 +54,7 @@ export function transformDataset(
   const permissions = calculatePermissions(rawDataset, user);
 
   // If isWatched is explicitly provided, use it. Otherwise infer from watchers array.
-  const isWatched = options?.isWatched ?? (rawDataset.watchers && rawDataset.watchers.length > 0);
+  const isWatched = options?.isWatched ?? (rawDataset.watchers ? rawDataset.watchers.length > 0 : false);
 
   return DatasetSchema.parse({
     ...rawDataset,
@@ -66,7 +66,7 @@ export function transformDataset(
       geojson: rawDataset.area.geojson as FeatureCollection | null,
     } : rawDataset.area,
     isWatched,
-    watchersCount: rawDataset._count?.watchers || rawDataset.watchers?.length || 0,
+    watchersCount: rawDataset._count?.watchers ?? rawDataset.watchers?.length ?? 0,
     ...permissions,
   });
 }

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -1,0 +1,72 @@
+import type { Dataset } from "@/schemas/dataset";
+import { DatasetSchema } from "@/schemas/dataset";
+import { resolveTemplateForLocale } from "@/lib/template-locale";
+import type { FeatureCollection } from "geojson";
+import type { User } from "next-auth";
+
+type RawDataset = {
+  [key: string]: unknown;
+  geojson?: unknown;
+  bbox?: unknown;
+  template?: {
+    translations?: Array<unknown>;
+    name: string;
+    description: string | null;
+    [key: string]: unknown;
+  };
+  area?: {
+    geojson?: unknown;
+    [key: string]: unknown;
+  };
+  watchers?: Array<unknown>;
+  _count?: {
+    watchers?: number;
+  };
+  isFeatured?: boolean | null;
+};
+
+function calculatePermissions(rawDataset: RawDataset, user: User | null) {
+  return {
+    canFeature: user?.isAdmin ?? false,
+    canDelete: false,
+    isFeatured: rawDataset.isFeatured ?? false,
+  };
+}
+
+export function transformDataset(
+  rawDataset: RawDataset,
+  user: User | null,
+  locale: string,
+  options?: { isWatched?: boolean }
+): Dataset {
+  if (!rawDataset.template) {
+    throw new Error("Dataset template is required");
+  }
+
+  const resolvedTemplate = resolveTemplateForLocale(
+    rawDataset.template as {
+      translations: Array<{ locale: string; name: string; description: string | null }>;
+      name: string;
+      description: string | null;
+    },
+    locale
+  );
+  const permissions = calculatePermissions(rawDataset, user);
+
+  // If isWatched is explicitly provided, use it. Otherwise infer from watchers array.
+  const isWatched = options?.isWatched ?? (rawDataset.watchers && rawDataset.watchers.length > 0);
+
+  return DatasetSchema.parse({
+    ...rawDataset,
+    geojson: rawDataset.geojson as FeatureCollection | null,
+    bbox: rawDataset.bbox as number[] | null,
+    template: resolvedTemplate,
+    area: rawDataset.area ? {
+      ...rawDataset.area,
+      geojson: rawDataset.area.geojson as FeatureCollection | null,
+    } : rawDataset.area,
+    isWatched,
+    watchersCount: rawDataset._count?.watchers || rawDataset.watchers?.length || 0,
+    ...permissions,
+  });
+}

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -37,23 +37,22 @@ export function transformDataset(
   rawDataset: RawDataset,
   user: User | null,
   locale: string,
-  options?: { isWatched?: boolean }
+  options?: { isWatched?: boolean; skipTemplateResolution?: boolean }
 ): Dataset {
   if (!rawDataset.template) {
     throw new Error("Dataset template is required");
   }
 
-  // Skip re-resolution if template was already resolved (translations stripped)
-  const resolvedTemplate = "translations" in rawDataset.template
-    ? resolveTemplateForLocale(
+  const resolvedTemplate = options?.skipTemplateResolution
+    ? (rawDataset.template as { name: string; description: string | null })
+    : resolveTemplateForLocale(
         rawDataset.template as {
           translations: Array<{ locale: string; name: string; description: string | null }>;
           name: string;
           description: string | null;
         },
         locale
-      )
-    : rawDataset.template as { name: string; description: string | null };
+      );
   const permissions = calculatePermissions(rawDataset, user);
 
   // If isWatched is explicitly provided, use it. Otherwise infer from watchers array.

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -43,14 +43,17 @@ export function transformDataset(
     throw new Error("Dataset template is required");
   }
 
-  const resolvedTemplate = resolveTemplateForLocale(
-    rawDataset.template as {
-      translations: Array<{ locale: string; name: string; description: string | null }>;
-      name: string;
-      description: string | null;
-    },
-    locale
-  );
+  // Skip re-resolution if template was already resolved (translations stripped)
+  const resolvedTemplate = "translations" in rawDataset.template
+    ? resolveTemplateForLocale(
+        rawDataset.template as {
+          translations: Array<{ locale: string; name: string; description: string | null }>;
+          name: string;
+          description: string | null;
+        },
+        locale
+      )
+    : rawDataset.template as { name: string; description: string | null };
   const permissions = calculatePermissions(rawDataset, user);
 
   // If isWatched is explicitly provided, use it. Otherwise infer from watchers array.


### PR DESCRIPTION
## Problem

Dataset transformation logic was duplicated across 3 locations, causing a production bug where the area dataset page was missing `isFeatured` and `canFeature` fields. Adding permission fields required updating 3+ files manually, violating locality.

**Root cause:** No shared module for dataset parsing — each page independently performed identical 8-field mappings (geojson casting, bbox casting, template resolution, watch status, permissions).

## Changes

**Created `lib/dataset/transform.ts`:**
- `transformDataset(rawDataset, user, locale, options?)` — centralizes all field mappings
- Handles two data loading patterns via optional `isWatched` parameter
- Internal `calculatePermissions()` function for future extraction
- Fixed bug: area dataset page now includes `isFeatured` and `canFeature` fields

**Updated 3 callers:**
- `app/[locale]/dataset/[id]/page.tsx` — uses `transformDataset()`
- `app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx` — uses `transformDataset()`  
- `app/api/datasets/watched/route.ts` — uses `transformDataset()`

## Benefits

- **Locality:** Single source of truth for dataset parsing
- **Leverage:** Simple interface (4 args) → complex behavior (8 mappings + validation)
- **Future-proof:** Adding permission fields now requires updating 1 file instead of 3+
- **Deletion test:** Removing this module would force complexity back into all callers

Type-check passes. This addresses the architecture review finding from PR #262 feedback.