### PR TITLE
fix: block country/state search and cap dataset size at 50k elements

### DIFF
--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/db";
 import { CreateDatasetSchema } from "@/schemas/dataset";
 import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
-import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
+import { fetchDatasetSnapshot, DatasetTooLargeError } from "@/lib/dataset-snapshot";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -92,6 +92,10 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(dataset, { status: 201 });
   } catch (err) {
+    if (err instanceof DatasetTooLargeError) {
+      return NextResponse.json({ error: err.message }, { status: 422 });
+    }
+
     if (
       err instanceof Prisma.PrismaClientKnownRequestError &&
       err.code === "P2002"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,6 +11,25 @@ export const DEPRECATION_DAYS = 30;
 /** Simplification tolerance for area boundaries (reduces coordinate count while preserving detail) */
 export const BOUNDARY_SIMPLIFICATION_TOLERANCE = 0.00001;
 
+/** Maximum number of OSM elements allowed in a dataset */
+export const MAX_DATASET_ELEMENTS = 50_000;
+
+/** Nominatim addresstype values allowed for area search (city-level and below only) */
+export const ALLOWED_AREA_ADDRESS_TYPES = new Set([
+  "city",
+  "town",
+  "village",
+  "suburb",
+  "neighbourhood",
+  "hamlet",
+  "municipality",
+  "borough",
+  "quarter",
+  "city_district",
+  "district",
+  "island",
+]);
+
 /** Supported locales for translations */
 export const SUPPORTED_LOCALES = ["en", "pt-BR", "es"] as const;
 

--- a/src/lib/dataset-snapshot.ts
+++ b/src/lib/dataset-snapshot.ts
@@ -2,10 +2,21 @@ import type { FeatureCollection } from "geojson";
 import {
   executeOverpassQuery,
   convertOverpassToGeoJSON,
+  countOverpassElements,
 } from "@/lib/overpass/transport";
 import type { OverpassData } from "@/types/overpass";
 import { calculateBbox } from "@/lib/utils";
 import type { Bbox } from "@/types/geojson";
+import { MAX_DATASET_ELEMENTS } from "@/lib/constants";
+
+export class DatasetTooLargeError extends Error {
+  constructor(public readonly count: number) {
+    super(
+      `Dataset too large: ${count.toLocaleString()} elements (max ${MAX_DATASET_ELEMENTS.toLocaleString()}). Try a smaller area.`
+    );
+    this.name = "DatasetTooLargeError";
+  }
+}
 
 export interface DatasetStats {
   editorsCount: number;
@@ -148,6 +159,12 @@ export async function fetchDatasetSnapshot(
     /\{OSM_RELATION_ID\}/g,
     areaId.toString()
   );
+
+  const elementCount = await countOverpassElements(queryString);
+  if (elementCount > MAX_DATASET_ELEMENTS) {
+    throw new DatasetTooLargeError(elementCount);
+  }
+
   const overpassData = await executeOverpassQuery(queryString);
   const geojson = convertOverpassToGeoJSON(overpassData);
   const stats = extractDatasetStats(overpassData);

--- a/src/lib/nominatim.ts
+++ b/src/lib/nominatim.ts
@@ -5,6 +5,7 @@ import {
 import { fromNominatim } from "@/lib/area-conversion";
 import { getUserAgent } from "@/lib/overpass/transport";
 import type { Area } from "@/types/area";
+import { ALLOWED_AREA_ADDRESS_TYPES } from "@/lib/constants";
 
 // Safeguard to prevent external API calls in test mode
 function preventExternalCallsInTests() {
@@ -55,9 +56,11 @@ export async function searchAreasWithNominatim(
     // Validate the response with Zod
     const validatedData = NominatimSearchResponseSchema.parse(rawData);
 
-    // Filter to only include relations (areas like cities, regions, etc.)
+    // Filter to relations at city-level and below (block countries, states, regions)
     const filteredResults = validatedData.filter(
-      (result) => result.osm_type === "relation"
+      (result) =>
+        result.osm_type === "relation" &&
+        (!result.addresstype || ALLOWED_AREA_ADDRESS_TYPES.has(result.addresstype))
     );
 
     return filteredResults;

--- a/src/lib/nominatim.ts
+++ b/src/lib/nominatim.ts
@@ -60,7 +60,8 @@ export async function searchAreasWithNominatim(
     const filteredResults = validatedData.filter(
       (result) =>
         result.osm_type === "relation" &&
-        (!result.addresstype || ALLOWED_AREA_ADDRESS_TYPES.has(result.addresstype))
+        result.addresstype !== undefined &&
+        ALLOWED_AREA_ADDRESS_TYPES.has(result.addresstype)
     );
 
     return filteredResults;

--- a/src/lib/overpass/transport.ts
+++ b/src/lib/overpass/transport.ts
@@ -74,6 +74,34 @@ export async function executeOverpassQuery(
   return data as OverpassResponse;
 }
 
+export async function countOverpassElements(query: string): Promise<number> {
+  preventExternalCallsInTests();
+
+  const countQuery = query
+    .replace(/\[timeout:\d+\]/, "[timeout:10]")
+    .replace(/out\s+[^;]+;\s*$/, "out count;");
+
+  const response = await fetch(OVERPASS_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": getUserAgent(),
+    },
+    body: `data=${encodeURIComponent(countQuery)}`,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Overpass API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const total = data?.elements?.[0]?.tags?.total;
+  if (total === undefined) {
+    throw new Error("Unexpected response format from Overpass count query");
+  }
+  return parseInt(total, 10);
+}
+
 export function convertOverpassToGeoJSON(
   overpassData: OverpassData
 ): FeatureCollection {

--- a/src/lib/overpass/transport.ts
+++ b/src/lib/overpass/transport.ts
@@ -99,7 +99,11 @@ export async function countOverpassElements(query: string): Promise<number> {
   if (total === undefined) {
     throw new Error("Unexpected response format from Overpass count query");
   }
-  return parseInt(total, 10);
+  const elementCount = parseInt(total, 10);
+  if (!Number.isInteger(elementCount)) {
+    throw new Error(`Invalid element count from Overpass: "${total}"`);
+  }
+  return elementCount;
 }
 
 export function convertOverpassToGeoJSON(


### PR DESCRIPTION
## Area size limits

**Problem:** The search box allows selecting any OSM relation including countries and states. No size guards exist on dataset creation. A country-level selection would produce a massive boundary GeoJSON and an Overpass query returning millions of elements, breaking the platform.

**Acceptance Criteria:**
- [ ] Searching for a country (e.g. Brazil, Germany) returns no country-level result
- [ ] Searching for a city (e.g. Sao Paulo, Berlin) still works correctly
- [ ] Creating a dataset for an area with >50k OSM elements returns a clear error (HTTP 422)
- [ ] Creating a dataset for a small area succeeds as before

**Changes:**
- `constants.ts` — add `ALLOWED_AREA_ADDRESS_TYPES` (city-level and below) and `MAX_DATASET_ELEMENTS = 50_000`
- `nominatim.ts` — filter search results to allowed addresstype values, blocking country/state/region
- `overpass/transport.ts` — add `countOverpassElements()`: runs a cheap `out count;` pre-flight query before any full fetch
- `dataset-snapshot.ts` — add `DatasetTooLargeError`; call count pre-flight in `fetchDatasetSnapshot` and throw if over cap
- `api/datasets/route.ts` — catch `DatasetTooLargeError` and return 422 with element count in message

Future: #322 (vector tiles epic) and #323 (lift cap for tile-served datasets) track the long-term solution.
