### PR TITLE
fix: address v1.11.0 review feedback

### DIFF
--- a/src/app/[locale]/explore/largest/page.tsx
+++ b/src/app/[locale]/explore/largest/page.tsx
@@ -25,7 +25,6 @@ const DATASET_SELECT = {
   id: true,
   cityName: true,
   dataCount: true,
-  stats: true,
   areaId: true,
   templateId: true,
   createdAt: true,

--- a/src/app/[locale]/explore/most-contributors/page.tsx
+++ b/src/app/[locale]/explore/most-contributors/page.tsx
@@ -25,7 +25,6 @@ const DATASET_SELECT = {
   id: true,
   cityName: true,
   dataCount: true,
-  stats: true,
   areaId: true,
   templateId: true,
   createdAt: true,

--- a/src/app/[locale]/explore/most-watched/page.tsx
+++ b/src/app/[locale]/explore/most-watched/page.tsx
@@ -25,7 +25,6 @@ const DATASET_SELECT = {
   id: true,
   cityName: true,
   dataCount: true,
-  stats: true,
   areaId: true,
   templateId: true,
   createdAt: true,

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -83,7 +83,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       take: 20,
     }).then(datasets => shuffleArray(datasets).slice(0, 6)),
     prisma.dataset.findMany({
-      where: { isActive: true, dataCount: { gt: 0 }, recentlyEditedCount: { not: null } },
+      where: { isActive: true, dataCount: { gt: 0 }, lastEditedAt: { not: null } },
       select: {
         ...DATASET_SELECT,
         recentlyEditedCount: true,

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -69,7 +69,7 @@ export default async function RecentlyEditedPage({
   const t = await getTranslations("ExplorePage");
 
   const datasets = await prisma.dataset.findMany({
-    where: { isActive: true, dataCount: { gt: 0 }, recentlyEditedCount: { not: null } },
+    where: { isActive: true, dataCount: { gt: 0 }, lastEditedAt: { not: null } },
     select: {
       ...DATASET_SELECT,
       recentlyEditedCount: true,

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -26,7 +26,6 @@ const DATASET_SELECT = {
   id: true,
   cityName: true,
   dataCount: true,
-  stats: true,
   areaId: true,
   templateId: true,
   createdAt: true,

--- a/src/components/dataset/map/layers/__tests__/expressions.test.ts
+++ b/src/components/dataset/map/layers/__tests__/expressions.test.ts
@@ -34,6 +34,33 @@ describe('buildCircleColorExpression', () => {
     ]);
   });
 
+  it('should lowercase non-canonical casing colorMap keys', () => {
+    const theme: CategoricalTheme = {
+      type: 'categorical',
+      field: 'covered',
+      colorMap: new Map([
+        ['Yes', '#4e79a7'],
+        ['No', '#e15759'],
+      ]),
+      topValues: [
+        { value: 'Yes', count: 80 },
+        { value: 'No', count: 20 },
+      ],
+      otherCount: 0,
+    };
+
+    const expression = buildCircleColorExpression(theme);
+
+    expect(expression).toEqual([
+      'case',
+      ['==', ['downcase', ['get', 'covered']], 'yes'],
+      '#4e79a7',
+      ['==', ['downcase', ['get', 'covered']], 'no'],
+      '#e15759',
+      '#9ca3af', // fallback color
+    ]);
+  });
+
   it('should build interpolate expression for intensity theme', () => {
     const theme: IntensityTheme = {
       type: 'intensity',

--- a/src/components/dataset/map/layers/__tests__/expressions.test.ts
+++ b/src/components/dataset/map/layers/__tests__/expressions.test.ts
@@ -24,11 +24,11 @@ describe('buildCircleColorExpression', () => {
 
     expect(expression).toEqual([
       'case',
-      ['==', ['get', 'amenity'], 'bench'],
+      ['==', ['downcase', ['get', 'amenity']], 'bench'],
       '#4e79a7',
-      ['==', ['get', 'amenity'], 'fountain'],
+      ['==', ['downcase', ['get', 'amenity']], 'fountain'],
       '#f28e2c',
-      ['==', ['get', 'amenity'], 'atm'],
+      ['==', ['downcase', ['get', 'amenity']], 'atm'],
       '#e15759',
       '#9ca3af', // fallback color
     ]);

--- a/src/components/dataset/map/layers/expressions.ts
+++ b/src/components/dataset/map/layers/expressions.ts
@@ -31,7 +31,7 @@ export const buildCircleColorExpression = (theme: MapTheme) => {
     const expression: unknown[] = ["case"];
 
     for (const [value, color] of entries) {
-      expression.push(["==", ["get", theme.field], value], color);
+      expression.push(["==", ["downcase", ["get", theme.field]], value.toLowerCase()], color);
     }
 
     // Fallback color for "other" values


### PR DESCRIPTION
## Summary

Addresses Greptile review feedback on #315 (Release v1.11.0). Merge before re-reviewing #315.

- **fix(explore): align recently-edited filter with displayed column** — `recently-edited/page.tsx` and `explore/page.tsx` filtered on `recentlyEditedCount` but ordered/displayed `lastEditedAt`. Aligned filter to `lastEditedAt` so rows shown always have a value to display.
- **fix(map-themes): match categorical values case-insensitively** — `detection.ts` groups values case-insensitively and stores the most-common casing as the colorMap key, but `expressions.ts` used exact `==` equality. Wrapped get with `downcase` and lowercased the comparison value so non-canonical casing (e.g. `"Yes"` vs canonical `"yes"`) get the right color instead of falling to gray fallback.
- **refactor(explore): drop unused stats column from section pages** — `largest`, `most-watched`, `most-contributors`, and `recently-edited` pages selected `stats: true` but never read `dataset.stats`. Removed to reduce payload and clarify intent. (`featured/page.tsx` and `explore/page.tsx` still select stats — they use it via `processDatasetStats`.)

## Test plan

- [x] `pnpm type-check` — passes
- [x] `pnpm lint` — 0 errors (55 pre-existing warnings in test files)
- [x] `pnpm i18n:check` — passes
- [x] `pnpm test:unit --run` — 194/194 pass
- [ ] Visual check on `/explore/recently-edited` after merge

Refs #315