### PR TITLE
feat(ui): add DatasetCard component

### DIFF
--- a/src/components/ui/dataset-card.stories.tsx
+++ b/src/components/ui/dataset-card.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { DatasetCard } from "./dataset-card";
+
+const meta: Meta<typeof DatasetCard> = {
+  title: "UI/DatasetCard",
+  component: DatasetCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: "Bicycle Parking",
+    city: "Paris",
+    country: "france",
+    category: "transportation",
+    features: 1204,
+    href: "/area/paris/dataset/bicycle-paris",
+  },
+};
+
+export const WithStats: Story = {
+  args: {
+    name: "Hospitals",
+    city: "London",
+    country: "united kingdom",
+    category: "healthcare",
+    features: 312,
+    href: "/area/london/dataset/hospitals-london",
+    stats: [
+      { label: "Contributors", value: "12" },
+      { label: "Last updated", value: "2 days ago" },
+    ],
+  },
+};
+
+export const LargeNumbers: Story = {
+  args: {
+    name: "Urban Trees",
+    city: "Berlin",
+    country: "germany",
+    category: "nature",
+    features: 38420,
+    href: "/area/berlin/dataset/trees-berlin",
+  },
+};
+
+export const DarkMode: Story = {
+  args: {
+    name: "Bicycle Parking",
+    city: "Paris",
+    country: "france",
+    category: "transportation",
+    features: 1204,
+    href: "/area/paris/dataset/bicycle-paris",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+
+// Grid showcase for different contexts
+export const GridShowcase: Story = {
+  args: {},
+  render: () => (
+    <div className="space-y-8 p-6 bg-neutral-50 dark:bg-neutral-900 rounded-lg">
+      {/* Default grid - for Featured Datasets page */}
+      <div>
+        <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-3">
+          {"Featured Datasets"}
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <DatasetCard
+            name="Bicycle Parking"
+            city="Paris"
+            country="france"
+            category="transportation"
+            features={1204}
+            href="/area/paris/dataset/bicycle-paris"
+          />
+          <DatasetCard
+            name="Urban Trees"
+            city="Berlin"
+            country="germany"
+            category="nature"
+            features={38420}
+            href="/area/berlin/dataset/trees-berlin"
+          />
+          <DatasetCard
+            name="ATMs"
+            city="Tokyo"
+            country="japan"
+            category="financial"
+            features={890}
+            href="/area/tokyo/dataset/atms-tokyo"
+          />
+        </div>
+      </div>
+
+      {/* With stats - for Dashboard */}
+      <div>
+        <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-3">
+          {"Dashboard (With stats)"}
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <DatasetCard
+            name="Schools"
+            city="Berlin"
+            country="germany"
+            category="education"
+            href="/area/berlin/dataset/schools-berlin"
+            stats={[
+              { label: "Contributors", value: "15" },
+              { label: "Last updated", value: "1 day ago" },
+            ]}
+          />
+          <DatasetCard
+            name="Bicycle Parking"
+            city="Paris"
+            country="france"
+            category="transportation"
+            features={1204}
+            href="/area/paris/dataset/bicycle-paris"
+            stats={[
+              { label: "Contributors", value: "8" },
+              { label: "Last updated", value: "3 days ago" },
+            ]}
+          />
+        </div>
+      </div>
+
+      {/* Various cities and categories */}
+      <div>
+        <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-3">
+          {"Various Cities & Categories"}
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <DatasetCard
+            name="Schools"
+            city="Santa Rita do Passa Quatro"
+            country="brazil"
+            category="education"
+            features={45}
+            href="/area/santa-rita-do-passa-quatro/dataset/schools-santa-rita"
+            stats={[
+              { label: "Contributors", value: "12" },
+              { label: "Last updated", value: "1 week ago" },
+            ]}
+          />
+          <DatasetCard
+            name="Hospitals"
+            city="San Francisco"
+            country="united states"
+            category="healthcare"
+            features={312}
+            href="/area/san-francisco/dataset/hospitals-san-francisco"
+            stats={[
+              { label: "Contributors", value: "28" },
+              { label: "Last updated", value: "4 days ago" },
+            ]}
+          />
+          <DatasetCard
+            name="Public Transport"
+            city="New York City"
+            country="united states"
+            category="transportation"
+            features={1247}
+            href="/area/new-york-city/dataset/transport-new-york"
+            stats={[
+              { label: "Contributors", value: "45" },
+              { label: "Last updated", value: "2 days ago" },
+            ]}
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/dataset-card.stories.tsx
+++ b/src/components/ui/dataset-card.stories.tsx
@@ -19,8 +19,8 @@ export const Default: Story = {
     city: "Paris",
     country: "france",
     category: "transportation",
-    features: 1204,
     href: "/area/paris/dataset/bicycle-paris",
+    stats: [{ label: "Features", value: 1204 }],
   },
 };
 
@@ -30,9 +30,9 @@ export const WithStats: Story = {
     city: "London",
     country: "united kingdom",
     category: "healthcare",
-    features: 312,
     href: "/area/london/dataset/hospitals-london",
     stats: [
+      { label: "Features", value: 312 },
       { label: "Contributors", value: "12" },
       { label: "Last updated", value: "2 days ago" },
     ],
@@ -45,8 +45,8 @@ export const LargeNumbers: Story = {
     city: "Berlin",
     country: "germany",
     category: "nature",
-    features: 38420,
     href: "/area/berlin/dataset/trees-berlin",
+    stats: [{ label: "Features", value: 38420 }],
   },
 };
 
@@ -56,8 +56,8 @@ export const DarkMode: Story = {
     city: "Paris",
     country: "france",
     category: "transportation",
-    features: 1204,
     href: "/area/paris/dataset/bicycle-paris",
+    stats: [{ label: "Features", value: 1204 }],
   },
   parameters: {
     backgrounds: { default: "dark" },
@@ -80,24 +80,24 @@ export const GridShowcase: Story = {
             city="Paris"
             country="france"
             category="transportation"
-            features={1204}
             href="/area/paris/dataset/bicycle-paris"
+            stats={[{ label: "Features", value: 1204 }]}
           />
           <DatasetCard
             name="Urban Trees"
             city="Berlin"
             country="germany"
             category="nature"
-            features={38420}
             href="/area/berlin/dataset/trees-berlin"
+            stats={[{ label: "Features", value: 38420 }]}
           />
           <DatasetCard
             name="ATMs"
             city="Tokyo"
             country="japan"
             category="financial"
-            features={890}
             href="/area/tokyo/dataset/atms-tokyo"
+            stats={[{ label: "Features", value: 890 }]}
           />
         </div>
       </div>
@@ -124,9 +124,9 @@ export const GridShowcase: Story = {
             city="Paris"
             country="france"
             category="transportation"
-            features={1204}
             href="/area/paris/dataset/bicycle-paris"
             stats={[
+              { label: "Features", value: 1204 },
               { label: "Contributors", value: "8" },
               { label: "Last updated", value: "3 days ago" },
             ]}
@@ -145,9 +145,9 @@ export const GridShowcase: Story = {
             city="Santa Rita do Passa Quatro"
             country="brazil"
             category="education"
-            features={45}
             href="/area/santa-rita-do-passa-quatro/dataset/schools-santa-rita"
             stats={[
+              { label: "Features", value: 45 },
               { label: "Contributors", value: "12" },
               { label: "Last updated", value: "1 week ago" },
             ]}
@@ -157,9 +157,9 @@ export const GridShowcase: Story = {
             city="San Francisco"
             country="united states"
             category="healthcare"
-            features={312}
             href="/area/san-francisco/dataset/hospitals-san-francisco"
             stats={[
+              { label: "Features", value: 312 },
               { label: "Contributors", value: "28" },
               { label: "Last updated", value: "4 days ago" },
             ]}
@@ -169,9 +169,9 @@ export const GridShowcase: Story = {
             city="New York City"
             country="united states"
             category="transportation"
-            features={1247}
             href="/area/new-york-city/dataset/transport-new-york"
             stats={[
+              { label: "Features", value: 1247 },
               { label: "Contributors", value: "45" },
               { label: "Last updated", value: "2 days ago" },
             ]}

--- a/src/components/ui/dataset-card.tsx
+++ b/src/components/ui/dataset-card.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Link } from "react-aria-components";
+import { MapPin, Users, Pencil } from "lucide-react";
+import { getCategoryIcon } from "@/lib/category-icons";
+
+export interface DatasetCardProps {
+  id?: string;
+  name: string;
+  city: string;
+  country: string;
+  category: string;
+  features?: number;
+  href: string;
+  stats?: Array<{ label: string; value: string | number }>;
+}
+
+/**
+ * Get country flag emoji from country code
+ */
+function getCountryFlag(country: string): string {
+  // Temporary placeholder - will be replaced with proper flag conversion
+  const flagMap: Record<string, string> = {
+    france: "🇫🇷",
+    germany: "🇩🇪",
+    japan: "🇯🇵",
+    "united kingdom": "🇬🇧",
+    portugal: "🇵🇹",
+    netherlands: "🇳🇱",
+    brazil: "🇧🇷",
+    "united states": "🇺🇸",
+  };
+  return flagMap[country.toLowerCase()] || "";
+}
+
+/**
+ * Format number in compact notation (1.2k, 2M, etc.)
+ */
+function formatCompactNumber(value: number | string): string {
+  const num = typeof value === 'string' ? parseInt(value.replace(/,/g, ''), 10) : value;
+  if (num < 1000) return num.toString();
+  if (num < 1000000) return `${(num / 1000).toFixed(1).replace(/\.0$/, '')}k`;
+  return `${(num / 1000000).toFixed(1).replace(/\.0$/, '')}M`;
+}
+
+/**
+ * Format stat value based on label type
+ */
+function formatStatValue(label: string, value: string | number): string {
+  const lowerLabel = label.toLowerCase();
+  const strValue = String(value);
+
+  // Format dates: "2 days ago" → "2d", "3 months ago" → "3mo"
+  if (lowerLabel.includes("update") || lowerLabel.includes("last") || lowerLabel.includes("time")) {
+    const match = strValue.toLowerCase().match(/(\d+)\s*(day|week|month|year)s?\s*ago/);
+    if (match) {
+      const [, num, unit] = match;
+      return `${num}${unit === 'month' ? 'mo' : unit.charAt(0)}`;
+    }
+  }
+
+  // Format numbers for everything else
+  return formatCompactNumber(value);
+}
+
+/**
+ * Get icon for stat type based on label
+ */
+function getStatIcon(label: string) {
+  const lowerLabel = label.toLowerCase();
+  if (lowerLabel.includes("contributor") || lowerLabel.includes("user") || lowerLabel.includes("people")) return Users;
+  if (lowerLabel.includes("update") || lowerLabel.includes("last") || lowerLabel.includes("time")) return Pencil;
+  return MapPin;
+}
+
+export function DatasetCard({
+  name,
+  city,
+  country,
+  category,
+  features,
+  href,
+  stats,
+}: DatasetCardProps) {
+  const flag = getCountryFlag(country);
+  const categoryIcon = getCategoryIcon(category);
+
+  return (
+    <Link
+      href={href}
+      aria-label={`${name} dataset in ${city}`}
+      className="flex items-center gap-5 p-5 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-xl hover:border-green-600 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-green-500"
+    >
+      {/* Icon */}
+      <div className="flex items-center justify-center shrink-0 w-16 h-16 text-olive-600 opacity-60 scale-[2]">
+        {categoryIcon}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{name}</h3>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">{flag} <span className="ml-1">{city}</span></p>
+        </div>
+
+        {/* Stats */}
+        <div className="flex items-center gap-3 text-[10px] mt-2">
+          {features && (
+            <div className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
+              <MapPin className="w-2.5 h-2.5" />
+              <span className="font-medium">{formatCompactNumber(features)}</span>
+            </div>
+          )}
+
+          {stats?.map((stat) => {
+            const StatIcon = getStatIcon(stat.label);
+            return (
+              <div key={stat.label} className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
+                <StatIcon className="w-2.5 h-2.5" />
+                <span className="font-medium">{formatStatValue(stat.label, stat.value)}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/ui/dataset-card.tsx
+++ b/src/components/ui/dataset-card.tsx
@@ -5,12 +5,10 @@ import { MapPin, Users, Pencil } from "lucide-react";
 import { getCategoryIcon } from "@/lib/category-icons";
 
 export interface DatasetCardProps {
-  id?: string;
   name: string;
   city: string;
   country: string;
   category: string;
-  features?: number;
   href: string;
   stats?: Array<{ label: string; value: string | number }>;
 }
@@ -57,6 +55,7 @@ function formatStatValue(label: string, value: string | number): string {
       const [, num, unit] = match;
       return `${num}${unit === 'month' ? 'mo' : unit.charAt(0)}`;
     }
+    return strValue;
   }
 
   // Format numbers for everything else
@@ -78,7 +77,6 @@ export function DatasetCard({
   city,
   country,
   category,
-  features,
   href,
   stats,
 }: DatasetCardProps) {
@@ -105,13 +103,6 @@ export function DatasetCard({
 
         {/* Stats */}
         <div className="flex items-center gap-3 text-[10px] mt-2">
-          {features && (
-            <div className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
-              <MapPin className="w-2.5 h-2.5" />
-              <span className="font-medium">{formatCompactNumber(features)}</span>
-            </div>
-          )}
-
           {stats?.map((stat) => {
             const StatIcon = getStatIcon(stat.label);
             return (


### PR DESCRIPTION
## DatasetCard component

**Problem:** No shared card component exists for displaying datasets in grid layouts — needed as a building block for the upcoming /featured-datasets page (#273) and dashboard.

**Changes:**
New `DatasetCard` component (`src/components/ui/dataset-card.tsx`):
- React Aria `Link` wrapper for accessibility (aria-label, focus ring)
- Category icon via `getCategoryIcon`, country flag, compact feature count
- Optional `stats` slot (contributors, last updated) with compact number/date formatting
- Dark mode support
- Storybook stories: Default, WithStats, LargeNumbers, DarkMode, GridShowcase