### PR TITLE
ci(deploy): remove CF-blocked post-deploy health checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,38 +113,6 @@ jobs:
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key deploy@${{ steps.target.outputs.host }} \
             ./deploy-wrapper.sh ${{ steps.target.outputs.branch }}
 
-      - name: Health check - staging
-        if: steps.target.outputs.environment == 'staging'
-        run: |
-          for i in {1..30}; do
-            if curl -f -s -o /dev/null -w "%{http_code}" https://staging.osmforcities.org/ | grep -E "^(200|307)$" > /dev/null; then
-              echo "✅ Staging health check passed"
-              break
-            fi
-            if [ $i -eq 30 ]; then
-              echo "❌ Staging health check failed after 30 attempts"
-              exit 1
-            fi
-            echo "⏳ Waiting for staging to be ready... ($i/30)"
-            sleep 10
-          done
-
-      - name: Health check - production
-        if: steps.target.outputs.environment == 'production'
-        run: |
-          for i in {1..30}; do
-            if curl -f -s -o /dev/null -w "%{http_code}" https://osmforcities.org/ | grep -E "^(200|307)$" > /dev/null; then
-              echo "✅ Production health check passed"
-              break
-            fi
-            if [ $i -eq 30 ]; then
-              echo "❌ Production health check failed after 30 attempts"
-              exit 1
-            fi
-            echo "⏳ Waiting for production to be ready... ($i/30)"
-            sleep 10
-          done
-
       - name: Deployment summary
         run: |
           echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Related: infra#24 (Cloudflare origin protection)

**Problem:** After staging was fronted by Cloudflare (~2026-06-20), `deploy.yml` runs started failing — but only the post-deploy HTTP health-check steps, not the deploy itself. The checks curl the public hostname (`https://staging.osmforcities.org/`), which now resolves to Cloudflare; CF returns a non-200/307 (bot challenge) to GitHub Actions runner (datacenter) IPs, while residential IPs get a healthy 307. Pre-CF runs passed; post-CF runs failed all 30 retries.

**Acceptance Criteria:**
- [x] Staging deploys no longer fail at the post-deploy health check
- [x] App-health verification is not lost

**Changes:**
Removed the `Health check - staging` and `Health check - production` steps from `.github/workflows/deploy.yml`. Deploy success/failure is now decided solely by `deploy-wrapper.sh`'s exit code, which already runs an in-deploy localhost health check (`curl http://127.0.0.1:3000/`) that fails the deploy if the app is unhealthy. The removed external check was redundant for app health; the external-through-CF reachability it tested is better served by dedicated uptime monitoring (out of scope here).
