### PR TITLE
feat(map): ThemeSwitcher control for toggling map visualization themes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -339,13 +339,16 @@
     "last7Days": "Last 7 days",
     "last30Days": "Last 30 days",
     "last90Days": "Last 90 days",
-    "age": "Age",
     "noDataInTimeframe": "No data found in the selected time period",
-    "lastEditedLegend": "Last Edited",
+    "lastEditedLegend": "Recent edits",
     "recentChanges": "≤ 7 days ago",
     "mediumChanges": "8-30 days ago",
     "olderChanges": "31-90 days ago",
-    "veryOldChanges": "> 90 days ago"
+    "veryOldChanges": "> 90 days ago",
+    "recentEdits": "Recent edits",
+    "themeSelect": "Select map theme",
+    "previousTheme": "Previous theme",
+    "nextTheme": "Next theme"
   },
   "DatasetWatchButton": {
     "privateDataset": "Private Dataset"

--- a/messages/es.json
+++ b/messages/es.json
@@ -337,13 +337,16 @@
     "last7Days": "Últimos 7 días",
     "last30Days": "Últimos 30 días",
     "last90Days": "Últimos 90 días",
-    "age": "Antigüedad",
     "noDataInTimeframe": "No se encontraron datos en el período seleccionado",
     "lastEditedLegend": "Última Edición",
     "recentChanges": "≤ 7 días atrás",
     "mediumChanges": "8-30 días atrás",
     "olderChanges": "31-90 días atrás",
-    "veryOldChanges": "> 90 días atrás"
+    "veryOldChanges": "> 90 días atrás",
+    "recentEdits": "Recent edits",
+    "themeSelect": "Select map theme",
+    "previousTheme": "Previous theme",
+    "nextTheme": "Next theme"
   },
   "DatasetWatchButton": {
     "privateDataset": "Conjunto de Datos Privado"

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -337,13 +337,16 @@
     "last7Days": "Últimos 7 dias",
     "last30Days": "Últimos 30 dias",
     "last90Days": "Últimos 90 dias",
-    "age": "Idade",
     "noDataInTimeframe": "Nenhum dado encontrado no período selecionado",
     "lastEditedLegend": "Última Edição",
     "recentChanges": "≤ 7 dias atrás",
     "mediumChanges": "8-30 dias atrás",
     "olderChanges": "31-90 dias atrás",
-    "veryOldChanges": "> 90 dias atrás"
+    "veryOldChanges": "> 90 dias atrás",
+    "recentEdits": "Recent edits",
+    "themeSelect": "Select map theme",
+    "previousTheme": "Previous theme",
+    "nextTheme": "Next theme"
   },
   "DatasetWatchButton": {
     "privateDataset": "Conjunto de Dados Privado"

--- a/src/components/dataset/full-map.tsx
+++ b/src/components/dataset/full-map.tsx
@@ -11,6 +11,7 @@ import { AoiBoundaryLayer } from "./map/aoi-boundary-layer";
 import { AgeLegend } from "./map/age-legend";
 import { MapLegend } from "./map/map-legend";
 import { MapDateFilterControl } from "./map/map-date-filter-control";
+import { ThemeSwitcher } from "./map/theme-switcher";
 import { useDateFilter, useMapData, useFeatureSelection } from "./map/hooks";
 import type { Feature, FeatureCollection } from "geojson";
 import { MapErrorState, MapNoDataState } from "./map/map-states";
@@ -59,8 +60,18 @@ export const DatasetFullMap = forwardRef<DatasetFullMapHandle, DatasetFullMapPro
     return allThemes.filter((t) => t.type === 'categorical');
   }, [processedData?.features]);
 
-  // Theme selection - null means age theme, non-null means categorical theme
+  // Theme selection - null means recent edits, non-null means categorical theme
   const [selectedCategoricalTheme, setSelectedCategoricalTheme] = useState<CategoricalTheme | null>(null);
+  const themeInitialized = useRef(false);
+
+  // Default to the first detected theme on first render where themes appear
+  useEffect(() => {
+    if (!themeInitialized.current && categoricalThemes.length > 0) {
+      setSelectedCategoricalTheme(categoricalThemes[0]);
+      themeInitialized.current = true;
+    }
+  }, [categoricalThemes]);
+
   // Update filter if needed
   useEffect(() => {
     if (processedData?.availableTimeframes) {
@@ -91,32 +102,13 @@ export const DatasetFullMap = forwardRef<DatasetFullMapHandle, DatasetFullMapPro
       {/* Map */}
       <div className="flex-1 relative">
         {hasFilteredData && (
-          /* Theme Selector */
+          /* Theme Switcher */
           <div className="absolute z-10 top-4 left-4">
-            {categoricalThemes.length > 0 && (
-              <select
-                value={selectedCategoricalTheme ? selectedCategoricalTheme.field : 'age'}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  if (value === 'age') {
-                    setSelectedCategoricalTheme(null);
-                  } else {
-                    const theme = categoricalThemes.find(t => t.field === value);
-                    if (theme) {
-                      setSelectedCategoricalTheme(theme);
-                    }
-                  }
-                }}
-                className="px-3 py-2 text-sm bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-olive-500 focus:border-olive-500"
-              >
-                <option value="age">{t('age')}</option>
-                {categoricalThemes.map(theme => (
-                  <option key={theme.field} value={theme.field}>
-                    {theme.field}
-                  </option>
-                ))}
-              </select>
-            )}
+            <ThemeSwitcher
+              detectedThemes={categoricalThemes}
+              activeTheme={selectedCategoricalTheme}
+              onChange={setSelectedCategoricalTheme}
+            />
           </div>
         )}
 

--- a/src/components/dataset/map/theme-switcher.stories.tsx
+++ b/src/components/dataset/map/theme-switcher.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { useState } from "react";
+import { ThemeSwitcher } from "./theme-switcher";
+import type { CategoricalTheme } from "@/lib/map-themes";
+
+function StatefulThemeSwitcher({
+  detectedThemes,
+  initialTheme,
+  onChange,
+}: {
+  detectedThemes: CategoricalTheme[];
+  initialTheme: CategoricalTheme | null;
+  onChange: (theme: CategoricalTheme | null) => void;
+}) {
+  const [active, setActive] = useState<CategoricalTheme | null>(initialTheme);
+  return (
+    <ThemeSwitcher
+      detectedThemes={detectedThemes}
+      activeTheme={active}
+      onChange={(theme) => {
+        setActive(theme);
+        onChange(theme);
+      }}
+    />
+  );
+}
+
+const bicycleParkingTheme: CategoricalTheme = {
+  type: "categorical",
+  field: "bicycle_parking",
+  colorMap: new Map([
+    ["stands", "#0b4ad8"],
+    ["wall_loops", "#22c55e"],
+    ["rack", "#f97316"],
+  ]),
+  topValues: [
+    { value: "stands", count: 42 },
+    { value: "wall_loops", count: 18 },
+    { value: "rack", count: 9 },
+  ],
+  otherCount: 3,
+};
+
+const amenityTheme: CategoricalTheme = {
+  type: "categorical",
+  field: "amenity",
+  colorMap: new Map([["bench", "#22c55e"]]),
+  topValues: [{ value: "bench", count: 11 }],
+  otherCount: 0,
+};
+
+const accessTheme: CategoricalTheme = {
+  type: "categorical",
+  field: "access",
+  colorMap: new Map([["yes", "#0b4ad8"]]),
+  topValues: [{ value: "yes", count: 30 }],
+  otherCount: 0,
+};
+
+const meta: Meta<typeof ThemeSwitcher> = {
+  title: "Dataset/Map/ThemeSwitcher",
+  component: ThemeSwitcher,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MultipleThemes: Story = {
+  args: {
+    detectedThemes: [bicycleParkingTheme, amenityTheme, accessTheme],
+    activeTheme: bicycleParkingTheme,
+    onChange: fn(),
+  },
+  render: (args) => (
+    <StatefulThemeSwitcher
+      detectedThemes={args.detectedThemes}
+      initialTheme={args.activeTheme}
+      onChange={args.onChange}
+    />
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("Select map theme") as HTMLInputElement;
+    expect(input.value).toBe("bicycle_parking");
+
+    await userEvent.click(canvas.getByLabelText("Next theme"));
+    expect(args.onChange).toHaveBeenLastCalledWith(amenityTheme);
+
+    await userEvent.click(canvas.getByLabelText("Previous theme"));
+    expect(args.onChange).toHaveBeenLastCalledWith(bicycleParkingTheme);
+  },
+};
+
+export const SingleTheme: Story = {
+  args: {
+    detectedThemes: [bicycleParkingTheme],
+    activeTheme: bicycleParkingTheme,
+    onChange: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByLabelText("Next theme"));
+    expect(args.onChange).toHaveBeenLastCalledWith(null);
+  },
+};
+
+export const RecentEditsSelected: Story = {
+  args: {
+    detectedThemes: [bicycleParkingTheme, amenityTheme],
+    activeTheme: null,
+    onChange: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("Select map theme") as HTMLInputElement;
+    expect(input.value).toBe("Recent edits");
+  },
+};
+
+export const NoDetectedThemes: Story = {
+  args: {
+    detectedThemes: [],
+    activeTheme: null,
+    onChange: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    expect(canvasElement.textContent ?? "").toBe("");
+  },
+};

--- a/src/components/dataset/map/theme-switcher.tsx
+++ b/src/components/dataset/map/theme-switcher.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Button,
+  ComboBox,
+  Input,
+  ListBox,
+  ListBoxItem,
+  Popover,
+} from "react-aria-components";
+import type { CategoricalTheme } from "@/lib/map-themes";
+
+type RecentEditsTheme = {
+  readonly id: "recent-edits";
+  readonly type: "recent-edits";
+};
+
+type ThemeItem = CategoricalTheme | RecentEditsTheme;
+
+const RECENT_EDITS_THEME: RecentEditsTheme = {
+  id: "recent-edits",
+  type: "recent-edits",
+};
+
+interface ThemeSwitcherProps {
+  detectedThemes: CategoricalTheme[];
+  activeTheme: CategoricalTheme | null;
+  onChange: (theme: CategoricalTheme | null) => void;
+}
+
+export function ThemeSwitcher({
+  detectedThemes,
+  activeTheme,
+  onChange,
+}: ThemeSwitcherProps) {
+  const t = useTranslations("DatasetMap");
+
+  const themes: ThemeItem[] = useMemo(
+    () => [...detectedThemes, RECENT_EDITS_THEME],
+    [detectedThemes]
+  );
+
+  const activeItem: ThemeItem = activeTheme ?? RECENT_EDITS_THEME;
+  const activeKey = activeTheme ? activeTheme.field : RECENT_EDITS_THEME.id;
+  const activeIndex = themes.findIndex(
+    (theme) => getKey(theme) === activeKey
+  );
+
+  const select = useCallback(
+    (theme: ThemeItem) => {
+      onChange(theme.type === "recent-edits" ? null : theme);
+    },
+    [onChange]
+  );
+
+  const handlePrev = useCallback(() => {
+    const i = activeIndex <= 0 ? themes.length - 1 : activeIndex - 1;
+    select(themes[i]);
+  }, [activeIndex, themes, select]);
+
+  const handleNext = useCallback(() => {
+    const i = activeIndex >= themes.length - 1 ? 0 : activeIndex + 1;
+    select(themes[i]);
+  }, [activeIndex, themes, select]);
+
+  const handleSelectionChange = useCallback(
+    (key: React.Key | null) => {
+      if (key === null) return;
+      const found = themes.find((theme) => getKey(theme) === key);
+      if (found) select(found);
+    },
+    [themes, select]
+  );
+
+  if (detectedThemes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-1 bg-white/95 backdrop-blur-sm border rounded-lg p-1 shadow-sm">
+      <Button
+        onPress={handlePrev}
+        aria-label={t("previousTheme")}
+        className="px-2 py-1.5 rounded-md text-gray-600 hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 transition-colors"
+      >
+        <ChevronLeft size={16} />
+      </Button>
+
+      <ComboBox
+        items={themes}
+        selectedKey={activeKey}
+        onSelectionChange={handleSelectionChange}
+        allowsEmptyCollection={false}
+        menuTrigger="focus"
+      >
+        <Input
+          value={labelFor(activeItem, t("recentEdits"))}
+          aria-label={t("themeSelect")}
+          readOnly
+          className="px-3 py-1.5 text-sm font-medium text-gray-900 border-0 rounded-md focus:outline-none cursor-pointer w-32 truncate"
+        />
+        <Popover
+          className="mt-1 bg-white border border-gray-200 rounded-md shadow-lg z-50 max-h-60 overflow-y-auto"
+          style={{ width: "var(--trigger-width)" }}
+        >
+          <ListBox className="outline-none py-1">
+            {(theme: ThemeItem) => (
+              <ListBoxItem
+                key={getKey(theme)}
+                id={getKey(theme)}
+                className="px-3 py-2 text-sm cursor-pointer data-[hovered]:bg-muted data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[focused]:outline-none rounded-md mx-1 my-0.5 transition-colors"
+              >
+                {labelFor(theme, t("recentEdits"))}
+              </ListBoxItem>
+            )}
+          </ListBox>
+        </Popover>
+      </ComboBox>
+
+      <Button
+        onPress={handleNext}
+        aria-label={t("nextTheme")}
+        className="px-2 py-1.5 rounded-md text-gray-600 hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 transition-colors"
+      >
+        <ChevronRight size={16} />
+      </Button>
+    </div>
+  );
+}
+
+function getKey(theme: ThemeItem): string {
+  return theme.type === "recent-edits" ? theme.id : theme.field;
+}
+
+function labelFor(theme: ThemeItem, recentEditsLabel: string): string {
+  return theme.type === "recent-edits" ? recentEditsLabel : theme.field;
+}
+
+ThemeSwitcher.displayName = "ThemeSwitcher";


### PR DESCRIPTION
## Issue #266: feat: ThemeSwitcher control for toggling map visualization themes

**Problem:** The dataset full-map used an inline HTML `<select>` to switch between categorical coloring and the recency-of-edit fallback. It was inconsistent with the rest of the map controls and not keyboard-accessible via React Aria.

**Acceptance Criteria:**
- [ ] `<ThemeSwitcher />` renders all themes, highlights active
- [ ] Fires `onChange` when user selects a different theme
- [ ] Storybook stories: 3+ detected themes, 1 detected theme, empty (age only)
- [ ] Accessible (keyboard navigable, aria labels)
- [ ] `pnpm type-check` passes

**Changes:**
- Added `src/components/dataset/map/theme-switcher.tsx`: React Aria `ComboBox` + prev/next arrow buttons. Cycles through detected categorical themes with wrap-around; appends a local `RecentEditsTheme` marker for the recency fallback (null externally).
- Added `src/components/dataset/map/theme-switcher.stories.tsx`: 4 stories (MultipleThemes, SingleTheme, RecentEditsSelected, NoDetectedThemes) with interaction tests.
- Modified `src/components/dataset/full-map.tsx`: replaced inline `<select>` with `<ThemeSwitcher>`, added one-shot `useRef`-guarded effect to default-select the first detected theme on first render.
- Modified `messages/{en,es,pt-BR}.json`: removed unused `age` key, renamed `lastEditedLegend` value to "Recent edits", added `recentEdits`, `themeSelect`, `previousTheme`, `nextTheme`.

Component hides itself when no categorical themes are detected. The "Recent edits" entry maps to `null` in `onChange`, which triggers the existing `AgeLegend` and recency coloring.