### PR TITLE
fix: Greptile feedback #3, #4, #5 from PR #305

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -174,6 +174,7 @@
     "unfeature": "Unfeature",
     "featureTitle": "Feature this dataset on homepage",
     "unfeatureTitle": "Remove from featured",
+    "featureError": "Could not update featured status. Try again.",
     "dataMetrics": "Data Metrics",
     "actions": "Actions"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -173,6 +173,7 @@
     "unfeature": "Quitar destacado",
     "featureTitle": "Destacar este conjunto en la página principal",
     "unfeatureTitle": "Quitar de destacados",
+    "featureError": "No se pudo actualizar el estado destacado. Intente de nuevo.",
     "dataMetrics": "Métricas de Datos",
     "actions": "Acciones"
   },

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -173,6 +173,7 @@
     "unfeature": "Remover destaque",
     "featureTitle": "Destacar este conjunto na página inicial",
     "unfeatureTitle": "Remover dos destaques",
+    "featureError": "Não foi possível atualizar o status em destaque. Tente novamente.",
     "dataMetrics": "Métricas dos Dados",
     "actions": "Ações"
   },

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -40,21 +40,18 @@ export async function POST(req: NextRequest) {
 
   if (!area) {
     try {
-      const fetched = await fetchOsmRelationData(osmRelationId);
+      const [fetched, countryCode] = await Promise.all([
+        fetchOsmRelationData(osmRelationId),
+        getAreaDetailsById(osmRelationId)
+          .then((details) => details?.countryCode ?? null)
+          .catch(() => null),
+      ]);
 
       if (!fetched)
         return NextResponse.json(
           { error: "Failed to fetch OSM relation" },
           { status: 400 }
         );
-
-      let countryCode: string | null = null;
-      try {
-        const areaDetails = await getAreaDetailsById(osmRelationId);
-        countryCode = areaDetails?.countryCode ?? null;
-      } catch {
-        // Nominatim is best-effort; country code can be backfilled later
-      }
 
       area = await prisma.area.create({
         data: {

--- a/src/components/dataset/dataset-actions-section.tsx
+++ b/src/components/dataset/dataset-actions-section.tsx
@@ -22,6 +22,7 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isFeatured, setIsFeatured] = useState(dataset.isFeatured ?? false);
   const [isFeaturingLoading, setIsFeaturingLoading] = useState(false);
+  const [hasFeatureError, setHasFeatureError] = useState(false);
 
   const handleToggleWatch = async () => {
     try {
@@ -46,6 +47,7 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
   };
 
   const handleToggleFeatured = async () => {
+    setHasFeatureError(false);
     setIsFeaturingLoading(true);
     try {
       const res = await fetch(`/api/datasets/${dataset.id}/feature`, {
@@ -56,6 +58,7 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
       setIsFeatured(data.isFeatured);
     } catch (error) {
       console.error("Error toggling featured status:", error);
+      setHasFeatureError(true);
     } finally {
       setIsFeaturingLoading(false);
     }
@@ -87,16 +90,23 @@ export function DatasetActionsSection({ dataset }: DatasetActionsSectionProps) {
         )}
 
         {dataset.canFeature && (
-          <Button
-            onClick={handleToggleFeatured}
-            disabled={isFeaturingLoading}
-            className="flex items-center gap-2 w-full h-10"
-            variant={isFeatured ? "default" : "outline"}
-            title={isFeatured ? t("unfeatureTitle") : t("featureTitle")}
-          >
-            <Star className={`h-4 w-4 ${isFeatured ? "fill-current" : ""}`} />
-            {isFeatured ? t("unfeature") : t("feature")}
-          </Button>
+          <>
+            <Button
+              onClick={handleToggleFeatured}
+              disabled={isFeaturingLoading}
+              className="flex items-center gap-2 w-full h-10"
+              variant={isFeatured ? "default" : "outline"}
+              title={isFeatured ? t("unfeatureTitle") : t("featureTitle")}
+            >
+              <Star className={`h-4 w-4 ${isFeatured ? "fill-current" : ""}`} />
+              {isFeatured ? t("unfeature") : t("feature")}
+            </Button>
+            {hasFeatureError && (
+              <p role="alert" className="text-sm text-red-600">
+                {t("featureError")}
+              </p>
+            )}
+          </>
         )}
 
         {/* Refresh Button */}

--- a/src/lib/map-themes/detection.ts
+++ b/src/lib/map-themes/detection.ts
@@ -281,9 +281,10 @@ export function calculateScore(theme: MapTheme, coverage: number): number {
       return coverage * 10;
     case 'intensity':
       return coverage * 5;
-    case 'categorical':
+    case 'categorical': {
       const categoryCount = theme.topValues.length + theme.otherCount;
       return coverage * Math.min(categoryCount, 10);
+    }
     default:
       return 0;
   }


### PR DESCRIPTION
## Context

Follow-up fixes for Greptile code review feedback on PR #305 (Release v1.10.0). Items #1 and #2 (category select fixes) are handled separately.

**Item #3** — Lint: `no-case-declarations` in `src/lib/map-themes/detection.ts`
**Item #4** — Parallelize Overpass + Nominatim in dataset creation endpoint
**Item #5** — Surface feature-toggle errors to admin via inline message

**Changes:**
- Wrapped `'categorical'` switch case in braces to fix ESLint `no-case-declarations` warning
- Refactored `POST /api/datasets` to run Overpass fetch and Nominatim lookup in parallel via `Promise.all`, matching the pattern in `dataset-operations.ts`. Nominatim failures are caught and return `null` (best-effort country code).
- Added `hasFeatureError` state and inline `<p role="alert">` error message below the Feature button. Added `DatasetPage.featureError` i18n key to all 3 locale files (en, es, pt-BR).

**Verification:**
- `pnpm type-check` — clean
- `pnpm lint` — no new errors (pre-existing test warnings unrelated)
- `pnpm i18n:check` — no missing/invalid keys