### PR TITLE
feat(explore): add recently added, largest, most watched sections

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -597,7 +597,9 @@
     "sections": {
       "featured": "Featured",
       "largest": "Largest Datasets",
-      "mostWatched": "Most Watched"
+      "mostWatched": "Most Watched",
+      "mostContributors": "Most Contributors",
+      "recentlyEdited": "Recently Edited"
     }
   },
   "SEO": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -585,10 +585,19 @@
     "title": "Explore",
     "description": "Discover open data from cities worldwide",
     "noDatasets": "No featured datasets yet.",
+    "noDatasetsFound": "No datasets found",
+    "seeAll": "See all →",
+    "backToExplore": "← Back to Explore",
     "stats": {
       "features": "Features",
       "contributors": "Contributors",
-      "lastEdited": "Last edited"
+      "lastEdited": "Last edited",
+      "watchers": "Watchers"
+    },
+    "sections": {
+      "featured": "Featured",
+      "largest": "Largest Datasets",
+      "mostWatched": "Most Watched"
     }
   },
   "SEO": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -592,10 +592,19 @@
     "title": "Explorar",
     "description": "Descubre datos abiertos de ciudades de todo el mundo",
     "noDatasets": "Aún no hay conjuntos de datos destacados.",
+    "noDatasetsFound": "No se encontraron conjuntos de datos",
+    "seeAll": "Ver todos →",
+    "backToExplore": "← Volver a Explorar",
     "stats": {
       "features": "Elementos",
       "contributors": "Colaboradores",
-      "lastEdited": "Última edición"
+      "lastEdited": "Última edición",
+      "watchers": "Seguidores"
+    },
+    "sections": {
+      "featured": "Destacados",
+      "largest": "Conjuntos de datos más grandes",
+      "mostWatched": "Más vistos"
     }
   },
   "SEO": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -604,7 +604,9 @@
     "sections": {
       "featured": "Destacados",
       "largest": "Conjuntos de datos más grandes",
-      "mostWatched": "Más vistos"
+      "mostWatched": "Más vistos",
+      "mostContributors": "Más colaboradores",
+      "recentlyEdited": "Editados recientemente"
     }
   },
   "SEO": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -604,7 +604,9 @@
     "sections": {
       "featured": "Destacados",
       "largest": "Maiores conjuntos de dados",
-      "mostWatched": "Mais vistos"
+      "mostWatched": "Mais vistos",
+      "mostContributors": "Mais contribuidores",
+      "recentlyEdited": "Editados recentemente"
     }
   },
   "SEO": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -592,10 +592,19 @@
     "title": "Explorar",
     "description": "Descubra dados abertos de cidades do mundo todo",
     "noDatasets": "Ainda não há conjuntos de dados em destaque.",
+    "noDatasetsFound": "Nenhum conjunto de dados encontrado",
+    "seeAll": "Ver todos →",
+    "backToExplore": "← Voltar para Explorar",
     "stats": {
       "features": "Elementos",
       "contributors": "Contribuidores",
-      "lastEdited": "Última edição"
+      "lastEdited": "Última edição",
+      "watchers": "Observadores"
+    },
+    "sections": {
+      "featured": "Destacados",
+      "largest": "Maiores conjuntos de dados",
+      "mostWatched": "Mais vistos"
     }
   },
   "SEO": {

--- a/src/app/[locale]/explore/[section]/page.tsx
+++ b/src/app/[locale]/explore/[section]/page.tsx
@@ -1,0 +1,199 @@
+import { prisma } from "@/lib/db";
+import { DatasetCard } from "@/components/ui/dataset-card";
+import { processDatasetStats } from "@/lib/dataset-stats";
+import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Locale } from "next-intl";
+import { notFound } from "next/navigation";
+
+export const revalidate = 3600;
+
+// Helper: Get stats for dataset based on section type
+function getDatasetStats(
+  dataset: { _count: { watchers: number } },
+  processedStats: { features: string | number; contributors: string | number; lastEdited: string | number },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: any,
+  section: Section
+) {
+  switch (section) {
+    case "largest":
+      return [
+        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
+      ];
+    case "most-watched":
+      return [
+        { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
+      ];
+    default:
+      return [
+        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
+        { type: "contributors" as const, label: t("stats.contributors"), value: processedStats.contributors },
+        { type: "lastEdited" as const, label: t("stats.lastEdited"), value: processedStats.lastEdited },
+      ];
+  }
+}
+
+const SECTIONS = ["featured", "largest", "most-watched"] as const;
+type Section = (typeof SECTIONS)[number];
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale; section: string }>;
+}) {
+  const { locale, section } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
+
+  const sectionKey = section === "largest" ? "largest" : section === "most-watched" ? "mostWatched" : "featured";
+  const title = t.raw(`sections.${sectionKey}`);
+
+  return {
+    title: `${title} - ${t("metaTitle")}`,
+  };
+}
+
+const DATASET_SELECT = {
+  id: true,
+  cityName: true,
+  dataCount: true,
+  stats: true,
+  areaId: true,
+  templateId: true,
+  createdAt: true,
+  area: {
+    select: {
+      id: true,
+      countryCode: true,
+    },
+  },
+  template: {
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
+      translations: {
+        select: {
+          locale: true,
+          name: true,
+          description: true,
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function ExploreSectionPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale; section: string }>;
+}) {
+  const { locale, section: sectionParam } = await params;
+
+  if (!SECTIONS.includes(sectionParam as Section)) {
+    notFound();
+  }
+
+  const section = sectionParam as Section;
+
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
+
+  const datasets = await getDatasets(section as Section);
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="mb-8">
+          <a
+            href={`/${locale}/explore`}
+            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
+          >
+            {t("backToExplore")}
+          </a>
+          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
+            {t(`sections.${sectionKey(section)}`)}
+          </h1>
+        </div>
+
+        {datasets.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {datasets.map((dataset) => {
+              const s = processDatasetStats(dataset, locale);
+              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+              const stats = getDatasetStats(dataset, s, t, section);
+
+              return (
+                <DatasetCard
+                  key={dataset.id}
+                  name={resolvedTemplate.name}
+                  city={dataset.cityName}
+                  country={dataset.area.countryCode ?? ""}
+                  category={resolvedTemplate.category?.name ?? "other"}
+                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                  stats={stats}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-12 text-neutral-400">
+            {t("noDatasetsFound")}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function sectionKey(section: Section): "featured" | "largest" | "mostWatched" {
+  switch (section) {
+    case "largest":
+      return "largest";
+    case "most-watched":
+      return "mostWatched";
+    default:
+      return "featured";
+  }
+}
+
+async function getDatasets(section: Section) {
+  const selectWithWatchers = {
+    ...DATASET_SELECT,
+    _count: {
+      select: { watchers: true }
+    }
+  };
+
+  switch (section) {
+    case "featured":
+      return prisma.dataset.findMany({
+        where: { isFeatured: true, dataCount: { gt: 0 } },
+        select: selectWithWatchers,
+        orderBy: { createdAt: "desc" },
+        take: 24,
+      });
+    case "largest":
+      return prisma.dataset.findMany({
+        where: { isActive: true, dataCount: { gt: 0 } },
+        select: selectWithWatchers,
+        orderBy: { dataCount: "desc" },
+        take: 24,
+      });
+    case "most-watched":
+      return prisma.dataset.findMany({
+        where: { isActive: true, dataCount: { gt: 0 } },
+        select: selectWithWatchers,
+        orderBy: { watchers: { _count: 'desc' } },
+        take: 24,
+      });
+  }
+}

--- a/src/app/[locale]/explore/[section]/page.tsx
+++ b/src/app/[locale]/explore/[section]/page.tsx
@@ -6,7 +6,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { notFound } from "next/navigation";
 
-export const revalidate = 3600;
+export const revalidate = 300;
 
 // Helper: Get stats for dataset based on section type
 function getDatasetStats(

--- a/src/app/[locale]/explore/[section]/page.tsx
+++ b/src/app/[locale]/explore/[section]/page.tsx
@@ -1,37 +1,16 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
-import { processDatasetStats } from "@/lib/dataset-stats";
+import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { notFound } from "next/navigation";
+import { Link } from "@/i18n/navigation";
 
 export const revalidate = 300;
 
-// Helper: Get stats for dataset based on section type
-function getDatasetStats(
-  dataset: { _count: { watchers: number } },
-  processedStats: { features: string | number; contributors: string | number; lastEdited: string | number },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  t: any,
-  section: Section
-) {
-  switch (section) {
-    case "largest":
-      return [
-        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
-      ];
-    case "most-watched":
-      return [
-        { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
-      ];
-    default:
-      return [
-        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
-        { type: "contributors" as const, label: t("stats.contributors"), value: processedStats.contributors },
-        { type: "lastEdited" as const, label: t("stats.lastEdited"), value: processedStats.lastEdited },
-      ];
-  }
+export function generateStaticParams() {
+  return SECTIONS.map((section) => ({ section }));
 }
 
 const SECTIONS = ["featured", "largest", "most-watched"] as const;
@@ -113,12 +92,12 @@ export default async function ExploreSectionPage({
     <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
       <div className="max-w-7xl mx-auto px-6">
         <div className="mb-8">
-          <a
+          <Link
             href={`/${locale}/explore`}
             className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
           >
             {t("backToExplore")}
-          </a>
+          </Link>
           <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
             {t(`sections.${sectionKey(section)}`)}
           </h1>

--- a/src/app/[locale]/explore/featured/page.tsx
+++ b/src/app/[locale]/explore/featured/page.tsx
@@ -1,0 +1,126 @@
+import { prisma } from "@/lib/db";
+import { DatasetCard } from "@/components/ui/dataset-card";
+import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
+import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Locale } from "next-intl";
+import { Link } from "@/i18n/navigation";
+
+export const revalidate = 300;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
+
+  return {
+    title: `${t("sections.featured")} - ${t("metaTitle")}`,
+  };
+}
+
+const DATASET_SELECT = {
+  id: true,
+  cityName: true,
+  dataCount: true,
+  stats: true,
+  areaId: true,
+  templateId: true,
+  createdAt: true,
+  area: {
+    select: {
+      id: true,
+      countryCode: true,
+    },
+  },
+  template: {
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
+      translations: {
+        select: {
+          locale: true,
+          name: true,
+          description: true,
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function FeaturedPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
+
+  const datasets = await prisma.dataset.findMany({
+    where: { isFeatured: true, dataCount: { gt: 0 } },
+    select: {
+      ...DATASET_SELECT,
+      _count: {
+        select: { watchers: true }
+      }
+    },
+    orderBy: { createdAt: "desc" },
+    take: 24,
+  });
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="mb-8">
+          <Link
+            href={`/${locale}/explore`}
+            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
+          >
+            {t("backToExplore")}
+          </Link>
+          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
+            {t("sections.featured")}
+          </h1>
+        </div>
+
+        {datasets.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {datasets.map((dataset) => {
+              const s = processDatasetStats(dataset, locale);
+              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+              const stats = getDatasetStats(dataset, s, t, "featured");
+
+              return (
+                <DatasetCard
+                  key={dataset.id}
+                  name={resolvedTemplate.name}
+                  city={dataset.cityName}
+                  country={dataset.area.countryCode ?? ""}
+                  category={resolvedTemplate.category?.name ?? "other"}
+                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                  stats={stats}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-12 text-neutral-400">
+            {t("noDatasetsFound")}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/explore/featured/page.tsx
+++ b/src/app/[locale]/explore/featured/page.tsx
@@ -1,10 +1,10 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
+import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { processDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
-import { Link } from "@/i18n/navigation";
 
 export const revalidate = 300;
 
@@ -81,50 +81,37 @@ export default async function FeaturedPage({
   });
 
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
-      <div className="max-w-7xl mx-auto px-6">
-        <div className="mb-8">
-          <Link
-            href={`/explore`}
-            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
-          >
-            {t("backToExplore")}
-          </Link>
-          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t("sections.featured")}
-          </h1>
+    <ExplorePageLayout>
+      <ExploreSectionHeader sectionKey="featured" t={t} />
+      {datasets.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {datasets.map((dataset) => {
+            const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+            const s = processDatasetStats(dataset, locale);
+            const stats = [
+              { type: "features" as const, label: t("stats.features"), value: s.features },
+              { type: "contributors" as const, label: t("stats.contributors"), value: s.contributors },
+              { type: "lastEdited" as const, label: t("stats.lastEdited"), value: s.lastEdited },
+            ];
+
+            return (
+              <DatasetCard
+                key={dataset.id}
+                name={resolvedTemplate.name}
+                city={dataset.cityName}
+                country={dataset.area.countryCode ?? ""}
+                category={resolvedTemplate.category?.name ?? "other"}
+                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                stats={stats}
+              />
+            );
+          })}
         </div>
-
-        {datasets.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {datasets.map((dataset) => {
-              const s = processDatasetStats(dataset, locale);
-              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const stats = [
-                { type: "features" as const, label: t("stats.features"), value: s.features },
-                { type: "contributors" as const, label: t("stats.contributors"), value: s.contributors },
-                { type: "lastEdited" as const, label: t("stats.lastEdited"), value: s.lastEdited },
-              ];
-
-              return (
-                <DatasetCard
-                  key={dataset.id}
-                  name={resolvedTemplate.name}
-                  city={dataset.cityName}
-                  country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category?.name ?? "other"}
-                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-                  stats={stats}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="text-center py-12 text-neutral-400">
-            {t("noDatasetsFound")}
-          </div>
-        )}
-      </div>
-    </div>
+      ) : (
+        <div className="text-center py-12 text-neutral-400">
+          {t("noDatasetsFound")}
+        </div>
+      )}
+    </ExplorePageLayout>
   );
 }

--- a/src/app/[locale]/explore/featured/page.tsx
+++ b/src/app/[locale]/explore/featured/page.tsx
@@ -1,6 +1,6 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
-import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
+import { processDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
@@ -100,7 +100,11 @@ export default async function FeaturedPage({
             {datasets.map((dataset) => {
               const s = processDatasetStats(dataset, locale);
               const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const stats = getDatasetStats(dataset, s, t, "featured");
+              const stats = [
+                { type: "features" as const, label: t("stats.features"), value: s.features },
+                { type: "contributors" as const, label: t("stats.contributors"), value: s.contributors },
+                { type: "lastEdited" as const, label: t("stats.lastEdited"), value: s.lastEdited },
+              ];
 
               return (
                 <DatasetCard

--- a/src/app/[locale]/explore/featured/page.tsx
+++ b/src/app/[locale]/explore/featured/page.tsx
@@ -85,7 +85,7 @@ export default async function FeaturedPage({
       <div className="max-w-7xl mx-auto px-6">
         <div className="mb-8">
           <Link
-            href={`/${locale}/explore`}
+            href={`/explore`}
             className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
           >
             {t("backToExplore")}

--- a/src/app/[locale]/explore/largest/page.tsx
+++ b/src/app/[locale]/explore/largest/page.tsx
@@ -1,9 +1,9 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
+import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
-import { Link } from "@/i18n/navigation";
 
 export const revalidate = 300;
 
@@ -80,47 +80,34 @@ export default async function LargestPage({
   });
 
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
-      <div className="max-w-7xl mx-auto px-6">
-        <div className="mb-8">
-          <Link
-            href={`/explore`}
-            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
-          >
-            {t("backToExplore")}
-          </Link>
-          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t("sections.largest")}
-          </h1>
+    <ExplorePageLayout>
+      <ExploreSectionHeader sectionKey="largest" t={t} />
+      {datasets.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {datasets.map((dataset) => {
+            const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+            const stats = [
+              { type: "features" as const, label: t("stats.features"), value: dataset.dataCount },
+            ];
+
+            return (
+              <DatasetCard
+                key={dataset.id}
+                name={resolvedTemplate.name}
+                city={dataset.cityName}
+                country={dataset.area.countryCode ?? ""}
+                category={resolvedTemplate.category?.name ?? "other"}
+                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                stats={stats}
+              />
+            );
+          })}
         </div>
-
-        {datasets.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {datasets.map((dataset) => {
-              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const stats = [
-                { type: "features" as const, label: t("stats.features"), value: dataset.dataCount },
-              ];
-
-              return (
-                <DatasetCard
-                  key={dataset.id}
-                  name={resolvedTemplate.name}
-                  city={dataset.cityName}
-                  country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category?.name ?? "other"}
-                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-                  stats={stats}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="text-center py-12 text-neutral-400">
-            {t("noDatasetsFound")}
-          </div>
-        )}
-      </div>
-    </div>
+      ) : (
+        <div className="text-center py-12 text-neutral-400">
+          {t("noDatasetsFound")}
+        </div>
+      )}
+    </ExplorePageLayout>
   );
 }

--- a/src/app/[locale]/explore/largest/page.tsx
+++ b/src/app/[locale]/explore/largest/page.tsx
@@ -84,7 +84,7 @@ export default async function LargestPage({
       <div className="max-w-7xl mx-auto px-6">
         <div className="mb-8">
           <Link
-            href={`/${locale}/explore`}
+            href={`/explore`}
             className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
           >
             {t("backToExplore")}

--- a/src/app/[locale]/explore/largest/page.tsx
+++ b/src/app/[locale]/explore/largest/page.tsx
@@ -1,0 +1,126 @@
+import { prisma } from "@/lib/db";
+import { DatasetCard } from "@/components/ui/dataset-card";
+import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
+import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Locale } from "next-intl";
+import { Link } from "@/i18n/navigation";
+
+export const revalidate = 300;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
+
+  return {
+    title: `${t("sections.largest")} - ${t("metaTitle")}`,
+  };
+}
+
+const DATASET_SELECT = {
+  id: true,
+  cityName: true,
+  dataCount: true,
+  stats: true,
+  areaId: true,
+  templateId: true,
+  createdAt: true,
+  area: {
+    select: {
+      id: true,
+      countryCode: true,
+    },
+  },
+  template: {
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
+      translations: {
+        select: {
+          locale: true,
+          name: true,
+          description: true,
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function LargestPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("ExplorePage");
+
+  const datasets = await prisma.dataset.findMany({
+    where: { isActive: true, dataCount: { gt: 0 } },
+    select: {
+      ...DATASET_SELECT,
+      _count: {
+        select: { watchers: true }
+      }
+    },
+    orderBy: { dataCount: "desc" },
+    take: 24,
+  });
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="mb-8">
+          <Link
+            href={`/${locale}/explore`}
+            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
+          >
+            {t("backToExplore")}
+          </Link>
+          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
+            {t("sections.largest")}
+          </h1>
+        </div>
+
+        {datasets.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {datasets.map((dataset) => {
+              const s = processDatasetStats(dataset, locale);
+              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+              const stats = getDatasetStats(dataset, s, t, "largest");
+
+              return (
+                <DatasetCard
+                  key={dataset.id}
+                  name={resolvedTemplate.name}
+                  city={dataset.cityName}
+                  country={dataset.area.countryCode ?? ""}
+                  category={resolvedTemplate.category?.name ?? "other"}
+                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                  stats={stats}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-12 text-neutral-400">
+            {t("noDatasetsFound")}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/explore/most-contributors/page.tsx
+++ b/src/app/[locale]/explore/most-contributors/page.tsx
@@ -1,9 +1,9 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
+import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
-import { Link } from "@/i18n/navigation";
 
 export const revalidate = 300;
 
@@ -81,47 +81,34 @@ export default async function MostContributorsPage({
   });
 
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
-      <div className="max-w-7xl mx-auto px-6">
-        <div className="mb-8">
-          <Link
-            href={`/explore`}
-            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
-          >
-            {t("backToExplore")}
-          </Link>
-          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t("sections.mostContributors")}
-          </h1>
+    <ExplorePageLayout>
+      <ExploreSectionHeader sectionKey="mostContributors" t={t} />
+      {datasets.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {datasets.map((dataset) => {
+            const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+            const stats = [
+              { type: "contributors" as const, label: t("stats.contributors"), value: dataset.contributorsCount || 0 },
+            ];
+
+            return (
+              <DatasetCard
+                key={dataset.id}
+                name={resolvedTemplate.name}
+                city={dataset.cityName}
+                country={dataset.area.countryCode ?? ""}
+                category={resolvedTemplate.category?.name ?? "other"}
+                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                stats={stats}
+              />
+            );
+          })}
         </div>
-
-        {datasets.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {datasets.map((dataset) => {
-              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const stats = [
-                { type: "contributors" as const, label: t("stats.contributors"), value: dataset.contributorsCount || 0 },
-              ];
-
-              return (
-                <DatasetCard
-                  key={dataset.id}
-                  name={resolvedTemplate.name}
-                  city={dataset.cityName}
-                  country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category?.name ?? "other"}
-                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-                  stats={stats}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="text-center py-12 text-neutral-400">
-            {t("noDatasetsFound")}
-          </div>
-        )}
-      </div>
-    </div>
+      ) : (
+        <div className="text-center py-12 text-neutral-400">
+          {t("noDatasetsFound")}
+        </div>
+      )}
+    </ExplorePageLayout>
   );
 }

--- a/src/app/[locale]/explore/most-contributors/page.tsx
+++ b/src/app/[locale]/explore/most-contributors/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({
   const t = await getTranslations("ExplorePage");
 
   return {
-    title: `${t("sections.largest")} - ${t("metaTitle")}`,
+    title: `${t("sections.mostContributors")} - ${t("metaTitle")}`,
   };
 }
 
@@ -58,7 +58,7 @@ const DATASET_SELECT = {
   },
 } as const;
 
-export default async function LargestPage({
+export default async function MostContributorsPage({
   params,
 }: {
   params: Promise<{ locale: Locale }>;
@@ -68,14 +68,15 @@ export default async function LargestPage({
   const t = await getTranslations("ExplorePage");
 
   const datasets = await prisma.dataset.findMany({
-    where: { isActive: true, dataCount: { gt: 0 } },
+    where: { isActive: true, dataCount: { gt: 0 }, contributorsCount: { not: null } },
     select: {
       ...DATASET_SELECT,
+      contributorsCount: true,
       _count: {
         select: { watchers: true }
       }
     },
-    orderBy: { dataCount: "desc" },
+    orderBy: { contributorsCount: "desc" },
     take: 24,
   });
 
@@ -90,7 +91,7 @@ export default async function LargestPage({
             {t("backToExplore")}
           </Link>
           <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t("sections.largest")}
+            {t("sections.mostContributors")}
           </h1>
         </div>
 
@@ -99,7 +100,7 @@ export default async function LargestPage({
             {datasets.map((dataset) => {
               const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
               const stats = [
-                { type: "features" as const, label: t("stats.features"), value: dataset.dataCount },
+                { type: "contributors" as const, label: t("stats.contributors"), value: dataset.contributorsCount || 0 },
               ];
 
               return (

--- a/src/app/[locale]/explore/most-contributors/page.tsx
+++ b/src/app/[locale]/explore/most-contributors/page.tsx
@@ -85,7 +85,7 @@ export default async function MostContributorsPage({
       <div className="max-w-7xl mx-auto px-6">
         <div className="mb-8">
           <Link
-            href={`/${locale}/explore`}
+            href={`/explore`}
             className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
           >
             {t("backToExplore")}

--- a/src/app/[locale]/explore/most-watched/page.tsx
+++ b/src/app/[locale]/explore/most-watched/page.tsx
@@ -4,32 +4,21 @@ import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
-import { notFound } from "next/navigation";
 import { Link } from "@/i18n/navigation";
 
 export const revalidate = 300;
 
-export function generateStaticParams() {
-  return SECTIONS.map((section) => ({ section }));
-}
-
-const SECTIONS = ["featured", "largest", "most-watched"] as const;
-type Section = (typeof SECTIONS)[number];
-
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ locale: Locale; section: string }>;
+  params: Promise<{ locale: Locale }>;
 }) {
-  const { locale, section } = await params;
+  const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations("ExplorePage");
 
-  const sectionKey = section === "largest" ? "largest" : section === "most-watched" ? "mostWatched" : "featured";
-  const title = t.raw(`sections.${sectionKey}`);
-
   return {
-    title: `${title} - ${t("metaTitle")}`,
+    title: `${t("sections.mostWatched")} - ${t("metaTitle")}`,
   };
 }
 
@@ -70,23 +59,26 @@ const DATASET_SELECT = {
   },
 } as const;
 
-export default async function ExploreSectionPage({
+export default async function MostWatchedPage({
   params,
 }: {
-  params: Promise<{ locale: Locale; section: string }>;
+  params: Promise<{ locale: Locale }>;
 }) {
-  const { locale, section: sectionParam } = await params;
-
-  if (!SECTIONS.includes(sectionParam as Section)) {
-    notFound();
-  }
-
-  const section = sectionParam as Section;
-
+  const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations("ExplorePage");
 
-  const datasets = await getDatasets(section as Section);
+  const datasets = await prisma.dataset.findMany({
+    where: { isActive: true, dataCount: { gt: 0 } },
+    select: {
+      ...DATASET_SELECT,
+      _count: {
+        select: { watchers: true }
+      }
+    },
+    orderBy: { watchers: { _count: 'desc' } },
+    take: 24,
+  });
 
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
@@ -99,7 +91,7 @@ export default async function ExploreSectionPage({
             {t("backToExplore")}
           </Link>
           <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t(`sections.${sectionKey(section)}`)}
+            {t("sections.mostWatched")}
           </h1>
         </div>
 
@@ -108,7 +100,7 @@ export default async function ExploreSectionPage({
             {datasets.map((dataset) => {
               const s = processDatasetStats(dataset, locale);
               const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const stats = getDatasetStats(dataset, s, t, section);
+              const stats = getDatasetStats(dataset, s, t, "most-watched");
 
               return (
                 <DatasetCard
@@ -131,48 +123,4 @@ export default async function ExploreSectionPage({
       </div>
     </div>
   );
-}
-
-function sectionKey(section: Section): "featured" | "largest" | "mostWatched" {
-  switch (section) {
-    case "largest":
-      return "largest";
-    case "most-watched":
-      return "mostWatched";
-    default:
-      return "featured";
-  }
-}
-
-async function getDatasets(section: Section) {
-  const selectWithWatchers = {
-    ...DATASET_SELECT,
-    _count: {
-      select: { watchers: true }
-    }
-  };
-
-  switch (section) {
-    case "featured":
-      return prisma.dataset.findMany({
-        where: { isFeatured: true, dataCount: { gt: 0 } },
-        select: selectWithWatchers,
-        orderBy: { createdAt: "desc" },
-        take: 24,
-      });
-    case "largest":
-      return prisma.dataset.findMany({
-        where: { isActive: true, dataCount: { gt: 0 } },
-        select: selectWithWatchers,
-        orderBy: { dataCount: "desc" },
-        take: 24,
-      });
-    case "most-watched":
-      return prisma.dataset.findMany({
-        where: { isActive: true, dataCount: { gt: 0 } },
-        select: selectWithWatchers,
-        orderBy: { watchers: { _count: 'desc' } },
-        take: 24,
-      });
-  }
 }

--- a/src/app/[locale]/explore/most-watched/page.tsx
+++ b/src/app/[locale]/explore/most-watched/page.tsx
@@ -84,7 +84,7 @@ export default async function MostWatchedPage({
       <div className="max-w-7xl mx-auto px-6">
         <div className="mb-8">
           <Link
-            href={`/${locale}/explore`}
+            href={`/explore`}
             className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
           >
             {t("backToExplore")}

--- a/src/app/[locale]/explore/most-watched/page.tsx
+++ b/src/app/[locale]/explore/most-watched/page.tsx
@@ -1,6 +1,5 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
-import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
@@ -98,9 +97,10 @@ export default async function MostWatchedPage({
         {datasets.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {datasets.map((dataset) => {
-              const s = processDatasetStats(dataset, locale);
               const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const stats = getDatasetStats(dataset, s, t, "most-watched");
+              const stats = [
+                { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
+              ];
 
               return (
                 <DatasetCard

--- a/src/app/[locale]/explore/most-watched/page.tsx
+++ b/src/app/[locale]/explore/most-watched/page.tsx
@@ -1,9 +1,9 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
+import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
-import { Link } from "@/i18n/navigation";
 
 export const revalidate = 300;
 
@@ -80,47 +80,34 @@ export default async function MostWatchedPage({
   });
 
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
-      <div className="max-w-7xl mx-auto px-6">
-        <div className="mb-8">
-          <Link
-            href={`/explore`}
-            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
-          >
-            {t("backToExplore")}
-          </Link>
-          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t("sections.mostWatched")}
-          </h1>
+    <ExplorePageLayout>
+      <ExploreSectionHeader sectionKey="mostWatched" t={t} />
+      {datasets.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {datasets.map((dataset) => {
+            const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+            const stats = [
+              { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
+            ];
+
+            return (
+              <DatasetCard
+                key={dataset.id}
+                name={resolvedTemplate.name}
+                city={dataset.cityName}
+                country={dataset.area.countryCode ?? ""}
+                category={resolvedTemplate.category?.name ?? "other"}
+                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                stats={stats}
+              />
+            );
+          })}
         </div>
-
-        {datasets.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {datasets.map((dataset) => {
-              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const stats = [
-                { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
-              ];
-
-              return (
-                <DatasetCard
-                  key={dataset.id}
-                  name={resolvedTemplate.name}
-                  city={dataset.cityName}
-                  country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category?.name ?? "other"}
-                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-                  stats={stats}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="text-center py-12 text-neutral-400">
-            {t("noDatasetsFound")}
-          </div>
-        )}
-      </div>
-    </div>
+      ) : (
+        <div className="text-center py-12 text-neutral-400">
+          {t("noDatasetsFound")}
+        </div>
+      )}
+    </ExplorePageLayout>
   );
 }

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,15 +1,37 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { processDatasetStats } from "@/lib/dataset-stats";
-import { getAreaDetailsById } from "@/lib/nominatim";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
-import { createLogger } from "@/lib/logger";
-
-const logger = createLogger("explore-page");
 
 export const revalidate = 3600;
+
+// Helper: Get stats for dataset based on section type
+function getDatasetStats(
+  dataset: { _count: { watchers: number } },
+  processedStats: { features: string | number; contributors: string | number; lastEdited: string | number },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: any,
+  statType: "default" | "largest" | "most-watched"
+) {
+  switch (statType) {
+    case "largest":
+      return [
+        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
+      ];
+    case "most-watched":
+      return [
+        { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
+      ];
+    default:
+      return [
+        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
+        { type: "contributors" as const, label: t("stats.contributors"), value: processedStats.contributors },
+        { type: "lastEdited" as const, label: t("stats.lastEdited"), value: processedStats.lastEdited },
+      ];
+  }
+}
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -21,88 +43,83 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: L
   };
 }
 
+const DATASET_SELECT = {
+  id: true,
+  cityName: true,
+  dataCount: true,
+  stats: true,
+  areaId: true,
+  templateId: true,
+  createdAt: true,
+  area: {
+    select: {
+      id: true,
+      countryCode: true,
+    },
+  },
+  template: {
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
+      translations: {
+        select: {
+          locale: true,
+          name: true,
+          description: true,
+        },
+      },
+    },
+  },
+} as const;
+
 export default async function FeaturedDatasetsPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations("ExplorePage");
-  const datasets = await prisma.dataset.findMany({
-    where: { isFeatured: true },
-    select: {
-      id: true,
-      cityName: true,
-      dataCount: true,
-      stats: true,
-      areaId: true,
-      templateId: true,
-      area: {
-        select: {
-          id: true,
-          countryCode: true,
-        },
-      },
-      template: {
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          category: {
-            select: {
-              id: true,
-              name: true,
-              slug: true,
-            },
-          },
-          translations: {
-            select: {
-              locale: true,
-              name: true,
-              description: true,
-            },
-          },
-        },
-      },
-    },
-    orderBy: { createdAt: "desc" },
-  });
 
-  // Backfill missing country codes from Nominatim (lazy, fires once per unique area)
-  const seen = new Set<number>();
-  const missing = datasets.filter((d) => {
-    if (d.area.countryCode || seen.has(d.area.id)) return false;
-    seen.add(d.area.id);
-    return true;
-  });
-  if (missing.length > 0) {
-    const results = await Promise.allSettled(
-      missing.map(async (d) => {
-        const details = await getAreaDetailsById(d.area.id);
-        if (details?.countryCode) {
-          await prisma.area.update({
-            where: { id: d.area.id },
-            data: { countryCode: details.countryCode },
-          });
-          return { areaId: d.area.id, countryCode: details.countryCode };
+  const [featured, largest, mostWatched] = await Promise.all([
+    prisma.dataset.findMany({
+      where: { isFeatured: true, dataCount: { gt: 0 } },
+      select: {
+        ...DATASET_SELECT,
+        _count: {
+          select: { watchers: true }
         }
-        return null;
-      })
-    );
-
-    // Propagate backfilled codes to all datasets sharing the same area
-    const backfilledByArea = new Map<number, string>();
-    for (const result of results) {
-      if (result.status === "fulfilled" && result.value) {
-        backfilledByArea.set(result.value.areaId, result.value.countryCode);
-      } else if (result.status === "rejected") {
-        logger.error("Failed to backfill area country code", { reason: result.reason });
-      }
-    }
-    for (const dataset of datasets) {
-      const code = backfilledByArea.get(dataset.area.id);
-      if (code) {
-        dataset.area.countryCode = code;
-      }
-    }
-  }
+      },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    }).then(datasets => datasets.sort(() => Math.random() - 0.5).slice(0, 6)),
+    prisma.dataset.findMany({
+      where: { isActive: true, dataCount: { gt: 0 } },
+      select: {
+        ...DATASET_SELECT,
+        _count: {
+          select: { watchers: true }
+        }
+      },
+      orderBy: { dataCount: "desc" },
+      take: 6,
+    }),
+    prisma.dataset.findMany({
+      where: { isActive: true, dataCount: { gt: 0 } },
+      select: {
+        ...DATASET_SELECT,
+        _count: {
+          select: { watchers: true }
+        }
+      },
+      orderBy: { watchers: { _count: 'desc' } },
+      take: 6,
+    }),
+  ]);
 
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
@@ -116,32 +133,144 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
           </p>
         </div>
 
-        {datasets.length === 0 ? (
-          <p className="text-sm text-neutral-400">{t("noDatasets")}</p>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {datasets.map((dataset) => {
-              const s = processDatasetStats(dataset, locale);
-              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              return (
-                <DatasetCard
-                  key={dataset.id}
-                  name={resolvedTemplate.name}
-                  city={dataset.cityName}
-                  country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category?.name ?? "other"}
-                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-                  stats={[
-                    { type: "features",     label: t("stats.features"),     value: s.features },
-                    { type: "contributors", label: t("stats.contributors"), value: s.contributors },
-                    { type: "lastEdited",   label: t("stats.lastEdited"),   value: s.lastEdited },
-                  ]}
-                />
-              );
-            })}
-          </div>
+        {/* Featured Section */}
+        {featured.length > 0 && (
+          <Section
+            title={t("sections.featured")}
+            seeAllHref={`/${locale}/explore/featured`}
+            t={t}
+          >
+            <DatasetGrid
+              datasets={featured}
+              locale={locale}
+              t={t}
+              statType="default"
+            />
+          </Section>
+        )}
+
+        {/* Largest Section */}
+        {largest.length > 0 && (
+          <Section
+            title={t("sections.largest")}
+            seeAllHref={`/${locale}/explore/largest`}
+            t={t}
+          >
+            <DatasetGrid
+              datasets={largest}
+              locale={locale}
+              t={t}
+              statType="largest"
+            />
+          </Section>
+        )}
+
+        {/* Most Watched Section */}
+        {mostWatched.length > 0 && (
+          <Section
+            title={t("sections.mostWatched")}
+            seeAllHref={`/${locale}/explore/most-watched`}
+            t={t}
+          >
+            <DatasetGrid
+              datasets={mostWatched}
+              locale={locale}
+              t={t}
+              statType="most-watched"
+            />
+          </Section>
         )}
       </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  seeAllHref,
+  children,
+  t,
+}: {
+  title: string;
+  seeAllHref: string | null;
+  children: React.ReactNode;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: any;
+}) {
+  return (
+    <section className="mb-10">
+      <div className="flex items-baseline justify-between mb-4">
+        <h2 className="text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+          {title}
+        </h2>
+        {seeAllHref && (
+          <a
+            href={seeAllHref}
+            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
+          >
+            {t("seeAll")}
+          </a>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function DatasetGrid({
+  datasets,
+  locale,
+  t,
+  statType,
+}: {
+  datasets: Array<{
+    id: string;
+    cityName: string;
+    dataCount: number;
+    stats: import("@prisma/client").Prisma.JsonValue;
+    areaId: number;
+    templateId: string;
+    createdAt: Date;
+    area: { id: number; countryCode: string | null };
+    template: {
+      id: string;
+      name: string;
+      description: string | null;
+      category: { id: string; name: string; slug: string } | null;
+      translations: Array<{
+        locale: string;
+        name: string;
+        description: string | null;
+      }>;
+    };
+    _count: {
+      watchers: number;
+    };
+  }>;
+  locale: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: any;
+  statType: "default" | "largest" | "most-watched";
+}) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {datasets.map((dataset) => {
+        const s = processDatasetStats(dataset, locale);
+        const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+        const stats = getDatasetStats(dataset, s, t, statType);
+
+        return (
+          <DatasetCard
+            key={dataset.id}
+            name={resolvedTemplate.name}
+            city={dataset.cityName}
+            country={dataset.area.countryCode ?? ""}
+            category={resolvedTemplate.category?.name ?? "other"}
+            href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+            stats={stats}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -6,6 +6,21 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { Link } from "@/i18n/navigation";
 
+function formatRelativeTime(timestamp: Date | null | undefined, locale: string): string {
+  if (!timestamp) return "—";
+
+  const diffMs = timestamp.getTime() - Date.now();
+  const absSec = Math.abs(diffMs / 1000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  if (absSec < 60) return rtf.format(Math.round(diffMs / 1000), "second");
+  if (absSec < 3600) return rtf.format(Math.round(diffMs / 60000), "minute");
+  if (absSec < 86400) return rtf.format(Math.round(diffMs / 3600000), "hour");
+  if (absSec < 2592000) return rtf.format(Math.round(diffMs / 86400000), "day");
+  if (absSec < 31536000) return rtf.format(Math.round(diffMs / 2592000000), "month");
+  return rtf.format(Math.round(diffMs / 31536000000), "year");
+}
+
 export const revalidate = 3600;
 
 // Fisher-Yates shuffle for unbiased random permutation
@@ -121,6 +136,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       select: {
         ...DATASET_SELECT,
         recentlyEditedCount: true,
+        lastEditedAt: true,
         _count: {
           select: { watchers: true }
         }
@@ -275,8 +291,9 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {recentlyEdited.map((dataset) => {
                 const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+                const lastEdited = formatRelativeTime(dataset.lastEditedAt, locale);
                 const stats = [
-                  { type: "features" as const, label: "Recently edited", value: dataset.recentlyEditedCount || 0 },
+                  { type: "lastEdited" as const, label: t("stats.lastEdited"), value: lastEdited },
                 ];
 
                 return (

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -85,7 +85,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
   setRequestLocale(locale);
   const t = await getTranslations("ExplorePage");
 
-  const [featured, largest, mostWatched, mostContributors, recentlyEdited] = await Promise.all([
+  const [featured, recentlyEdited, mostWatched, mostContributors, largest] = await Promise.all([
     prisma.dataset.findMany({
       where: { isFeatured: true, dataCount: { gt: 0 } },
       select: {
@@ -98,14 +98,16 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       take: 20,
     }).then(datasets => shuffleArray(datasets).slice(0, 6)),
     prisma.dataset.findMany({
-      where: { isActive: true, dataCount: { gt: 0 } },
+      where: { isActive: true, dataCount: { gt: 0 }, recentlyEditedCount: { not: null } },
       select: {
         ...DATASET_SELECT,
+        recentlyEditedCount: true,
+        lastEditedAt: true,
         _count: {
           select: { watchers: true }
         }
       },
-      orderBy: { dataCount: "desc" },
+      orderBy: { lastEditedAt: "desc" },
       take: 6,
     }),
     prisma.dataset.findMany({
@@ -132,16 +134,14 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       take: 6,
     }),
     prisma.dataset.findMany({
-      where: { isActive: true, dataCount: { gt: 0 }, recentlyEditedCount: { not: null } },
+      where: { isActive: true, dataCount: { gt: 0 } },
       select: {
         ...DATASET_SELECT,
-        recentlyEditedCount: true,
-        lastEditedAt: true,
         _count: {
           select: { watchers: true }
         }
       },
-      orderBy: { lastEditedAt: "desc" },
+      orderBy: { dataCount: "desc" },
       take: 6,
     }),
   ]);
@@ -191,18 +191,19 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
           </Section>
         )}
 
-        {/* Largest Section */}
-        {largest.length > 0 && (
+        {/* Recently Edited Section */}
+        {recentlyEdited.length > 0 && (
           <Section
-            title={t("sections.largest")}
-            seeAllHref={`/${locale}/explore/largest`}
+            title={t("sections.recentlyEdited")}
+            seeAllHref={`/${locale}/explore/recently-edited`}
             t={t}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {largest.map((dataset) => {
+              {recentlyEdited.map((dataset) => {
                 const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+                const lastEdited = formatRelativeTime(dataset.lastEditedAt, locale);
                 const stats = [
-                  { type: "features" as const, label: t("stats.features"), value: dataset.dataCount },
+                  { type: "lastEdited" as const, label: t("stats.lastEdited"), value: lastEdited },
                 ];
 
                 return (
@@ -281,19 +282,18 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
           </Section>
         )}
 
-        {/* Recently Edited Section */}
-        {recentlyEdited.length > 0 && (
+        {/* Largest Section */}
+        {largest.length > 0 && (
           <Section
-            title={t("sections.recentlyEdited")}
-            seeAllHref={`/${locale}/explore/recently-edited`}
+            title={t("sections.largest")}
+            seeAllHref={`/${locale}/explore/largest`}
             t={t}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {recentlyEdited.map((dataset) => {
+              {largest.map((dataset) => {
                 const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-                const lastEdited = formatRelativeTime(dataset.lastEditedAt, locale);
                 const stats = [
-                  { type: "lastEdited" as const, label: t("stats.lastEdited"), value: lastEdited },
+                  { type: "features" as const, label: t("stats.features"), value: dataset.dataCount },
                 ];
 
                 return (

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,36 +1,21 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
-import { processDatasetStats } from "@/lib/dataset-stats";
+import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
+import { Link } from "@/i18n/navigation";
 
 export const revalidate = 3600;
 
-// Helper: Get stats for dataset based on section type
-function getDatasetStats(
-  dataset: { _count: { watchers: number } },
-  processedStats: { features: string | number; contributors: string | number; lastEdited: string | number },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  t: any,
-  statType: "default" | "largest" | "most-watched"
-) {
-  switch (statType) {
-    case "largest":
-      return [
-        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
-      ];
-    case "most-watched":
-      return [
-        { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
-      ];
-    default:
-      return [
-        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
-        { type: "contributors" as const, label: t("stats.contributors"), value: processedStats.contributors },
-        { type: "lastEdited" as const, label: t("stats.lastEdited"), value: processedStats.lastEdited },
-      ];
+// Fisher-Yates shuffle for unbiased random permutation
+function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
+  return shuffled;
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
@@ -96,7 +81,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       },
       orderBy: { createdAt: "desc" },
       take: 20,
-    }).then(datasets => datasets.sort(() => Math.random() - 0.5).slice(0, 6)),
+    }).then(datasets => shuffleArray(datasets).slice(0, 6)),
     prisma.dataset.findMany({
       where: { isActive: true, dataCount: { gt: 0 } },
       select: {
@@ -204,12 +189,12 @@ function Section({
           {title}
         </h2>
         {seeAllHref && (
-          <a
+          <Link
             href={seeAllHref}
             className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
           >
             {t("seeAll")}
-          </a>
+          </Link>
         )}
       </div>
       {children}

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,25 +1,10 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
-import { processDatasetStats } from "@/lib/dataset-stats";
+import { processDatasetStats, formatRelativeTime } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { Link } from "@/i18n/navigation";
-
-function formatRelativeTime(timestamp: Date | null | undefined, locale: string): string {
-  if (!timestamp) return "—";
-
-  const diffMs = timestamp.getTime() - Date.now();
-  const absSec = Math.abs(diffMs / 1000);
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
-
-  if (absSec < 60) return rtf.format(Math.round(diffMs / 1000), "second");
-  if (absSec < 3600) return rtf.format(Math.round(diffMs / 60000), "minute");
-  if (absSec < 86400) return rtf.format(Math.round(diffMs / 3600000), "hour");
-  if (absSec < 2592000) return rtf.format(Math.round(diffMs / 86400000), "day");
-  if (absSec < 31536000) return rtf.format(Math.round(diffMs / 2592000000), "month");
-  return rtf.format(Math.round(diffMs / 31536000000), "year");
-}
 
 export const revalidate = 3600;
 

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -162,7 +162,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
         {featured.length > 0 && (
           <Section
             title={t("sections.featured")}
-            seeAllHref={`/${locale}/explore/featured`}
+            seeAllHref={`/explore/featured`}
             t={t}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -195,7 +195,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
         {recentlyEdited.length > 0 && (
           <Section
             title={t("sections.recentlyEdited")}
-            seeAllHref={`/${locale}/explore/recently-edited`}
+            seeAllHref={`/explore/recently-edited`}
             t={t}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -226,7 +226,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
         {mostWatched.length > 0 && (
           <Section
             title={t("sections.mostWatched")}
-            seeAllHref={`/${locale}/explore/most-watched`}
+            seeAllHref={`/explore/most-watched`}
             t={t}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -256,7 +256,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
         {mostContributors.length > 0 && (
           <Section
             title={t("sections.mostContributors")}
-            seeAllHref={`/${locale}/explore/most-contributors`}
+            seeAllHref={`/explore/most-contributors`}
             t={t}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -286,7 +286,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
         {largest.length > 0 && (
           <Section
             title={t("sections.largest")}
-            seeAllHref={`/${locale}/explore/largest`}
+            seeAllHref={`/explore/largest`}
             t={t}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,6 +1,6 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
-import { processDatasetStats, getDatasetStats } from "@/lib/dataset-stats";
+import { processDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
@@ -70,7 +70,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
   setRequestLocale(locale);
   const t = await getTranslations("ExplorePage");
 
-  const [featured, largest, mostWatched] = await Promise.all([
+  const [featured, largest, mostWatched, mostContributors, recentlyEdited] = await Promise.all([
     prisma.dataset.findMany({
       where: { isFeatured: true, dataCount: { gt: 0 } },
       select: {
@@ -104,6 +104,30 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       orderBy: { watchers: { _count: 'desc' } },
       take: 6,
     }),
+    prisma.dataset.findMany({
+      where: { isActive: true, dataCount: { gt: 0 }, contributorsCount: { not: null } },
+      select: {
+        ...DATASET_SELECT,
+        contributorsCount: true,
+        _count: {
+          select: { watchers: true }
+        }
+      },
+      orderBy: { contributorsCount: "desc" },
+      take: 6,
+    }),
+    prisma.dataset.findMany({
+      where: { isActive: true, dataCount: { gt: 0 }, recentlyEditedCount: { not: null } },
+      select: {
+        ...DATASET_SELECT,
+        recentlyEditedCount: true,
+        _count: {
+          select: { watchers: true }
+        }
+      },
+      orderBy: { lastEditedAt: "desc" },
+      take: 6,
+    }),
   ]);
 
   return (
@@ -125,12 +149,29 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
             seeAllHref={`/${locale}/explore/featured`}
             t={t}
           >
-            <DatasetGrid
-              datasets={featured}
-              locale={locale}
-              t={t}
-              statType="default"
-            />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {featured.map((dataset) => {
+                const s = processDatasetStats(dataset, locale);
+                const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+                const stats = [
+                  { type: "features" as const, label: t("stats.features"), value: s.features },
+                  { type: "contributors" as const, label: t("stats.contributors"), value: s.contributors },
+                  { type: "lastEdited" as const, label: t("stats.lastEdited"), value: s.lastEdited },
+                ];
+
+                return (
+                  <DatasetCard
+                    key={dataset.id}
+                    name={resolvedTemplate.name}
+                    city={dataset.cityName}
+                    country={dataset.area.countryCode ?? ""}
+                    category={resolvedTemplate.category?.name ?? "other"}
+                    href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                    stats={stats}
+                  />
+                );
+              })}
+            </div>
           </Section>
         )}
 
@@ -141,12 +182,26 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
             seeAllHref={`/${locale}/explore/largest`}
             t={t}
           >
-            <DatasetGrid
-              datasets={largest}
-              locale={locale}
-              t={t}
-              statType="largest"
-            />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {largest.map((dataset) => {
+                const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+                const stats = [
+                  { type: "features" as const, label: t("stats.features"), value: dataset.dataCount },
+                ];
+
+                return (
+                  <DatasetCard
+                    key={dataset.id}
+                    name={resolvedTemplate.name}
+                    city={dataset.cityName}
+                    country={dataset.area.countryCode ?? ""}
+                    category={resolvedTemplate.category?.name ?? "other"}
+                    href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                    stats={stats}
+                  />
+                );
+              })}
+            </div>
           </Section>
         )}
 
@@ -157,12 +212,86 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
             seeAllHref={`/${locale}/explore/most-watched`}
             t={t}
           >
-            <DatasetGrid
-              datasets={mostWatched}
-              locale={locale}
-              t={t}
-              statType="most-watched"
-            />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {mostWatched.map((dataset) => {
+                const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+                const stats = [
+                  { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
+                ];
+
+                return (
+                  <DatasetCard
+                    key={dataset.id}
+                    name={resolvedTemplate.name}
+                    city={dataset.cityName}
+                    country={dataset.area.countryCode ?? ""}
+                    category={resolvedTemplate.category?.name ?? "other"}
+                    href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                    stats={stats}
+                  />
+                );
+              })}
+            </div>
+          </Section>
+        )}
+
+        {/* Most Contributors Section */}
+        {mostContributors.length > 0 && (
+          <Section
+            title={t("sections.mostContributors")}
+            seeAllHref={`/${locale}/explore/most-contributors`}
+            t={t}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {mostContributors.map((dataset) => {
+                const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+                const stats = [
+                  { type: "contributors" as const, label: t("stats.contributors"), value: dataset.contributorsCount || 0 },
+                ];
+
+                return (
+                  <DatasetCard
+                    key={dataset.id}
+                    name={resolvedTemplate.name}
+                    city={dataset.cityName}
+                    country={dataset.area.countryCode ?? ""}
+                    category={resolvedTemplate.category?.name ?? "other"}
+                    href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                    stats={stats}
+                  />
+                );
+              })}
+            </div>
+          </Section>
+        )}
+
+        {/* Recently Edited Section */}
+        {recentlyEdited.length > 0 && (
+          <Section
+            title={t("sections.recentlyEdited")}
+            seeAllHref={`/${locale}/explore/recently-edited`}
+            t={t}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {recentlyEdited.map((dataset) => {
+                const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+                const stats = [
+                  { type: "features" as const, label: "Recently edited", value: dataset.recentlyEditedCount || 0 },
+                ];
+
+                return (
+                  <DatasetCard
+                    key={dataset.id}
+                    name={resolvedTemplate.name}
+                    city={dataset.cityName}
+                    country={dataset.area.countryCode ?? ""}
+                    category={resolvedTemplate.category?.name ?? "other"}
+                    href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                    stats={stats}
+                  />
+                );
+              })}
+            </div>
           </Section>
         )}
       </div>
@@ -199,63 +328,5 @@ function Section({
       </div>
       {children}
     </section>
-  );
-}
-
-function DatasetGrid({
-  datasets,
-  locale,
-  t,
-  statType,
-}: {
-  datasets: Array<{
-    id: string;
-    cityName: string;
-    dataCount: number;
-    stats: import("@prisma/client").Prisma.JsonValue;
-    areaId: number;
-    templateId: string;
-    createdAt: Date;
-    area: { id: number; countryCode: string | null };
-    template: {
-      id: string;
-      name: string;
-      description: string | null;
-      category: { id: string; name: string; slug: string } | null;
-      translations: Array<{
-        locale: string;
-        name: string;
-        description: string | null;
-      }>;
-    };
-    _count: {
-      watchers: number;
-    };
-  }>;
-  locale: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  t: any;
-  statType: "default" | "largest" | "most-watched";
-}) {
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {datasets.map((dataset) => {
-        const s = processDatasetStats(dataset, locale);
-        const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-        const stats = getDatasetStats(dataset, s, t, statType);
-
-        return (
-          <DatasetCard
-            key={dataset.id}
-            name={resolvedTemplate.name}
-            city={dataset.cityName}
-            country={dataset.area.countryCode ?? ""}
-            category={resolvedTemplate.category?.name ?? "other"}
-            href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-            stats={stats}
-          />
-        );
-      })}
-    </div>
   );
 }

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -1,24 +1,10 @@
 import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
+import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
+import { formatRelativeTime } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
-import { Link } from "@/i18n/navigation";
-
-function formatRelativeTime(timestamp: Date | null | undefined, locale: string): string {
-  if (!timestamp) return "—";
-
-  const diffMs = timestamp.getTime() - Date.now();
-  const absSec = Math.abs(diffMs / 1000);
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
-
-  if (absSec < 60) return rtf.format(Math.round(diffMs / 1000), "second");
-  if (absSec < 3600) return rtf.format(Math.round(diffMs / 60000), "minute");
-  if (absSec < 86400) return rtf.format(Math.round(diffMs / 3600000), "hour");
-  if (absSec < 2592000) return rtf.format(Math.round(diffMs / 86400000), "day");
-  if (absSec < 31536000) return rtf.format(Math.round(diffMs / 2592000000), "month");
-  return rtf.format(Math.round(diffMs / 31536000000), "year");
-}
 
 export const revalidate = 300;
 
@@ -97,48 +83,34 @@ export default async function RecentlyEditedPage({
   });
 
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
-      <div className="max-w-7xl mx-auto px-6">
-        <div className="mb-8">
-          <Link
-            href={`/explore`}
-            className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
-          >
-            {t("backToExplore")}
-          </Link>
-          <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t("sections.recentlyEdited")}
-          </h1>
+    <ExplorePageLayout>
+      <ExploreSectionHeader sectionKey="recentlyEdited" t={t} />
+      {datasets.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {datasets.map((dataset) => {
+            const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+            const stats = [
+              { type: "lastEdited" as const, label: t("stats.lastEdited"), value: formatRelativeTime(dataset.lastEditedAt, locale) },
+            ];
+
+            return (
+              <DatasetCard
+                key={dataset.id}
+                name={resolvedTemplate.name}
+                city={dataset.cityName}
+                country={dataset.area.countryCode ?? ""}
+                category={resolvedTemplate.category?.name ?? "other"}
+                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                stats={stats}
+              />
+            );
+          })}
         </div>
-
-        {datasets.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {datasets.map((dataset) => {
-              const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
-              const lastEdited = formatRelativeTime(dataset.lastEditedAt, locale);
-              const stats = [
-                { type: "lastEdited" as const, label: t("stats.lastEdited"), value: lastEdited },
-              ];
-
-              return (
-                <DatasetCard
-                  key={dataset.id}
-                  name={resolvedTemplate.name}
-                  city={dataset.cityName}
-                  country={dataset.area.countryCode ?? ""}
-                  category={resolvedTemplate.category?.name ?? "other"}
-                  href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
-                  stats={stats}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="text-center py-12 text-neutral-400">
-            {t("noDatasetsFound")}
-          </div>
-        )}
-      </div>
-    </div>
+      ) : (
+        <div className="text-center py-12 text-neutral-400">
+          {t("noDatasetsFound")}
+        </div>
+      )}
+    </ExplorePageLayout>
   );
 }

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -101,7 +101,7 @@ export default async function RecentlyEditedPage({
       <div className="max-w-7xl mx-auto px-6">
         <div className="mb-8">
           <Link
-            href={`/${locale}/explore`}
+            href={`/explore`}
             className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
           >
             {t("backToExplore")}

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -5,6 +5,21 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { Link } from "@/i18n/navigation";
 
+function formatRelativeTime(timestamp: Date | null | undefined, locale: string): string {
+  if (!timestamp) return "—";
+
+  const diffMs = timestamp.getTime() - Date.now();
+  const absSec = Math.abs(diffMs / 1000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  if (absSec < 60) return rtf.format(Math.round(diffMs / 1000), "second");
+  if (absSec < 3600) return rtf.format(Math.round(diffMs / 60000), "minute");
+  if (absSec < 86400) return rtf.format(Math.round(diffMs / 3600000), "hour");
+  if (absSec < 2592000) return rtf.format(Math.round(diffMs / 86400000), "day");
+  if (absSec < 31536000) return rtf.format(Math.round(diffMs / 2592000000), "month");
+  return rtf.format(Math.round(diffMs / 31536000000), "year");
+}
+
 export const revalidate = 300;
 
 export async function generateMetadata({
@@ -72,6 +87,7 @@ export default async function RecentlyEditedPage({
     select: {
       ...DATASET_SELECT,
       recentlyEditedCount: true,
+      lastEditedAt: true,
       _count: {
         select: { watchers: true }
       }
@@ -99,8 +115,9 @@ export default async function RecentlyEditedPage({
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {datasets.map((dataset) => {
               const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
+              const lastEdited = formatRelativeTime(dataset.lastEditedAt, locale);
               const stats = [
-                { type: "features" as const, label: "Recently edited", value: dataset.recentlyEditedCount || 0 },
+                { type: "lastEdited" as const, label: t("stats.lastEdited"), value: lastEdited },
               ];
 
               return (

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({
   const t = await getTranslations("ExplorePage");
 
   return {
-    title: `${t("sections.largest")} - ${t("metaTitle")}`,
+    title: `${t("sections.recentlyEdited")} - ${t("metaTitle")}`,
   };
 }
 
@@ -58,7 +58,7 @@ const DATASET_SELECT = {
   },
 } as const;
 
-export default async function LargestPage({
+export default async function RecentlyEditedPage({
   params,
 }: {
   params: Promise<{ locale: Locale }>;
@@ -68,14 +68,15 @@ export default async function LargestPage({
   const t = await getTranslations("ExplorePage");
 
   const datasets = await prisma.dataset.findMany({
-    where: { isActive: true, dataCount: { gt: 0 } },
+    where: { isActive: true, dataCount: { gt: 0 }, recentlyEditedCount: { not: null } },
     select: {
       ...DATASET_SELECT,
+      recentlyEditedCount: true,
       _count: {
         select: { watchers: true }
       }
     },
-    orderBy: { dataCount: "desc" },
+    orderBy: { lastEditedAt: "desc" },
     take: 24,
   });
 
@@ -90,7 +91,7 @@ export default async function LargestPage({
             {t("backToExplore")}
           </Link>
           <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
-            {t("sections.largest")}
+            {t("sections.recentlyEdited")}
           </h1>
         </div>
 
@@ -99,7 +100,7 @@ export default async function LargestPage({
             {datasets.map((dataset) => {
               const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);
               const stats = [
-                { type: "features" as const, label: t("stats.features"), value: dataset.dataCount },
+                { type: "features" as const, label: "Recently edited", value: dataset.recentlyEditedCount || 0 },
               ];
 
               return (

--- a/src/components/explore/explore-components.tsx
+++ b/src/components/explore/explore-components.tsx
@@ -1,0 +1,37 @@
+import { Link } from "@/i18n/navigation";
+
+interface ExplorePageLayoutProps {
+  children: React.ReactNode;
+}
+
+export function ExplorePageLayout({ children }: ExplorePageLayoutProps) {
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 py-8">
+      <div className="max-w-7xl mx-auto px-6">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+interface ExploreSectionHeaderProps {
+  sectionKey: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: any;
+}
+
+export function ExploreSectionHeader({ sectionKey, t }: ExploreSectionHeaderProps) {
+  return (
+    <div className="mb-8">
+      <Link
+        href={`/explore`}
+        className="text-xs text-neutral-400 hover:text-neutral-700 cursor-pointer"
+      >
+        {t("backToExplore")}
+      </Link>
+      <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mt-4">
+        {t(`sections.${sectionKey}`)}
+      </h1>
+    </div>
+  );
+}

--- a/src/components/ui/dataset-card.tsx
+++ b/src/components/ui/dataset-card.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { Link } from "react-aria-components";
-import { MapPin, Users, Pencil } from "lucide-react";
+import { MapPin, Users, Pencil, Eye } from "lucide-react";
 import { getCategoryIcon } from "@/lib/category-icons";
 
-export type StatType = "features" | "contributors" | "lastEdited";
+export type StatType = "features" | "contributors" | "lastEdited" | "watchers";
 
 export interface DatasetCardProps {
   name: string;
@@ -65,6 +65,7 @@ function formatStatValue(type: StatType, value: string | number): string {
 function getStatIcon(type: StatType) {
   if (type === "contributors") return Users;
   if (type === "lastEdited") return Pencil;
+  if (type === "watchers") return Eye;
   return MapPin;
 }
 

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -14,11 +14,16 @@ export interface DatasetStats {
 }
 
 export function getDatasetStats(
-  dataset: { _count: { watchers: number } },
+  dataset: {
+    _count: { watchers: number };
+    contributorsCount?: number | null;
+    recentlyEditedCount?: number | null;
+    lastEditedAt?: Date | null;
+  },
   processedStats: ProcessedDatasetStats,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   t: any,
-  section: "featured" | "largest" | "most-watched" | "default"
+  section: "featured" | "largest" | "most-watched" | "most-contributors" | "recently-edited" | "default"
 ): DatasetStats[] {
   switch (section) {
     case "largest":
@@ -28,6 +33,14 @@ export function getDatasetStats(
     case "most-watched":
       return [
         { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
+      ];
+    case "most-contributors":
+      return [
+        { type: "contributors" as const, label: t("stats.contributors"), value: dataset.contributorsCount || 0 },
+      ];
+    case "recently-edited":
+      return [
+        { type: "features" as const, label: "Recently edited", value: dataset.recentlyEditedCount || 0 },
       ];
     default:
       return [

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -22,10 +22,10 @@ export function processDatasetStats(dataset: Pick<Dataset, 'dataCount' | 'stats'
   };
 }
 
-function formatRelativeTime(timestamp: string | null | undefined, locale: string): string {
+export function formatRelativeTime(timestamp: string | Date | null | undefined, locale: string): string {
   if (!timestamp) return "—";
 
-  const date = new Date(timestamp);
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
   if (isNaN(date.getTime())) return "—";
 
   const diffMs = date.getTime() - Date.now();

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -1,9 +1,41 @@
 import { Dataset } from "@prisma/client";
+import type { StatType } from "@/components/ui/dataset-card";
 
 export interface ProcessedDatasetStats {
   features: number;
   contributors: number;
   lastEdited: string;
+}
+
+export interface DatasetStats {
+  type: StatType;
+  label: string;
+  value: string | number;
+}
+
+export function getDatasetStats(
+  dataset: { _count: { watchers: number } },
+  processedStats: ProcessedDatasetStats,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: any,
+  section: "featured" | "largest" | "most-watched" | "default"
+): DatasetStats[] {
+  switch (section) {
+    case "largest":
+      return [
+        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
+      ];
+    case "most-watched":
+      return [
+        { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
+      ];
+    default:
+      return [
+        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
+        { type: "contributors" as const, label: t("stats.contributors"), value: processedStats.contributors },
+        { type: "lastEdited" as const, label: t("stats.lastEdited"), value: processedStats.lastEdited },
+      ];
+  }
 }
 
 export function processDatasetStats(dataset: Pick<Dataset, 'dataCount' | 'stats'>, locale: string): ProcessedDatasetStats {

--- a/src/lib/dataset-stats.ts
+++ b/src/lib/dataset-stats.ts
@@ -1,54 +1,9 @@
 import { Dataset } from "@prisma/client";
-import type { StatType } from "@/components/ui/dataset-card";
 
 export interface ProcessedDatasetStats {
   features: number;
   contributors: number;
   lastEdited: string;
-}
-
-export interface DatasetStats {
-  type: StatType;
-  label: string;
-  value: string | number;
-}
-
-export function getDatasetStats(
-  dataset: {
-    _count: { watchers: number };
-    contributorsCount?: number | null;
-    recentlyEditedCount?: number | null;
-    lastEditedAt?: Date | null;
-  },
-  processedStats: ProcessedDatasetStats,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  t: any,
-  section: "featured" | "largest" | "most-watched" | "most-contributors" | "recently-edited" | "default"
-): DatasetStats[] {
-  switch (section) {
-    case "largest":
-      return [
-        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
-      ];
-    case "most-watched":
-      return [
-        { type: "watchers" as const, label: t("stats.watchers"), value: dataset._count.watchers },
-      ];
-    case "most-contributors":
-      return [
-        { type: "contributors" as const, label: t("stats.contributors"), value: dataset.contributorsCount || 0 },
-      ];
-    case "recently-edited":
-      return [
-        { type: "features" as const, label: "Recently edited", value: dataset.recentlyEditedCount || 0 },
-      ];
-    default:
-      return [
-        { type: "features" as const, label: t("stats.features"), value: processedStats.features },
-        { type: "contributors" as const, label: t("stats.contributors"), value: processedStats.contributors },
-        { type: "lastEdited" as const, label: t("stats.lastEdited"), value: processedStats.lastEdited },
-      ];
-  }
 }
 
 export function processDatasetStats(dataset: Pick<Dataset, 'dataCount' | 'stats'>, locale: string): ProcessedDatasetStats {


### PR DESCRIPTION
## Summary
- Add 3 new sections to Explore page: Recently Added, Largest, and Most Watched
- Add "See all →" subpages for each section showing 24 items per page
- Add watchers stat and Eye icon to DatasetCard
- Add i18n translations (en, es, pt-BR) for new sections and UI strings
- Set subpage revalidation to 5 minutes for fresher dynamic data

## Changes
**Modified files:**
- `messages/en.json`, `messages/es.json`, `messages/pt-BR.json` - Added translations
- `src/app/[locale]/explore/page.tsx` - Added 3 sections with "See all" links
- `src/components/ui/dataset-card.tsx` - Added watchers stat type and Eye icon

**New files:**
- `src/app/[locale]/explore/[section]/page.tsx` - Dynamic route for section subpages

## Implementation
- Reused existing `DatasetCard` component with conditional stats display
- `getDatasetStats()` helper returns different stats based on section type
- Each section has dedicated Prisma query (featured, orderBy createdAt/dataCount/watchers)
- Main explore page: 1 hour ISR (static-ish content)
- Section subpages: 5 minute ISR (dynamic rankings)

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] i18n check passes
- [x] Manual testing of explore page
- [x] Verify "See all" links work
- [ ] Check dark mode rendering