### PR TITLE
perf: optimize area and dataset page loading

### DIFF
--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -24,6 +24,8 @@ import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 
+export const revalidate = 3600;
+
 type DatasetPageProps = {
   params: Promise<{
     areaId: string;

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -10,6 +10,8 @@ import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { auth } from "@/auth";
 
+export const revalidate = 3600;
+
 type AreaPageProps = {
   params: Promise<{
     areaId: string;
@@ -19,19 +21,36 @@ type AreaPageProps = {
 async function getActiveTemplates(locale: string) {
   const rows = await prisma.template.findMany({
     where: { isActive: true },
-    include: {
-      translations: true,
-      category: true,
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      tags: true,
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
+      translations: {
+        select: {
+          locale: true,
+          name: true,
+          description: true,
+        },
+      },
     },
     orderBy: { name: "asc" },
   });
   return rows.map((t) => {
+    const categorySlug = t.category?.slug ?? "other";
     const resolved = resolveTemplateForLocale(t, locale);
     return {
       id: resolved.id,
       name: resolved.name,
       description: resolved.description,
-      category: resolved.category?.slug ?? "other",
+      category: categorySlug,
       tags: resolved.tags,
     };
   });

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -66,15 +66,39 @@ async function getDatasetWithDetails(areaId: number, templateId: string, locale:
       templateId,
       isActive: true,
     },
-    include: {
+    select: {
+      id: true,
+      templateId: true,
+      areaId: true,
+      cityName: true,
+      geojson: true,
+      bbox: true,
+      dataCount: true,
+      lastChecked: true,
+      stats: true,
+      createdAt: true,
+      updatedAt: true,
+      isActive: true,
       template: {
         select: {
           id: true,
           name: true,
           description: true,
-          category: true,
+          category: {
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+            },
+          },
           tags: true,
-          translations: true,
+          translations: {
+            select: {
+              locale: true,
+              name: true,
+              description: true,
+            },
+          },
         },
       },
       area: {
@@ -216,15 +240,39 @@ async function createDatasetOnDemand(
         contributorsCount: snapshot.stats.editorsCount,
         recentlyEditedCount: snapshot.stats.recentActivity.elementsEdited,
       },
-      include: {
+      select: {
+        id: true,
+        templateId: true,
+        areaId: true,
+        cityName: true,
+        geojson: true,
+        bbox: true,
+        dataCount: true,
+        lastChecked: true,
+        stats: true,
+        createdAt: true,
+        updatedAt: true,
+        isActive: true,
         template: {
           select: {
             id: true,
             name: true,
             description: true,
-            category: true,
+            category: {
+              select: {
+                id: true,
+                name: true,
+                slug: true,
+              },
+            },
             tags: true,
-            translations: true,
+            translations: {
+              select: {
+                locale: true,
+                name: true,
+                description: true,
+              },
+            },
           },
         },
         area: {

--- a/src/lib/nominatim.ts
+++ b/src/lib/nominatim.ts
@@ -81,8 +81,9 @@ export async function getAreaDetailsById(
 
   try {
     const response = await fetch(
-      `https://nominatim.openstreetmap.org/lookup?osm_ids=R${osmRelationId}&format=json&addressdetails=1&extratags=1`,
+      `https://nominatim.openstreetmap.org/lookup?osm_ids=R${osmRelationId}&format=json&addressdetails=1&extratags=1&accept-language=${language}`,
       {
+        next: { revalidate: 86400 }, // 24 hours
         headers: {
           "Accept-Language": language,
           "User-Agent": getUserAgent(),


### PR DESCRIPTION
## Summary
- Optimize Prisma queries: convert `include` to `select` to reduce data transfer
- Add static revalidation (1 hour) for area and dataset pages
- Cache Nominatim API responses (24 hours)

## Test plan
- [x] Area page loads: `/en/area/111968`
- [x] Dataset page loads: `/en/area/71525/dataset/arts-centre`
- [x] Type-check passes
- [x] Upsell page only fetches needed data (template + area name)

## Changes
- `src/app/[locale]/area/[areaId]/page.tsx`: Add revalidate, optimize template query
- `src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx`: Add revalidate
- `src/lib/nominatim.ts`: Add Next.js cache to Nominatim fetch
- `src/lib/dataset-operations.ts`: Optimize queries with select