### PR TITLE
feat(dataset): promote stats to first-class indexed columns

### DIFF
--- a/prisma/migrations/20260614171815_promote_dataset_stats/migration.sql
+++ b/prisma/migrations/20260614171815_promote_dataset_stats/migration.sql
@@ -15,7 +15,7 @@ CREATE INDEX "datasets_recentlyEditedCount_idx" ON "datasets"("recentlyEditedCou
 -- Backfill from existing stats JSON
 UPDATE "datasets"
 SET
-  "lastEditedAt"        = (stats->>'mostRecentElement')::timestamptz,
+  "lastEditedAt"        = (stats->>'mostRecentElement')::timestamptz AT TIME ZONE 'UTC',
   "contributorsCount"   = (stats->>'editorsCount')::int,
   "recentlyEditedCount" = (stats->'recentActivity'->>'elementsEdited')::int
 WHERE stats IS NOT NULL;

--- a/prisma/migrations/20260614171815_promote_dataset_stats/migration.sql
+++ b/prisma/migrations/20260614171815_promote_dataset_stats/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE "datasets" ADD COLUMN     "contributorsCount" INTEGER,
+ADD COLUMN     "lastEditedAt" TIMESTAMP(3),
+ADD COLUMN     "recentlyEditedCount" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "datasets_lastEditedAt_idx" ON "datasets"("lastEditedAt");
+
+-- CreateIndex
+CREATE INDEX "datasets_contributorsCount_idx" ON "datasets"("contributorsCount");
+
+-- CreateIndex
+CREATE INDEX "datasets_recentlyEditedCount_idx" ON "datasets"("recentlyEditedCount");
+
+-- Backfill from existing stats JSON
+UPDATE "datasets"
+SET
+  "lastEditedAt"        = (stats->>'mostRecentElement')::timestamptz,
+  "contributorsCount"   = (stats->>'editorsCount')::int,
+  "recentlyEditedCount" = (stats->'recentActivity'->>'elementsEdited')::int
+WHERE stats IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,15 +118,21 @@ model Dataset {
   createdAt   DateTime       @default(now())
   updatedAt   DateTime       @updatedAt
   areaId      Int
-  bbox        Json?
-  stats       Json?
-  watchers    DatasetWatch[]
-  area        Area           @relation(fields: [areaId], references: [id], onDelete: Cascade)
-  template    Template       @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  user        User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  bbox                Json?
+  stats               Json?
+  lastEditedAt        DateTime?
+  contributorsCount   Int?
+  recentlyEditedCount Int?
+  watchers            DatasetWatch[]
+  area                Area           @relation(fields: [areaId], references: [id], onDelete: Cascade)
+  template            Template       @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  user                User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([templateId, areaId])
   @@index([isFeatured, createdAt])
+  @@index([lastEditedAt])
+  @@index([contributorsCount])
+  @@index([recentlyEditedCount])
   @@map("datasets")
 }
 

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -63,6 +63,9 @@ export async function POST(
         geojson: JSON.parse(JSON.stringify(snapshot.geojson)),
         bbox: snapshot.bbox ? JSON.parse(JSON.stringify(snapshot.bbox)) : null,
         updatedAt: new Date(),
+        lastEditedAt: snapshot.stats.mostRecentElement ?? null,
+        contributorsCount: snapshot.stats.editorsCount,
+        recentlyEditedCount: snapshot.stats.recentActivity.elementsEdited,
       },
       include: {
         template: {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -75,6 +75,9 @@ export async function POST(req: NextRequest) {
             dataCount: snapshot.dataCount,
             lastChecked: new Date(),
             updatedAt: new Date(),
+            lastEditedAt: snapshot.stats.mostRecentElement ?? null,
+            contributorsCount: snapshot.stats.editorsCount,
+            recentlyEditedCount: snapshot.stats.recentActivity.elementsEdited,
           },
         });
 

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -212,6 +212,9 @@ async function createDatasetOnDemand(
         dataCount: snapshot.dataCount,
         lastChecked: new Date(),
         stats: JSON.parse(JSON.stringify(snapshot.stats)),
+        lastEditedAt: snapshot.stats.mostRecentElement ?? null,
+        contributorsCount: snapshot.stats.editorsCount,
+        recentlyEditedCount: snapshot.stats.recentActivity.elementsEdited,
       },
       include: {
         template: {


### PR DESCRIPTION
## Dataset stats: first-class indexed columns

**Problem:** `lastEditedAt`, `contributorsCount`, and `recentlyEditedCount` were buried in the `stats` JSON field. Prisma cannot sort or filter on JSON fields without raw SQL, making it impossible to build efficient dataset listings sorted by recent activity or contributor count.

**Acceptance Criteria:**
- [x] `lastEditedAt`, `contributorsCount`, `recentlyEditedCount` exist as typed columns on `datasets`
- [x] Indexes on all three columns for efficient `orderBy`/`where`
- [x] Existing rows backfilled from `stats` JSON at migration time
- [x] All three snapshot write paths (creation, cron, manual refresh) populate the columns

**Changes:**
- `prisma/schema.prisma` — added 3 nullable columns + indexes to `Dataset` model
- `prisma/migrations/20260614171815_promote_dataset_stats/` — column creation + backfill from `stats->>'mostRecentElement'`, `stats->>'editorsCount'`, `stats->'recentActivity'->>'elementsEdited'`
- `src/lib/dataset-operations.ts` — creation path writes new columns
- `src/app/api/tasks/update-datasets/route.ts` — cron path writes new columns
- `src/app/api/datasets/[id]/refresh/route.ts` — manual refresh writes new columns