### PR TITLE
feat: add explore page with featured datasets

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -16,6 +16,7 @@
     "users": "Users",
     "preferences": "Preferences",
     "brandName": "OSM for Cities",
+    "explore": "Explore",
     "signIn": "Sign In",
     "signOut": "Sign Out",
     "mainMenu": "Main navigation menu",
@@ -365,6 +366,7 @@
       "title": "Understand your city through open data",
       "description": "OSM for Cities organizes OpenStreetMap data into datasets you can follow. Track schools, transport, parks, and clinics as they change, receive updates by email, and understand how your city evolves over time.",
       "seeHowItWorks": "See how it works",
+      "exploreDatasets": "Explore datasets",
       "osmAttribution": "© OpenStreetMap contributors"
     },
     "features": {
@@ -575,6 +577,12 @@
     "signInToBrowse": "Explore the map of <strong>{dataset} in {area}</strong>, made by the OpenStreetMap community.",
     "continueWithEmail": "Continue with email",
     "back": "Back"
+  },
+  "ExplorePage": {
+    "metaTitle": "Explore — OSM for Cities",
+    "title": "Explore",
+    "description": "Discover open data from cities worldwide",
+    "noDatasets": "No featured datasets yet."
   },
   "SEO": {
     "home": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -582,7 +582,12 @@
     "metaTitle": "Explore — OSM for Cities",
     "title": "Explore",
     "description": "Discover open data from cities worldwide",
-    "noDatasets": "No featured datasets yet."
+    "noDatasets": "No featured datasets yet.",
+    "stats": {
+      "features": "Features",
+      "contributors": "Contributors",
+      "lastEdited": "Last edited"
+    }
   },
   "SEO": {
     "home": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -589,7 +589,12 @@
     "metaTitle": "Explorar — OSM for Cities",
     "title": "Explorar",
     "description": "Descubre datos abiertos de ciudades de todo el mundo",
-    "noDatasets": "Aún no hay conjuntos de datos destacados."
+    "noDatasets": "Aún no hay conjuntos de datos destacados.",
+    "stats": {
+      "features": "Elementos",
+      "contributors": "Colaboradores",
+      "lastEdited": "Última edición"
+    }
   },
   "SEO": {
     "home": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -8,6 +8,7 @@
   "Navigation": {
     "home": "Inicio",
     "dashboard": "Panel",
+    "explore": "Explorar",
     "about": "Acerca de",
     "myDatasets": "Mis Conjuntos de Datos",
     "public": "Público",
@@ -362,6 +363,7 @@
     "hero": {
       "title": "Comprende tu ciudad a través de datos abiertos",
       "description": "OSM for Cities organiza los datos de OpenStreetMap en conjuntos de datos que puedes seguir. Rastrea escuelas, transporte, parques y clínicas a medida que cambian, recibe actualizaciones por correo electrónico y comprende cómo evoluciona tu ciudad con el tiempo.",
+      "exploreDatasets": "Explorar conjuntos de datos",
       "seeHowItWorks": "Ver cómo funciona",
       "osmAttribution": "© Colaboradores de OpenStreetMap"
     },
@@ -582,6 +584,12 @@
     "signInToBrowse": "Explora el mapa de <strong>{dataset} en {area}</strong>, creado por la comunidad de OpenStreetMap.",
     "continueWithEmail": "Continuar con email",
     "back": "Volver"
+  },
+  "ExplorePage": {
+    "metaTitle": "Explorar — OSM for Cities",
+    "title": "Explorar",
+    "description": "Descubre datos abiertos de ciudades de todo el mundo",
+    "noDatasets": "Aún no hay conjuntos de datos destacados."
   },
   "SEO": {
     "home": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -589,7 +589,12 @@
     "metaTitle": "Explorar — OSM for Cities",
     "title": "Explorar",
     "description": "Descubra dados abertos de cidades do mundo todo",
-    "noDatasets": "Ainda não há conjuntos de dados em destaque."
+    "noDatasets": "Ainda não há conjuntos de dados em destaque.",
+    "stats": {
+      "features": "Elementos",
+      "contributors": "Contribuidores",
+      "lastEdited": "Última edição"
+    }
   },
   "SEO": {
     "home": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -8,6 +8,7 @@
   "Navigation": {
     "home": "Início",
     "dashboard": "Painel",
+    "explore": "Explorar",
     "about": "Sobre",
     "myDatasets": "Meus Conjuntos de Dados",
     "public": "Público",
@@ -362,6 +363,7 @@
     "hero": {
       "title": "Compreenda sua cidade através de dados abertos",
       "description": "OSM for Cities organiza dados do OpenStreetMap em conjuntos de dados que você pode seguir. Acompanhe escolas, transporte, parques e clínicas conforme mudam, receba atualizações por e-mail e compreenda como sua cidade evolui ao longo do tempo.",
+      "exploreDatasets": "Explorar conjuntos de dados",
       "seeHowItWorks": "Veja como funciona",
       "osmAttribution": "© Colaboradores do OpenStreetMap"
     },
@@ -582,6 +584,12 @@
     "signInToBrowse": "Explore o mapa de <strong>{dataset} em {area}</strong>, feito pela comunidade OpenStreetMap.",
     "continueWithEmail": "Continuar com email",
     "back": "Voltar"
+  },
+  "ExplorePage": {
+    "metaTitle": "Explorar — OSM for Cities",
+    "title": "Explorar",
+    "description": "Descubra dados abertos de cidades do mundo todo",
+    "noDatasets": "Ainda não há conjuntos de dados em destaque."
   },
   "SEO": {
     "home": {

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,0 +1,73 @@
+import { prisma } from "@/lib/db";
+import { DatasetCard } from "@/components/ui/dataset-card";
+import { processDatasetStats } from "@/lib/dataset-stats";
+import { getTranslations } from "next-intl/server";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "ExplorePage" });
+
+  return {
+    title: t("metaTitle"),
+  };
+}
+
+export default async function FeaturedDatasetsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "ExplorePage" });
+  const datasets = await prisma.dataset.findMany({
+    where: { isFeatured: true },
+    include: {
+      area: true,
+      template: true,
+      _count: { select: { watchers: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+            {t("title")}
+          </h1>
+          <p className="text-sm text-neutral-500 mt-1">
+            {t("description")}
+          </p>
+        </div>
+
+        {datasets.length === 0 ? (
+          <p className="text-sm text-neutral-400">{t("noDatasets")}</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {datasets.map((dataset) => (
+              <DatasetCard
+                key={dataset.id}
+                name={dataset.template.name}
+                city={dataset.cityName}
+                country={dataset.area.countryCode ?? ""}
+                category={dataset.template.category}
+                href={`/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                stats={[
+                  {
+                    label: "Features",
+                    value: processDatasetStats(dataset).features,
+                  },
+                  {
+                    label: "Contributors",
+                    value: processDatasetStats(dataset).contributors,
+                  },
+                  {
+                    label: "Last edited",
+                    value: processDatasetStats(dataset).lastEdited,
+                  },
+                ]}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -41,22 +41,18 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
     return true;
   });
   if (missing.length > 0) {
-    try {
-      await Promise.all(
-        missing.map(async (d) => {
-          const details = await getAreaDetailsById(d.area.id);
-          if (details?.countryCode) {
-            await prisma.area.update({
-              where: { id: d.area.id },
-              data: { countryCode: details.countryCode },
-            });
-            d.area.countryCode = details.countryCode;
-          }
-        })
-      );
-    } catch {
-      // Silently fail — page renders with 🌐 fallback flags
-    }
+    await Promise.allSettled(
+      missing.map(async (d) => {
+        const details = await getAreaDetailsById(d.area.id);
+        if (details?.countryCode) {
+          await prisma.area.update({
+            where: { id: d.area.id },
+            data: { countryCode: details.countryCode },
+          });
+          d.area.countryCode = details.countryCode;
+        }
+      })
+    );
   }
 
   return (

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { processDatasetStats } from "@/lib/dataset-stats";
 import { getAreaDetailsById } from "@/lib/nominatim";
+import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 
@@ -25,7 +26,9 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
     where: { isFeatured: true },
     include: {
       area: true,
-      template: true,
+      template: {
+        include: { translations: true },
+      },
     },
     orderBy: { createdAt: "desc" },
   });
@@ -74,13 +77,14 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {datasets.map((dataset) => {
               const s = processDatasetStats(dataset, locale);
+              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
               return (
                 <DatasetCard
                   key={dataset.id}
-                  name={dataset.template.name}
+                  name={resolvedTemplate.name}
                   city={dataset.cityName}
                   country={dataset.area.countryCode ?? ""}
-                  category={dataset.template.category}
+                  category={resolvedTemplate.category}
                   href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
                   stats={[
                     { type: "features",     label: t("stats.features"),     value: s.features },

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -5,6 +5,9 @@ import { getAreaDetailsById } from "@/lib/nominatim";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("explore-page");
 
 export const revalidate = 3600;
 
@@ -69,7 +72,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       if (result.status === "fulfilled" && result.value) {
         backfilledByArea.set(result.value.areaId, result.value.countryCode);
       } else if (result.status === "rejected") {
-        console.error("Failed to backfill area country code:", result.reason);
+        logger.error("Failed to backfill area country code", { reason: result.reason });
       }
     }
     for (const dataset of datasets) {

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,26 +1,30 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { processDatasetStats } from "@/lib/dataset-stats";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Locale } from "next-intl";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "ExplorePage" });
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
 
   return {
     title: t("metaTitle"),
   };
 }
 
-export default async function FeaturedDatasetsPage({ params }: { params: Promise<{ locale: string }> }) {
+export default async function FeaturedDatasetsPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "ExplorePage" });
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
   const datasets = await prisma.dataset.findMany({
     where: { isFeatured: true },
     include: {
       area: true,
       template: true,
-      _count: { select: { watchers: true } },
     },
     orderBy: { createdAt: "desc" },
   });
@@ -41,30 +45,24 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
           <p className="text-sm text-neutral-400">{t("noDatasets")}</p>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {datasets.map((dataset) => (
-              <DatasetCard
-                key={dataset.id}
-                name={dataset.template.name}
-                city={dataset.cityName}
-                country={dataset.area.countryCode ?? ""}
-                category={dataset.template.category}
-                href={`/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-                stats={[
-                  {
-                    label: "Features",
-                    value: processDatasetStats(dataset).features,
-                  },
-                  {
-                    label: "Contributors",
-                    value: processDatasetStats(dataset).contributors,
-                  },
-                  {
-                    label: "Last edited",
-                    value: processDatasetStats(dataset).lastEdited,
-                  },
-                ]}
-              />
-            ))}
+            {datasets.map((dataset) => {
+              const s = processDatasetStats(dataset, locale);
+              return (
+                <DatasetCard
+                  key={dataset.id}
+                  name={dataset.template.name}
+                  city={dataset.cityName}
+                  country={dataset.area.countryCode ?? ""}
+                  category={dataset.template.category}
+                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                  stats={[
+                    { type: "features",     label: t("stats.features"),     value: s.features },
+                    { type: "contributors", label: t("stats.contributors"), value: s.contributors },
+                    { type: "lastEdited",   label: t("stats.lastEdited"),   value: s.lastEdited },
+                  ]}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { processDatasetStats } from "@/lib/dataset-stats";
+import { getAreaDetailsById } from "@/lib/nominatim";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 
@@ -28,6 +29,23 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
     },
     orderBy: { createdAt: "desc" },
   });
+
+  // Backfill missing country codes from Nominatim (lazy, fires once per area)
+  const missing = datasets.filter((d) => !d.area.countryCode);
+  if (missing.length > 0) {
+    await Promise.all(
+      missing.map(async (d) => {
+        const details = await getAreaDetailsById(d.area.id);
+        if (details?.countryCode) {
+          await prisma.area.update({
+            where: { id: d.area.id },
+            data: { countryCode: details.countryCode },
+          });
+          d.area.countryCode = details.countryCode;
+        }
+      })
+    );
+  }
 
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -68,6 +68,8 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
     for (const result of results) {
       if (result.status === "fulfilled" && result.value) {
         backfilledByArea.set(result.value.areaId, result.value.countryCode);
+      } else if (result.status === "rejected") {
+        console.error("Failed to backfill area country code:", result.reason);
       }
     }
     for (const dataset of datasets) {
@@ -103,7 +105,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
                   name={resolvedTemplate.name}
                   city={dataset.cityName}
                   country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category.name}
+                  category={resolvedTemplate.category?.name ?? "other"}
                   href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
                   stats={[
                     { type: "features",     label: t("stats.features"),     value: s.features },

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -30,21 +30,30 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
     orderBy: { createdAt: "desc" },
   });
 
-  // Backfill missing country codes from Nominatim (lazy, fires once per area)
-  const missing = datasets.filter((d) => !d.area.countryCode);
+  // Backfill missing country codes from Nominatim (lazy, fires once per unique area)
+  const seen = new Set<number>();
+  const missing = datasets.filter((d) => {
+    if (d.area.countryCode || seen.has(d.area.id)) return false;
+    seen.add(d.area.id);
+    return true;
+  });
   if (missing.length > 0) {
-    await Promise.all(
-      missing.map(async (d) => {
-        const details = await getAreaDetailsById(d.area.id);
-        if (details?.countryCode) {
-          await prisma.area.update({
-            where: { id: d.area.id },
-            data: { countryCode: details.countryCode },
-          });
-          d.area.countryCode = details.countryCode;
-        }
-      })
-    );
+    try {
+      await Promise.all(
+        missing.map(async (d) => {
+          const details = await getAreaDetailsById(d.area.id);
+          if (details?.countryCode) {
+            await prisma.area.update({
+              where: { id: d.area.id },
+              data: { countryCode: details.countryCode },
+            });
+            d.area.countryCode = details.countryCode;
+          }
+        })
+      );
+    } catch {
+      // Silently fail — page renders with 🌐 fallback flags
+    }
   }
 
   return (

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -25,7 +25,12 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
   const datasets = await prisma.dataset.findMany({
     where: { isFeatured: true },
     include: {
-      area: true,
+      area: {
+        select: {
+          id: true,
+          countryCode: true,
+        },
+      },
       template: {
         include: { translations: true },
       },

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -49,7 +49,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
     return true;
   });
   if (missing.length > 0) {
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       missing.map(async (d) => {
         const details = await getAreaDetailsById(d.area.id);
         if (details?.countryCode) {
@@ -57,10 +57,25 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
             where: { id: d.area.id },
             data: { countryCode: details.countryCode },
           });
-          d.area.countryCode = details.countryCode;
+          return { areaId: d.area.id, countryCode: details.countryCode };
         }
+        return null;
       })
     );
+
+    // Propagate backfilled codes to all datasets sharing the same area
+    const backfilledByArea = new Map<number, string>();
+    for (const result of results) {
+      if (result.status === "fulfilled" && result.value) {
+        backfilledByArea.set(result.value.areaId, result.value.countryCode);
+      }
+    }
+    for (const dataset of datasets) {
+      const code = backfilledByArea.get(dataset.area.id);
+      if (code) {
+        dataset.area.countryCode = code;
+      }
+    }
   }
 
   return (

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -32,7 +32,10 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
         },
       },
       template: {
-        include: { translations: true },
+        include: {
+          translations: true,
+          category: true,
+        },
       },
     },
     orderBy: { createdAt: "desc" },
@@ -85,7 +88,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
                   name={resolvedTemplate.name}
                   city={dataset.cityName}
                   country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category}
+                  category={resolvedTemplate.category.name}
                   href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
                   stats={[
                     { type: "features",     label: t("stats.features"),     value: s.features },

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -39,10 +39,7 @@ export async function POST(req: NextRequest) {
 
   if (!area) {
     try {
-      const [fetched, areaDetails] = await Promise.all([
-        fetchOsmRelationData(osmRelationId),
-        getAreaDetailsById(osmRelationId),
-      ]);
+      const fetched = await fetchOsmRelationData(osmRelationId);
 
       if (!fetched)
         return NextResponse.json(
@@ -50,12 +47,20 @@ export async function POST(req: NextRequest) {
           { status: 400 }
         );
 
+      let countryCode: string | null = null;
+      try {
+        const areaDetails = await getAreaDetailsById(osmRelationId);
+        countryCode = areaDetails?.countryCode ?? null;
+      } catch {
+        // Nominatim is best-effort; country code can be backfilled later
+      }
+
       area = await prisma.area.create({
         data: {
           id: osmRelationId,
           name: fetched.name,
           bounds: fetched.bounds,
-          countryCode: areaDetails?.countryCode ?? null,
+          countryCode,
           geojson: JSON.parse(JSON.stringify(fetched.convertedGeojson)),
         },
       });

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/db";
 import { CreateDatasetSchema } from "@/schemas/dataset";
 import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData, fetchDatasetSnapshot } from "@/lib/osm";
+import { getAreaDetailsById } from "@/lib/nominatim";
 import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
@@ -38,7 +39,11 @@ export async function POST(req: NextRequest) {
 
   if (!area) {
     try {
-      const fetched = await fetchOsmRelationData(osmRelationId);
+      const [fetched, areaDetails] = await Promise.all([
+        fetchOsmRelationData(osmRelationId),
+        getAreaDetailsById(osmRelationId),
+      ]);
+
       if (!fetched)
         return NextResponse.json(
           { error: "Failed to fetch OSM relation" },
@@ -50,7 +55,7 @@ export async function POST(req: NextRequest) {
           id: osmRelationId,
           name: fetched.name,
           bounds: fetched.bounds,
-          countryCode: fetched.countryCode,
+          countryCode: areaDetails?.countryCode ?? null,
           geojson: JSON.parse(JSON.stringify(fetched.convertedGeojson)),
         },
       });

--- a/src/components/client-menu.tsx
+++ b/src/components/client-menu.tsx
@@ -63,6 +63,7 @@ export default function ClientMenu({ isLoggedIn }: ClientMenuProps) {
                     isLoggedIn={isLoggedIn}
                     translations={{
                       dashboard: t("dashboard"),
+                      explore: t("explore"),
                       about: t("about"),
                       preferences: t("preferences"),
                       signOut: t("signOut"),

--- a/src/components/dataset/dataset-info-panel.tsx
+++ b/src/components/dataset/dataset-info-panel.tsx
@@ -26,7 +26,7 @@ export function DatasetInfoPanel({ dataset }: DatasetInfoPanelProps) {
   const pageT = useTranslations("DatasetPage");
 
   const basicInfoRows: InfoRowData[] = [
-    { label: t("category"), value: dataset.template.category, isPill: true },
+    { label: t("category"), value: dataset.template.category?.name ?? "other", isPill: true },
     {
       label: t("status"),
       value: dataset.isActive ? pageT("active") : pageT("inactive"),

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -26,6 +26,7 @@ export default async function HamburgerMenu({ isLoggedIn }: HamburgerMenuProps) 
           isLoggedIn={isLoggedIn}
           translations={{
             dashboard: t("dashboard"),
+            explore: t("explore"),
             about: t("about"),
             preferences: t("preferences"),
             signOut: t("signOut"),

--- a/src/components/home/hero/hero-content.tsx
+++ b/src/components/home/hero/hero-content.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
-import { ArrowDown } from "lucide-react";
+import { ArrowRight, ArrowDown } from "lucide-react";
 import { scrollToSection } from "../shared/scroll-to-section";
 
 export function HeroContent() {
@@ -34,8 +35,18 @@ export function HeroContent() {
         </p>
         <div className="mt-6 flex flex-wrap items-center gap-4 md:mt-8">
           <Button
+            asChild
             size="lg"
             variant="primary"
+          >
+            <Link href="/explore" className="gap-2">
+              {t("hero.exploreDatasets")}
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
+          <Button
+            size="lg"
+            variant="secondary"
             onClick={() => scrollToSection("features")}
             className="gap-2"
           >

--- a/src/components/nav-actions.tsx
+++ b/src/components/nav-actions.tsx
@@ -7,6 +7,7 @@ interface NavActionsProps {
   translations: {
     dashboard: string;
     about: string;
+    explore: string;
     preferences: string;
     signOut: string;
     signIn: string;
@@ -29,6 +30,9 @@ export default function NavActions({
   if (isLoggedIn) {
     return (
       <div className={containerClass}>
+        <NavLink href="/explore" isMobile={isMobile}>
+          {translations.explore}
+        </NavLink>
         <NavLink href="/dashboard" isMobile={isMobile} data-testid="navbar-dashboard">
           {translations.dashboard}
         </NavLink>
@@ -53,6 +57,9 @@ export default function NavActions({
 
   return (
     <div className={containerClass}>
+      <NavLink href="/explore" isMobile={isMobile}>
+        {translations.explore}
+      </NavLink>
       <NavLink href="/about" isMobile={isMobile}>
         {translations.about}
       </NavLink>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+  "inline-flex items-center justify-center cursor-pointer gap-2 whitespace-nowrap rounded-md font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center cursor-pointer gap-2 whitespace-nowrap rounded-md font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+  "inline-flex items-center justify-center cursor-pointer gap-2 whitespace-nowrap rounded-md font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
   {
     variants: {
       variant: {

--- a/src/components/ui/dataset-card.stories.tsx
+++ b/src/components/ui/dataset-card.stories.tsx
@@ -20,7 +20,7 @@ export const Default: Story = {
     country: "france",
     category: "transportation",
     href: "/area/paris/dataset/bicycle-paris",
-    stats: [{ label: "Features", value: 1204 }],
+    stats: [{ type: "features", label: "Features", value: 1204 }],
   },
 };
 
@@ -32,9 +32,9 @@ export const WithStats: Story = {
     category: "healthcare",
     href: "/area/london/dataset/hospitals-london",
     stats: [
-      { label: "Features", value: 312 },
-      { label: "Contributors", value: "12" },
-      { label: "Last updated", value: "2 days ago" },
+      { type: "features", label: "Features", value: 312 },
+      { type: "contributors", label: "Contributors", value: "12" },
+      { type: "lastEdited", label: "Last updated", value: "2 days ago" },
     ],
   },
 };
@@ -46,7 +46,7 @@ export const LargeNumbers: Story = {
     country: "germany",
     category: "nature",
     href: "/area/berlin/dataset/trees-berlin",
-    stats: [{ label: "Features", value: 38420 }],
+    stats: [{ type: "features", label: "Features", value: 38420 }],
   },
 };
 
@@ -57,7 +57,7 @@ export const DarkMode: Story = {
     country: "france",
     category: "transportation",
     href: "/area/paris/dataset/bicycle-paris",
-    stats: [{ label: "Features", value: 1204 }],
+    stats: [{ type: "features", label: "Features", value: 1204 }],
   },
   parameters: {
     backgrounds: { default: "dark" },
@@ -81,7 +81,7 @@ export const GridShowcase: Story = {
             country="france"
             category="transportation"
             href="/area/paris/dataset/bicycle-paris"
-            stats={[{ label: "Features", value: 1204 }]}
+            stats={[{ type: "features", label: "Features", value: 1204 }]}
           />
           <DatasetCard
             name="Urban Trees"
@@ -89,7 +89,7 @@ export const GridShowcase: Story = {
             country="germany"
             category="nature"
             href="/area/berlin/dataset/trees-berlin"
-            stats={[{ label: "Features", value: 38420 }]}
+            stats={[{ type: "features", label: "Features", value: 38420 }]}
           />
           <DatasetCard
             name="ATMs"
@@ -97,7 +97,7 @@ export const GridShowcase: Story = {
             country="japan"
             category="financial"
             href="/area/tokyo/dataset/atms-tokyo"
-            stats={[{ label: "Features", value: 890 }]}
+            stats={[{ type: "features", label: "Features", value: 890 }]}
           />
         </div>
       </div>
@@ -115,8 +115,8 @@ export const GridShowcase: Story = {
             category="education"
             href="/area/berlin/dataset/schools-berlin"
             stats={[
-              { label: "Contributors", value: "15" },
-              { label: "Last updated", value: "1 day ago" },
+              { type: "contributors", label: "Contributors", value: "15" },
+              { type: "lastEdited", label: "Last updated", value: "1 day ago" },
             ]}
           />
           <DatasetCard
@@ -126,9 +126,9 @@ export const GridShowcase: Story = {
             category="transportation"
             href="/area/paris/dataset/bicycle-paris"
             stats={[
-              { label: "Features", value: 1204 },
-              { label: "Contributors", value: "8" },
-              { label: "Last updated", value: "3 days ago" },
+              { type: "features", label: "Features", value: 1204 },
+              { type: "contributors", label: "Contributors", value: "8" },
+              { type: "lastEdited", label: "Last updated", value: "3 days ago" },
             ]}
           />
         </div>
@@ -147,9 +147,9 @@ export const GridShowcase: Story = {
             category="education"
             href="/area/santa-rita-do-passa-quatro/dataset/schools-santa-rita"
             stats={[
-              { label: "Features", value: 45 },
-              { label: "Contributors", value: "12" },
-              { label: "Last updated", value: "1 week ago" },
+              { type: "features", label: "Features", value: 45 },
+              { type: "contributors", label: "Contributors", value: "12" },
+              { type: "lastEdited", label: "Last updated", value: "1 week ago" },
             ]}
           />
           <DatasetCard
@@ -159,9 +159,9 @@ export const GridShowcase: Story = {
             category="healthcare"
             href="/area/san-francisco/dataset/hospitals-san-francisco"
             stats={[
-              { label: "Features", value: 312 },
-              { label: "Contributors", value: "28" },
-              { label: "Last updated", value: "4 days ago" },
+              { type: "features", label: "Features", value: 312 },
+              { type: "contributors", label: "Contributors", value: "28" },
+              { type: "lastEdited", label: "Last updated", value: "4 days ago" },
             ]}
           />
           <DatasetCard
@@ -171,9 +171,9 @@ export const GridShowcase: Story = {
             category="transportation"
             href="/area/new-york-city/dataset/transport-new-york"
             stats={[
-              { label: "Features", value: 1247 },
-              { label: "Contributors", value: "45" },
-              { label: "Last updated", value: "2 days ago" },
+              { type: "features", label: "Features", value: 1247 },
+              { type: "contributors", label: "Contributors", value: "45" },
+              { type: "lastEdited", label: "Last updated", value: "2 days ago" },
             ]}
           />
         </div>

--- a/src/components/ui/dataset-card.tsx
+++ b/src/components/ui/dataset-card.tsx
@@ -19,7 +19,7 @@ export interface DatasetCardProps {
  * Get country flag emoji from country code
  */
 function getCountryFlag(country: string): string {
-  if (!country) return "";
+  if (!country) return "🌐";
   // ISO 3166-1 alpha-2 code → Unicode regional indicator pair
   if (/^[a-zA-Z]{2}$/.test(country)) {
     return [...country.toUpperCase()]
@@ -44,7 +44,7 @@ function getCountryFlag(country: string): string {
     india: "🇮🇳",
     egypt: "🇪🇬",
   };
-  return flagMap[country.toLowerCase()] ?? "";
+  return flagMap[country.toLowerCase()] ?? "🌐";
 }
 
 /**

--- a/src/components/ui/dataset-card.tsx
+++ b/src/components/ui/dataset-card.tsx
@@ -102,7 +102,7 @@ export function DatasetCard({
           {stats.map((stat) => {
             const StatIcon = getStatIcon(stat.type);
             return (
-              <div key={stat.type} className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
+              <div key={stat.type} aria-label={stat.label} className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
                 <StatIcon className="w-2.5 h-2.5" />
                 <span className="font-medium">{formatStatValue(stat.type, stat.value)}</span>
               </div>

--- a/src/components/ui/dataset-card.tsx
+++ b/src/components/ui/dataset-card.tsx
@@ -4,13 +4,15 @@ import { Link } from "react-aria-components";
 import { MapPin, Users, Pencil } from "lucide-react";
 import { getCategoryIcon } from "@/lib/category-icons";
 
+export type StatType = "features" | "contributors" | "lastEdited";
+
 export interface DatasetCardProps {
   name: string;
   city: string;
   country: string;
   category: string;
   href: string;
-  stats: Array<{ label: string; value: string | number }>;
+  stats: Array<{ label: string; value: string | number; type: StatType }>;
 }
 
 /**
@@ -55,34 +57,14 @@ function formatCompactNumber(value: number | string): string {
   return `${(num / 1000000).toFixed(1).replace(/\.0$/, '')}M`;
 }
 
-/**
- * Format stat value based on label type
- */
-function formatStatValue(label: string, value: string | number): string {
-  const lowerLabel = label.toLowerCase();
-  const strValue = String(value);
-
-  // Format dates: "2 days ago" → "2d", "3 months ago" → "3mo"
-  if (lowerLabel.includes("update") || lowerLabel.includes("last") || lowerLabel.includes("time")) {
-    const match = strValue.toLowerCase().match(/(\d+)\s*(day|week|month|year)s?\s*ago/);
-    if (match) {
-      const [, num, unit] = match;
-      return `${num}${unit === 'month' ? 'mo' : unit.charAt(0)}`;
-    }
-    return strValue;
-  }
-
-  // Format numbers for everything else
+function formatStatValue(type: StatType, value: string | number): string {
+  if (type === "lastEdited") return String(value);
   return formatCompactNumber(value);
 }
 
-/**
- * Get icon for stat type based on label
- */
-function getStatIcon(label: string) {
-  const lowerLabel = label.toLowerCase();
-  if (lowerLabel.includes("contributor") || lowerLabel.includes("user") || lowerLabel.includes("people")) return Users;
-  if (lowerLabel.includes("update") || lowerLabel.includes("last") || lowerLabel.includes("time")) return Pencil;
+function getStatIcon(type: StatType) {
+  if (type === "contributors") return Users;
+  if (type === "lastEdited") return Pencil;
   return MapPin;
 }
 
@@ -118,11 +100,11 @@ export function DatasetCard({
         {/* Stats */}
         <div className="flex items-center gap-3 text-[10px] mt-2">
           {stats.map((stat) => {
-            const StatIcon = getStatIcon(stat.label);
+            const StatIcon = getStatIcon(stat.type);
             return (
-              <div key={stat.label} className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
+              <div key={stat.type} className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
                 <StatIcon className="w-2.5 h-2.5" />
-                <span className="font-medium">{formatStatValue(stat.label, stat.value)}</span>
+                <span className="font-medium">{formatStatValue(stat.type, stat.value)}</span>
               </div>
             );
           })}

--- a/src/components/ui/dataset-card.tsx
+++ b/src/components/ui/dataset-card.tsx
@@ -10,14 +10,21 @@ export interface DatasetCardProps {
   country: string;
   category: string;
   href: string;
-  stats?: Array<{ label: string; value: string | number }>;
+  stats: Array<{ label: string; value: string | number }>;
 }
 
 /**
  * Get country flag emoji from country code
  */
 function getCountryFlag(country: string): string {
-  // Temporary placeholder - will be replaced with proper flag conversion
+  if (!country) return "";
+  // ISO 3166-1 alpha-2 code → Unicode regional indicator pair
+  if (/^[a-zA-Z]{2}$/.test(country)) {
+    return [...country.toUpperCase()]
+      .map((c) => String.fromCodePoint(0x1f1e6 + c.charCodeAt(0) - 65))
+      .join("");
+  }
+  // Fallback: full country name map (used by Storybook stories)
   const flagMap: Record<string, string> = {
     france: "🇫🇷",
     germany: "🇩🇪",
@@ -27,8 +34,15 @@ function getCountryFlag(country: string): string {
     netherlands: "🇳🇱",
     brazil: "🇧🇷",
     "united states": "🇺🇸",
+    nigeria: "🇳🇬",
+    colombia: "🇨🇴",
+    ghana: "🇬🇭",
+    indonesia: "🇮🇩",
+    uganda: "🇺🇬",
+    india: "🇮🇳",
+    egypt: "🇪🇬",
   };
-  return flagMap[country.toLowerCase()] || "";
+  return flagMap[country.toLowerCase()] ?? "";
 }
 
 /**
@@ -103,7 +117,7 @@ export function DatasetCard({
 
         {/* Stats */}
         <div className="flex items-center gap-3 text-[10px] mt-2">
-          {stats?.map((stat) => {
+          {stats.map((stat) => {
             const StatIcon = getStatIcon(stat.label);
             return (
               <div key={stat.label} className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -125,12 +125,16 @@ async function createDatasetOnDemand(
   });
 
   if (area && !area.countryCode) {
-    const areaDetails = await getAreaDetailsById(areaId);
-    if (areaDetails?.countryCode) {
-      area = await prisma.area.update({
-        where: { id: areaId },
-        data: { countryCode: areaDetails.countryCode },
-      });
+    try {
+      const areaDetails = await getAreaDetailsById(areaId);
+      if (areaDetails?.countryCode) {
+        area = await prisma.area.update({
+          where: { id: areaId },
+          data: { countryCode: areaDetails.countryCode },
+        });
+      }
+    } catch (error) {
+      logger.error("Failed to backfill countryCode", { areaId, error });
     }
   }
 

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -6,6 +6,9 @@ import { fetchOsmRelationData, fetchDatasetSnapshot } from "@/lib/osm";
 import { Prisma } from "@prisma/client";
 import { trackEvent } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("dataset-operations");
 
 export type DatasetCreationResult = {
   dataset: NonNullable<Awaited<ReturnType<typeof getDatasetWithDetails>>>;
@@ -34,14 +37,19 @@ export async function getOrCreateDataset(
 
   if (dataset) {
     if (!dataset.area.countryCode) {
-      const areaDetails = await getAreaDetailsById(areaId);
-      if (areaDetails?.countryCode) {
-        await prisma.area.update({
-          where: { id: areaId },
-          data: { countryCode: areaDetails.countryCode },
-        });
-        dataset.area.countryCode = areaDetails.countryCode;
-      }
+      void (async () => {
+        try {
+          const areaDetails = await getAreaDetailsById(areaId);
+          if (areaDetails?.countryCode) {
+            await prisma.area.update({
+              where: { id: areaId },
+              data: { countryCode: areaDetails.countryCode },
+            });
+          }
+        } catch (error) {
+          logger.error("Failed to backfill countryCode", { areaId, error });
+        }
+      })();
     }
     return { dataset, wasCreated: false };
   }
@@ -181,7 +189,7 @@ async function createDatasetOnDemand(
         });
       }
     } catch (error) {
-      console.error("Failed to fetch area data:", error);
+      logger.error("Failed to fetch area data", { areaId, error });
       throw new Error(`Failed to fetch area data: ${areaId}`);
     }
   }
@@ -247,7 +255,7 @@ async function createDatasetOnDemand(
       template: resolvedTemplate,
     };
   } catch (error) {
-    console.error("Failed to fetch Overpass data:", error);
+    logger.error("Failed to fetch Overpass data", { areaId, templateId: template.id, error });
 
     if (error instanceof Error) {
       if (error.message.includes("timeout")) {

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -33,6 +33,16 @@ export async function getOrCreateDataset(
   let dataset = await getDatasetWithDetails(areaId, template.id, locale);
 
   if (dataset) {
+    if (!dataset.area.countryCode) {
+      const areaDetails = await getAreaDetailsById(areaId);
+      if (areaDetails?.countryCode) {
+        await prisma.area.update({
+          where: { id: areaId },
+          data: { countryCode: areaDetails.countryCode },
+        });
+        dataset.area.countryCode = areaDetails.countryCode;
+      }
+    }
     return { dataset, wasCreated: false };
   }
 
@@ -106,48 +116,65 @@ async function createDatasetOnDemand(
     where: { id: areaId },
   });
 
+  if (area && !area.countryCode) {
+    const areaDetails = await getAreaDetailsById(areaId);
+    if (areaDetails?.countryCode) {
+      area = await prisma.area.update({
+        where: { id: areaId },
+        data: { countryCode: areaDetails.countryCode },
+      });
+    }
+  }
+
   if (!area) {
     try {
-      const osmData = await fetchOsmRelationData(areaId);
+      const [osmData, areaDetails] = await Promise.all([
+        fetchOsmRelationData(areaId),
+        getAreaDetailsById(areaId),
+      ]);
+
+      if (!osmData && !areaDetails) {
+        throw new Error(`Area not found: ${areaId}`);
+      }
+
+      // City OSM relations don't carry ISO3166 tags — Nominatim is the
+      // only reliable source for country code.
+      const countryCode = areaDetails?.countryCode ?? null;
+
       if (osmData) {
         area = await prisma.area.upsert({
           where: { id: areaId },
           update: {
             name: osmData.name,
-            countryCode: osmData.countryCode,
+            countryCode,
             bounds: osmData.bounds,
             geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
           },
           create: {
             id: areaId,
             name: osmData.name,
-            countryCode: osmData.countryCode,
+            countryCode,
             bounds: osmData.bounds,
             geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
           },
         });
       } else {
-        const areaDetails = await getAreaDetailsById(areaId);
-        if (!areaDetails) {
-          throw new Error(`Area not found: ${areaId}`);
-        }
-
         area = await prisma.area.upsert({
           where: { id: areaId },
           update: {
-            name: areaDetails.name,
-            countryCode: areaDetails.countryCode,
-            bounds: areaDetails.boundingBox
-              ? JSON.stringify(areaDetails.boundingBox)
+            name: areaDetails!.name,
+            countryCode,
+            bounds: areaDetails!.boundingBox
+              ? JSON.stringify(areaDetails!.boundingBox)
               : null,
             geojson: Prisma.JsonNull,
           },
           create: {
             id: areaId,
-            name: areaDetails.name,
-            countryCode: areaDetails.countryCode,
-            bounds: areaDetails.boundingBox
-              ? JSON.stringify(areaDetails.boundingBox)
+            name: areaDetails!.name,
+            countryCode,
+            bounds: areaDetails!.boundingBox
+              ? JSON.stringify(areaDetails!.boundingBox)
               : null,
             geojson: Prisma.JsonNull,
           },

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -25,7 +25,10 @@ export function processDatasetStats(dataset: Dataset, locale: string): Processed
 function formatRelativeTime(timestamp: string | null | undefined, locale: string): string {
   if (!timestamp) return "—";
 
-  const diffMs = new Date(timestamp).getTime() - Date.now();
+  const date = new Date(timestamp);
+  if (isNaN(date.getTime())) return "—";
+
+  const diffMs = date.getTime() - Date.now();
   const absSec = Math.abs(diffMs / 1000);
   const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
 

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -1,0 +1,36 @@
+import { Dataset } from "@prisma/client";
+
+export interface ProcessedDatasetStats {
+  features: number;
+  contributors: number;
+  lastEdited: string;
+}
+
+export function processDatasetStats(dataset: Dataset): ProcessedDatasetStats {
+  const stats = dataset.stats as
+    | {
+        editorsCount?: number;
+        mostRecentElement?: string | null;
+      }
+    | undefined
+    | null;
+
+  return {
+    features: dataset.dataCount,
+    contributors: stats?.editorsCount || 0,
+    lastEdited: formatRelativeTime(stats?.mostRecentElement),
+  };
+}
+
+function formatRelativeTime(timestamp: string | null | undefined): string {
+  if (!timestamp) return "—";
+
+  const date = new Date(timestamp);
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+
+  if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)} hours ago`;
+  if (seconds < 2592000) return `${Math.floor(seconds / 86400)} days ago`;
+  if (seconds < 31536000) return `${Math.floor(seconds / 2592000)} months ago`;
+  return `${Math.floor(seconds / 31536000)} years ago`;
+}

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -6,7 +6,7 @@ export interface ProcessedDatasetStats {
   lastEdited: string;
 }
 
-export function processDatasetStats(dataset: Dataset): ProcessedDatasetStats {
+export function processDatasetStats(dataset: Dataset, locale: string): ProcessedDatasetStats {
   const stats = dataset.stats as
     | {
         editorsCount?: number;
@@ -18,19 +18,21 @@ export function processDatasetStats(dataset: Dataset): ProcessedDatasetStats {
   return {
     features: dataset.dataCount,
     contributors: stats?.editorsCount || 0,
-    lastEdited: formatRelativeTime(stats?.mostRecentElement),
+    lastEdited: formatRelativeTime(stats?.mostRecentElement, locale),
   };
 }
 
-function formatRelativeTime(timestamp: string | null | undefined): string {
+function formatRelativeTime(timestamp: string | null | undefined, locale: string): string {
   if (!timestamp) return "—";
 
-  const date = new Date(timestamp);
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  const diffMs = new Date(timestamp).getTime() - Date.now();
+  const absSec = Math.abs(diffMs / 1000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
 
-  if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)} hours ago`;
-  if (seconds < 2592000) return `${Math.floor(seconds / 86400)} days ago`;
-  if (seconds < 31536000) return `${Math.floor(seconds / 2592000)} months ago`;
-  return `${Math.floor(seconds / 31536000)} years ago`;
+  if (absSec < 60) return rtf.format(Math.round(diffMs / 1000), "second");
+  if (absSec < 3600) return rtf.format(Math.round(diffMs / 60000), "minute");
+  if (absSec < 86400) return rtf.format(Math.round(diffMs / 3600000), "hour");
+  if (absSec < 2592000) return rtf.format(Math.round(diffMs / 86400000), "day");
+  if (absSec < 31536000) return rtf.format(Math.round(diffMs / 2592000000), "month");
+  return rtf.format(Math.round(diffMs / 31536000000), "year");
 }

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -65,7 +65,7 @@ export function transformDataset(
     bbox: rawDataset.bbox as number[] | null,
     template: {
       ...resolvedTemplate,
-      category: (resolvedTemplate as { category?: { slug: string } }).category?.slug ?? "other",
+      category: (resolvedTemplate as { category?: { id: string; name: string; slug: string } | null }).category ?? null,
     },
     area: rawDataset.area ? {
       ...rawDataset.area,

--- a/src/lib/osm.ts
+++ b/src/lib/osm.ts
@@ -93,7 +93,6 @@ export async function fetchOsmRelationData(relationId: number) {
 
   return {
     name: rel.tags?.name || `Relation ${relationId}`,
-    countryCode: rel.tags?.["ISO3166-1"] || null,
     bounds: rel.bounds
       ? `${rel.bounds.minlat},${rel.bounds.minlon},${rel.bounds.maxlat},${rel.bounds.maxlon}`
       : null,

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -58,7 +58,11 @@ export const DatasetSchema = z.object({
   template: z.object({
     id: z.string(),
     name: z.string(),
-    category: z.string(),
+    category: z.object({
+      id: z.string(),
+      name: z.string(),
+      slug: z.string(),
+    }).nullable(),
     description: z.string().nullable(),
   }),
   user: z

--- a/tests/dataset-watch-button.spec.ts
+++ b/tests/dataset-watch-button.spec.ts
@@ -77,7 +77,7 @@ test.describe("Dataset Watch Button", () => {
 
   test("should display watch button for datasets", async ({ page }) => {
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     // Check that watch button is visible
@@ -90,7 +90,7 @@ test.describe("Dataset Watch Button", () => {
 
   test("should successfully watch a dataset", async ({ page }) => {
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     // Click watch button
@@ -116,7 +116,7 @@ test.describe("Dataset Watch Button", () => {
 
   test("should successfully unwatch a dataset", async ({ page }) => {
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     // First watch the dataset through the UI
@@ -167,7 +167,7 @@ test.describe("Dataset Watch Button", () => {
     });
 
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     const watchButton = page.getByTestId("dataset-watch-button");
@@ -200,7 +200,7 @@ test.describe("Dataset Watch Button", () => {
 
   test("should show correct button states", async ({ page }) => {
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     // Initially should show watch button
@@ -233,7 +233,7 @@ test.describe("Dataset Watch Button", () => {
     });
 
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     const watchButton = page.getByTestId("dataset-watch-button");
@@ -273,7 +273,7 @@ test.describe("Dataset Watch Button", () => {
     await prisma.$disconnect();
 
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     // Should show unwatch button initially
@@ -343,7 +343,7 @@ test.describe("Dataset Watch Button", () => {
     await seedPrisma.$disconnect();
 
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     const watchButton = page.getByTestId("dataset-watch-button");
@@ -400,7 +400,7 @@ test.describe("Dataset Watch Button", () => {
     await prisma.$disconnect();
 
     await page.goto(
-      `/area/${testDataset.area.id}/dataset/${testDataset.template.id}`
+      getLocalizedPath(`/area/${testDataset.area.id}/dataset/${testDataset.template.id}`)
     );
 
     // Current user should still be able to watch

--- a/tests/template-deprecation.spec.ts
+++ b/tests/template-deprecation.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "./utils/auth";
 
 test.describe("Template Deprecation", () => {
+  test.describe.configure({ mode: "serial" });
   let testUser: { id: string; email: string; password?: string };
 
   test.afterEach(async () => {


### PR DESCRIPTION
## Issue #273: feat(catalog): create /featured-datasets page

**Problem:** Need a public catalog page showing featured datasets in a card grid layout for discovery.

**Acceptance Criteria:**
- [x] Page lists all featured datasets in grid
- [x] Links work to dataset pages
- [x] Accessible without login
- [x] Empty state handled
- [x] Responsive layout

**Changes:**
- Created `/explore` page displaying featured datasets in responsive grid (1/2/3 columns)
- Added `processDatasetStats()` helper for card stats (features, contributors, lastEdited)
- Refactored `DatasetCard`: stats now required prop, improved country flag handling
- Made Explore the first navigation link for all users (logged in and out)
- Added `cursor-pointer` to Button component for proper hover cursor
- Updated hero CTA: added "Explore datasets" primary button linking to /explore
- Added i18n support for all locales (en, es, pt-BR)