### PR TITLE
fix(explore): optimize query by excluding geojson and adding index

### DIFF
--- a/prisma/migrations/20260613145727_add_featured_datasets_index/migration.sql
+++ b/prisma/migrations/20260613145727_add_featured_datasets_index/migration.sql
@@ -1,5 +1,5 @@
 -- DropIndex
-DROP INDEX "datasets_userId_templateId_areaId_key";
+DROP INDEX IF EXISTS "datasets_userId_templateId_areaId_key";
 
 -- AlterTable
 ALTER TABLE "categories" ALTER COLUMN "updatedAt" DROP DEFAULT;

--- a/prisma/migrations/20260613145727_add_featured_datasets_index/migration.sql
+++ b/prisma/migrations/20260613145727_add_featured_datasets_index/migration.sql
@@ -1,0 +1,14 @@
+-- DropIndex
+DROP INDEX "datasets_userId_templateId_areaId_key";
+
+-- AlterTable
+ALTER TABLE "categories" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "dataset_watches" ALTER COLUMN "id" DROP DEFAULT;
+
+-- CreateIndex
+CREATE INDEX "datasets_isFeatured_createdAt_idx" ON "datasets"("isFeatured", "createdAt");
+
+-- RenameIndex
+ALTER INDEX "Dataset_templateId_areaId_key" RENAME TO "datasets_templateId_areaId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,6 +126,7 @@ model Dataset {
   user        User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([templateId, areaId])
+  @@index([isFeatured, createdAt])
   @@map("datasets")
 }
 

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -27,7 +27,13 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
   const t = await getTranslations("ExplorePage");
   const datasets = await prisma.dataset.findMany({
     where: { isFeatured: true },
-    include: {
+    select: {
+      id: true,
+      cityName: true,
+      dataCount: true,
+      stats: true,
+      areaId: true,
+      templateId: true,
       area: {
         select: {
           id: true,
@@ -35,9 +41,24 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
         },
       },
       template: {
-        include: {
-          translations: true,
-          category: true,
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          category: {
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+            },
+          },
+          translations: {
+            select: {
+              locale: true,
+              name: true,
+              description: true,
+            },
+          },
         },
       },
     },

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -6,7 +6,7 @@ export interface ProcessedDatasetStats {
   lastEdited: string;
 }
 
-export function processDatasetStats(dataset: Dataset, locale: string): ProcessedDatasetStats {
+export function processDatasetStats(dataset: Pick<Dataset, 'dataCount' | 'stats'>, locale: string): ProcessedDatasetStats {
   const stats = dataset.stats as
     | {
         editorsCount?: number;


### PR DESCRIPTION
## Summary

- Use `select` instead of `include` to exclude heavy `geojson` field from explore page query
- Add compound index on `(isFeatured, createdAt)` for faster filtered queries
- Reduces page load time by not fetching unnecessary dataset data

## Test plan

- [x] Tested with featured dataset in worktree
- [x] Verified index created in database
- [x] Confirmed explore page loads quickly

## Migration

Creates `datasets_isFeatured_createdAt_idx` index for efficient querying of featured datasets sorted by creation date.