### PR TITLE
feat(explore): restrict listings to featured or watched datasets

### DIFF
--- a/src/app/[locale]/explore/largest/page.tsx
+++ b/src/app/[locale]/explore/largest/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { CATALOG_FILTER } from "@/lib/dataset-catalog-filter";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
@@ -67,7 +68,7 @@ export default async function LargestPage({
   const t = await getTranslations("ExplorePage");
 
   const datasets = await prisma.dataset.findMany({
-    where: { isActive: true, dataCount: { gt: 0 } },
+    where: { isActive: true, dataCount: { gt: 0 }, ...CATALOG_FILTER },
     select: {
       ...DATASET_SELECT,
       _count: {

--- a/src/app/[locale]/explore/most-contributors/page.tsx
+++ b/src/app/[locale]/explore/most-contributors/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { CATALOG_FILTER } from "@/lib/dataset-catalog-filter";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
@@ -67,7 +68,7 @@ export default async function MostContributorsPage({
   const t = await getTranslations("ExplorePage");
 
   const datasets = await prisma.dataset.findMany({
-    where: { isActive: true, dataCount: { gt: 0 }, contributorsCount: { not: null } },
+    where: { isActive: true, dataCount: { gt: 0 }, contributorsCount: { not: null }, ...CATALOG_FILTER },
     select: {
       ...DATASET_SELECT,
       contributorsCount: true,

--- a/src/app/[locale]/explore/most-watched/page.tsx
+++ b/src/app/[locale]/explore/most-watched/page.tsx
@@ -67,7 +67,7 @@ export default async function MostWatchedPage({
   const t = await getTranslations("ExplorePage");
 
   const datasets = await prisma.dataset.findMany({
-    where: { isActive: true, dataCount: { gt: 0 } },
+    where: { isActive: true, dataCount: { gt: 0 }, watchers: { some: {} } },
     select: {
       ...DATASET_SELECT,
       _count: {

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { CATALOG_FILTER } from "@/lib/dataset-catalog-filter";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { processDatasetStats, formatRelativeTime } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
@@ -83,7 +84,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       take: 20,
     }).then(datasets => shuffleArray(datasets).slice(0, 6)),
     prisma.dataset.findMany({
-      where: { isActive: true, dataCount: { gt: 0 }, lastEditedAt: { not: null } },
+      where: { isActive: true, dataCount: { gt: 0 }, lastEditedAt: { not: null }, ...CATALOG_FILTER },
       select: {
         ...DATASET_SELECT,
         recentlyEditedCount: true,
@@ -96,7 +97,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       take: 6,
     }),
     prisma.dataset.findMany({
-      where: { isActive: true, dataCount: { gt: 0 } },
+      where: { isActive: true, dataCount: { gt: 0 }, watchers: { some: {} } },
       select: {
         ...DATASET_SELECT,
         _count: {
@@ -107,7 +108,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       take: 6,
     }),
     prisma.dataset.findMany({
-      where: { isActive: true, dataCount: { gt: 0 }, contributorsCount: { not: null } },
+      where: { isActive: true, dataCount: { gt: 0 }, contributorsCount: { not: null }, ...CATALOG_FILTER },
       select: {
         ...DATASET_SELECT,
         contributorsCount: true,
@@ -119,7 +120,7 @@ export default async function FeaturedDatasetsPage({ params }: { params: Promise
       take: 6,
     }),
     prisma.dataset.findMany({
-      where: { isActive: true, dataCount: { gt: 0 } },
+      where: { isActive: true, dataCount: { gt: 0 }, ...CATALOG_FILTER },
       select: {
         ...DATASET_SELECT,
         _count: {

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { CATALOG_FILTER } from "@/lib/dataset-catalog-filter";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { formatRelativeTime } from "@/lib/dataset-stats";
@@ -68,7 +69,7 @@ export default async function RecentlyEditedPage({
   const t = await getTranslations("ExplorePage");
 
   const datasets = await prisma.dataset.findMany({
-    where: { isActive: true, dataCount: { gt: 0 }, lastEditedAt: { not: null } },
+    where: { isActive: true, dataCount: { gt: 0 }, lastEditedAt: { not: null }, ...CATALOG_FILTER },
     select: {
       ...DATASET_SELECT,
       recentlyEditedCount: true,

--- a/src/lib/dataset-catalog-filter.ts
+++ b/src/lib/dataset-catalog-filter.ts
@@ -7,5 +7,5 @@
  * or watched by at least one user.
  */
 export const CATALOG_FILTER = {
-  OR: [{ isFeatured: true }, { watchers: { some: {} } }],
+  AND: [{ OR: [{ isFeatured: true }, { watchers: { some: {} } }] }],
 };

--- a/src/lib/dataset-catalog-filter.ts
+++ b/src/lib/dataset-catalog-filter.ts
@@ -1,0 +1,11 @@
+/**
+ * Catalog filter for dataset listings.
+ *
+ * Visiting a dataset page caches the row (area + dataset) via getOrCreateDataset.
+ * Cache rows must not surface in any listing — only datasets that are explicitly
+ * cataloged should appear. A dataset is cataloged when it is either admin-featured
+ * or watched by at least one user.
+ */
+export const CATALOG_FILTER = {
+  OR: [{ isFeatured: true }, { watchers: { some: {} } }],
+};


### PR DESCRIPTION
## Summary
- Adds `CATALOG_FILTER` (`isFeatured: true OR watchers.some: {}`) and applies it to the Recently edited, Most contributors, and Largest queries on `/explore` and their sub-pages.
- Adds a strict `watchers: { some: {} }` filter to Most watched (landing section + sub-page) so cache-only rows with 0 watchers don't leak in.
- Adds `src/lib/dataset-catalog-filter.ts` as the single source of truth for the catalog predicate.

Visiting a dataset page continues to cache the row via `getOrCreateDataset` — that behavior is unchanged. Cache rows simply stop appearing in listings unless they're explicitly featured (admin) or watched (user).

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint` (0 errors, pre-existing warnings only)
- [x] `pnpm i18n:check`
- [x] `pnpm test:unit --run` (190 passing; 2 integration test files fail on missing port-5433 test DB — pre-existing, unrelated)
- [x] Manual: visit `/area/62422/dataset/hospitals` → cached but hidden on `/explore`, `/explore/recently-edited`, `/explore/largest`, `/explore/most-contributors`, `/explore/most-watched`
- [x] Manual: after watching hospitals → appears in all four filtered sections and their sub-pages
- [x] Manual: `/area/[id]` template catalog unchanged
