### PR TITLE
fix(i18n): fix anglicism in pt-BR/es home page, add i18n:review script

### DIFF
--- a/messages/es.json
+++ b/messages/es.json
@@ -372,7 +372,7 @@
       "title": "Cómo funciona OSM for Cities",
       "description": "Sigue conjuntos de datos, rastrea cambios, explora datos visualmente y descarga para análisis",
       "curate": {
-        "title": "Curate tus conjuntos de datos",
+        "title": "Selecciona tus conjuntos de datos",
         "description": "Elige lo que importa para tu ciudad. Sigue escuelas, transporte, parques, clínicas o cualquier conjunto de datos rastreado en OpenStreetMap. Construye una feed personalizada de la infraestructura que te importa."
       },
       "notifications": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -372,7 +372,7 @@
       "title": "Como o OSM for Cities funciona",
       "description": "Siga conjuntos de dados, monitore mudanças, explore dados visualmente e baixe para análise",
       "curate": {
-        "title": "Curate seus conjuntos de dados",
+        "title": "Selecione seus conjuntos de dados",
         "description": "Escolha o que importa para sua cidade. Siga escolas, transporte, parques, clínicas ou qualquer conjunto de dados rastreado no OpenStreetMap. Construa um feed personalizado da infraestrutura que você se importa."
       },
       "notifications": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepare": "husky",
     "i18n:check": "i18n-check --locales messages --source en",
     "i18n:check:fix": "i18n-check --locales messages --source en --fix",
+    "i18n:review": "tsx scripts/export-translations.ts",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset version && git add .",

--- a/scripts/export-translations.ts
+++ b/scripts/export-translations.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env tsx
+// Usage:
+//   pnpm i18n:review              — list sections with key/flagged counts
+//   pnpm i18n:review <Section>    — print all keys in that section
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MESSAGES_DIR = join(__dirname, "../messages");
+const LOCALES = ["pt-BR", "es"] as const;
+
+// Words allowed to appear unchanged in any translation (proper nouns, tech terms)
+const ALLOWED = new Set([
+  "email",
+  "spam",
+  "online",
+  "openstreetmap",
+  "osm",
+  "feed",
+  "dashboard",
+  "download",
+]);
+
+function flatten(
+  obj: Record<string, unknown>,
+  prefix = ""
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      result[path] = value;
+    } else if (typeof value === "object" && value !== null) {
+      Object.assign(result, flatten(value as Record<string, unknown>, path));
+    }
+  }
+  return result;
+}
+
+// Returns English words that appear verbatim in the translation (possible anglicisms).
+// Skips short words, capitalized words (proper nouns), and known allowed terms.
+function detectAnglicisms(enValue: string, translated: string): string[] {
+  const translatedLower = translated.toLowerCase();
+  return enValue
+    .split(/\s+/)
+    .filter((word) => {
+      const clean = word.replace(/[^a-zA-Z]/g, "");
+      if (clean.length < 5) return false;
+      if (clean[0] === clean[0].toUpperCase() && clean[0] !== clean[0].toLowerCase()) return false; // proper noun
+      if (ALLOWED.has(clean.toLowerCase())) return false;
+      return translatedLower.includes(clean.toLowerCase());
+    })
+    .map((w) => w.replace(/[^a-zA-Z]/g, ""));
+}
+
+function loadMessages() {
+  const en = flatten(
+    JSON.parse(readFileSync(join(MESSAGES_DIR, "en.json"), "utf-8"))
+  );
+  const locales: Record<string, Record<string, string>> = {};
+  for (const locale of LOCALES) {
+    locales[locale] = flatten(
+      JSON.parse(readFileSync(join(MESSAGES_DIR, `${locale}.json`), "utf-8"))
+    );
+  }
+  return { en, locales };
+}
+
+function groupBySection(keys: string[]): Record<string, string[]> {
+  const sections: Record<string, string[]> = {};
+  for (const key of keys) {
+    const section = key.split(".")[0];
+    if (!sections[section]) sections[section] = [];
+    sections[section].push(key);
+  }
+  return sections;
+}
+
+function countFlagged(
+  keys: string[],
+  en: Record<string, string>,
+  locales: Record<string, Record<string, string>>
+): number {
+  let count = 0;
+  for (const key of keys) {
+    for (const locale of LOCALES) {
+      const translated = locales[locale][key];
+      if (translated && detectAnglicisms(en[key], translated).length > 0) {
+        count++;
+        break;
+      }
+    }
+  }
+  return count;
+}
+
+function printSectionList(
+  sections: Record<string, string[]>,
+  en: Record<string, string>,
+  locales: Record<string, Record<string, string>>
+) {
+  console.log("Sections:\n");
+  for (const [section, keys] of Object.entries(sections)) {
+    const flagged = countFlagged(keys, en, locales);
+    const flag = flagged > 0 ? `  ⚠ ${flagged} flagged` : "";
+    console.log(`  ${section.padEnd(32)} ${String(keys.length).padStart(3)} keys${flag}`);
+  }
+  console.log(`\nUsage: pnpm i18n:review <Section>`);
+}
+
+function printSection(
+  section: string,
+  keys: string[],
+  en: Record<string, string>,
+  locales: Record<string, Record<string, string>>
+) {
+  const flaggedCount = countFlagged(keys, en, locales);
+  console.log(`\n=== ${section} (${keys.length} keys${flaggedCount > 0 ? `, ⚠ ${flaggedCount} flagged` : ""}) ===\n`);
+
+  for (const key of keys) {
+    const enValue = en[key];
+    const lines: string[] = [`${key}`];
+    lines.push(`  EN:    ${enValue}`);
+    for (const locale of LOCALES) {
+      const translated = locales[locale][key] ?? "(missing)";
+      const anglicisms = detectAnglicisms(enValue, translated);
+      const flag = anglicisms.length > 0 ? `   ⚠ "${anglicisms.join('", "')}"` : "";
+      lines.push(`  ${locale.padEnd(6)} ${translated}${flag}`);
+    }
+    console.log(lines.join("\n"));
+    console.log("---");
+  }
+}
+
+function main() {
+  const { en, locales } = loadMessages();
+  const sections = groupBySection(Object.keys(en));
+  const requestedSection = process.argv[2];
+
+  if (!requestedSection) {
+    printSectionList(sections, en, locales);
+    return;
+  }
+
+  const keys = sections[requestedSection];
+  if (!keys) {
+    console.error(
+      `Section "${requestedSection}" not found.\nAvailable: ${Object.keys(sections).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  printSection(requestedSection, keys, en, locales);
+}
+
+main();

--- a/scripts/export-translations.ts
+++ b/scripts/export-translations.ts
@@ -3,11 +3,13 @@
 //   pnpm i18n:review              — list sections with key/flagged counts
 //   pnpm i18n:review <Section>    — print all keys in that section
 
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 
 const MESSAGES_DIR = join(__dirname, "../messages");
-const LOCALES = ["pt-BR", "es"] as const;
+const LOCALES = readdirSync(MESSAGES_DIR)
+  .filter((f) => f.endsWith(".json") && f !== "en.json" && !f.endsWith(".ts"))
+  .map((f) => f.replace(".json", ""));
 
 // Words allowed to appear unchanged in any translation (proper nouns, tech terms)
 const ALLOWED = new Set([
@@ -40,7 +42,6 @@ function flatten(
 // Returns English words that appear verbatim in the translation (possible anglicisms).
 // Skips short words, capitalized words (proper nouns), and known allowed terms.
 function detectAnglicisms(enValue: string, translated: string): string[] {
-  const translatedLower = translated.toLowerCase();
   return enValue
     .split(/\s+/)
     .filter((word) => {
@@ -48,7 +49,7 @@ function detectAnglicisms(enValue: string, translated: string): string[] {
       if (clean.length < 5) return false;
       if (clean[0] === clean[0].toUpperCase() && clean[0] !== clean[0].toLowerCase()) return false; // proper noun
       if (ALLOWED.has(clean.toLowerCase())) return false;
-      return translatedLower.includes(clean.toLowerCase());
+      return new RegExp(`\\b${clean}\\b`, "i").test(translated);
     })
     .map((w) => w.replace(/[^a-zA-Z]/g, ""));
 }


### PR DESCRIPTION
**Problem:** `Home.features.curate.title` used "Curate" verbatim in pt-BR and es. The English source was updated to "Select your datasets" but translations weren't. `i18n-check` only validates key presence, not quality.

**Changes:**
- pt-BR: `"Curate seus conjuntos de dados"` → `"Selecione seus conjuntos de dados"`
- es: `"Curate tus conjuntos de dados"` → `"Selecciona tus conjuntos de datos"`
- `scripts/export-translations.ts`: new `pnpm i18n:review` command — prints translations side-by-side per section with anglicism heuristic, for agent review