### PR TITLE
perf(area): cache active templates query by locale

### DIFF
--- a/src/lib/area-templates.ts
+++ b/src/lib/area-templates.ts
@@ -1,5 +1,6 @@
+import { unstable_cache } from "next/cache";
 import { prisma } from "@/lib/db";
-import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { mapAppLocaleToDb, resolveTemplateForLocale } from "@/lib/template-locale";
 
 export type AreaTemplate = {
   id: string;
@@ -120,13 +121,8 @@ export async function getAreaDataTypes(
   return buildAreaDataTypes(templates, datasets);
 }
 
-/**
- * Fetch all active templates resolved for the given locale.
- * Shared by the area page and the area templates browse page.
- */
-export async function getActiveTemplates(
-  locale: string
-): Promise<AreaTemplate[]> {
+async function fetchActiveTemplates(locale: string): Promise<AreaTemplate[]> {
+  const dbLocale = mapAppLocaleToDb(locale);
   const rows = await prisma.template.findMany({
     where: { isActive: true },
     select: {
@@ -141,7 +137,10 @@ export async function getActiveTemplates(
           slug: true,
         },
       },
+      // Only fetch the translation for the requested locale — resolveTemplateForLocale
+      // picks the matching row (now the only one) and falls back to the base fields.
       translations: {
+        where: { locale: dbLocale },
         select: {
           locale: true,
           name: true,
@@ -164,3 +163,17 @@ export async function getActiveTemplates(
     };
   });
 }
+
+/**
+ * All active templates resolved for the given locale. Shared by the area page
+ * and the area templates browse page.
+ *
+ * Area-independent and varies only by locale (the cache key), so the result is
+ * cached instead of re-querying all active templates per load. Revalidates
+ * hourly; bust the "templates" tag to refresh sooner.
+ */
+export const getActiveTemplates = unstable_cache(
+  fetchActiveTemplates,
+  ["active-templates"],
+  { revalidate: 3600, tags: ["templates"] }
+);


### PR DESCRIPTION
## Issue #331: perf(area): make area page ISR-cached (drop searchParams + server-side auth)

**Problem:** The area page re-runs the heavy `getActiveTemplates` query (all active templates + their translations) on every request. `revalidate = 3600` is ineffective because the route renders dynamically.

**Acceptance Criteria:**
- [x] Heavy template query no longer runs on every area-page load
- [x] Translations resolve correctly per locale (en base names, pt-BR translations)

**Changes:**
Scoped this PR to caching the data layer rather than flipping the whole route to ISR-static.

- Wrap `getActiveTemplates` in `unstable_cache`, keyed by locale (`revalidate: 3600`, tag `"templates"`). The area-independent query now runs ~once per locale per hour instead of every load.
- Scope the `translations` sub-query to the requested locale (`where: { locale }`) instead of fetching all locales and resolving in JS — smaller payload, same result via `resolveTemplateForLocale` fallback.

Notes:
- `searchParams` was already removed in the #330 redesign — nothing to do there.
- NavBar's server-side `auth()` was investigated and confirmed NOT to block static generation (`/explore` and home are SSG with the same NavBar), so no nav refactor was needed. The area route stays dynamic (its own `auth()`/analytics), but the expensive work is now cached.

Verified: type-check, lint, i18n:check, build all pass. Runtime check on dev server: pt-BR renders translated names, en renders base names with no translation leakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved loading of active area templates by caching results, which should make repeated visits faster.
* **Bug Fixes**
  * Updated template selection to better match the current app language, helping ensure users see the correct localized content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->