### PR TITLE
fix(api): include category relation in all dataset queries

### DIFF
--- a/prisma/sync-templates.ts
+++ b/prisma/sync-templates.ts
@@ -116,7 +116,10 @@ async function main() {
 
     const categorySlug = template.category || "other";
     const dbSlug = YAML_TO_DB_SLUG[categorySlug] ?? categorySlug;
-    const categoryId: string = categoryMap.get(dbSlug) ?? "cat_other";
+    const categoryId = categoryMap.get(dbSlug) || categoryMap.get("other");
+    if (!categoryId) {
+      throw new Error(`Category "${dbSlug}" not found in database and fallback "other" category is missing`);
+    }
 
     await prisma.template.upsert({
       where: { id: template.id },

--- a/src/app/[locale]/dataset/[id]/page.tsx
+++ b/src/app/[locale]/dataset/[id]/page.tsx
@@ -21,7 +21,14 @@ async function getDataset(id: string, locale: string): Promise<Dataset | null> {
     const rawDataset = await prisma.dataset.findUnique({
       where: { id },
       include: {
-        template: { include: { translations: true } },
+        template: {
+          include: {
+            translations: true,
+            category: {
+              select: { slug: true },
+            },
+          },
+        },
         area: true,
         user: {
           select: {

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -25,7 +25,13 @@ export async function POST(
         userId: user.id,
       },
       include: {
-        template: true,
+        template: {
+          include: {
+            category: {
+              select: { slug: true },
+            },
+          },
+        },
         area: true,
       },
     });

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -65,7 +65,13 @@ export async function POST(
         updatedAt: new Date(),
       },
       include: {
-        template: true,
+        template: {
+          include: {
+            category: {
+              select: { slug: true },
+            },
+          },
+        },
         user: {
           select: {
             id: true,

--- a/src/app/api/datasets/[id]/route.ts
+++ b/src/app/api/datasets/[id]/route.ts
@@ -13,7 +13,13 @@ export async function GET(
         id: id,
       },
       include: {
-        template: true,
+        template: {
+          include: {
+            category: {
+              select: { slug: true },
+            },
+          },
+        },
         user: {
           select: {
             id: true,

--- a/src/app/api/datasets/watched/route.ts
+++ b/src/app/api/datasets/watched/route.ts
@@ -21,7 +21,13 @@ export async function GET() {
       include: {
         dataset: {
           include: {
-            template: true,
+            template: {
+              include: {
+                category: {
+                  select: { slug: true },
+                },
+              },
+            },
             user: {
               select: {
                 id: true,

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -44,12 +44,13 @@ export function transformDataset(
   }
 
   const resolvedTemplate = options?.skipTemplateResolution
-    ? (rawDataset.template as { name: string; description: string | null })
+    ? (rawDataset.template as { name: string; description: string | null; category?: { slug: string } })
     : resolveTemplateForLocale(
         rawDataset.template as {
           translations: Array<{ locale: string; name: string; description: string | null }>;
           name: string;
           description: string | null;
+          category?: { slug: string };
         },
         locale
       );
@@ -62,7 +63,10 @@ export function transformDataset(
     ...rawDataset,
     geojson: rawDataset.geojson as FeatureCollection | null,
     bbox: rawDataset.bbox as number[] | null,
-    template: resolvedTemplate,
+    template: {
+      ...resolvedTemplate,
+      category: (resolvedTemplate as { category?: { slug: string } }).category?.slug ?? "other",
+    },
     area: rawDataset.area ? {
       ...rawDataset.area,
       geojson: rawDataset.area.geojson as FeatureCollection | null,


### PR DESCRIPTION
## Summary

Fixes 404 errors on dataset pages caused by missing category relation in Prisma queries after the May 25, 2026 category migration (PR #280).

## Root Cause

The category migration converted `template.category` from a string field to a relation pointing to the `Category` model. Several components' Prisma queries weren't updated to include the category relation, causing pages to fail when trying to access `dataset.template.category.slug`.

## Changes

- **Dataset page** (`src/app/[locale]/dataset/[id]/page.tsx`): Add category include to template query
- **Dataset API routes** (`src/app/api/datasets/[id]/route.ts`, `src/app/api/datasets/watched/route.ts`, `src/app/api/datasets/[id]/refresh/route.ts`): Include category in template relation
- **Transform layer** (`src/lib/dataset/transform.ts`): Extract category.slug from relation object for schema compatibility
- **Template sync** (`prisma/sync-templates.ts`): Validate category fallback exists to prevent foreign key errors

## Testing

- ✓ Dataset pages load successfully without 404
- ✓ Category displays correctly in dataset info panel
- ✓ All dataset API routes return category properly
- ✓ Area page template grid still works
- ✓ Watched datasets API works

## Files Changed

- `src/app/[locale]/dataset/[id]/page.tsx`
- `src/app/api/datasets/[id]/route.ts`
- `src/app/api/datasets/[id]/refresh/route.ts`
- `src/app/api/datasets/watched/route.ts`
- `src/lib/dataset/transform.ts`
- `prisma/sync-templates.ts`