### PR TITLE
feat: require develop as source branch for main PRs

### DIFF
--- a/.github/workflows/check-source-branch.yml
+++ b/.github/workflows/check-source-branch.yml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require develop as source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ "${{ github.head_ref }}" != "develop" ]; then
-            echo "Error: PRs to main must come from develop branch, not ${{ github.head_ref }}"
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "Error: PRs to main must come from develop branch, not $HEAD_REF"
             exit 1
           fi
           echo "✅ Source branch is develop"

--- a/.github/workflows/check-source-branch.yml
+++ b/.github/workflows/check-source-branch.yml
@@ -1,0 +1,17 @@
+name: Check source branch
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require develop as source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "Error: PRs to main must come from develop branch, not ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "✅ Source branch is develop"


### PR DESCRIPTION
Adds GitHub Actions workflow that enforces only develop branch can merge to main. Workflow checks that PRs to main have develop as the source branch and fails otherwise.