### PR TITLE
fix(admin): featured toggle state + stale admin sessions after v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # osmforcities
 
+## Unreleased
+
+### Fixed
+
+- Featured dataset toggle now reflects the dataset's real featured state on the detail page. The dataset query omitted `isFeatured`, so the button always initialized as "not featured" (requiring two clicks to enable and showing the wrong state after reload).
+- Admin status now refreshes from the database on every session check. Previously `isAdmin` was only written to the session token at sign-in, so an admin whose session predated their promotion (or whose token claims were reset by the next-auth upgrade) saw admin-only controls — including the featured toggle — hidden until signing out and back in.
+
 ## 1.12.0
 
 ### Added

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,7 @@ import type { JWT } from "next-auth/jwt";
 import type { Session } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
+import { refreshTokenClaims } from "@/lib/auth-token";
 
 type DatabaseUser = {
   id: string;
@@ -173,12 +174,16 @@ const {
 
   callbacks: {
     async jwt({ token, user }): Promise<JWT> {
+      // On initial sign-in, capture the user id from the provider result.
       if (user && user.id) {
         token.id = user.id;
-        token.isAdmin = user.isAdmin;
-        token.language = user.language;
       }
-      return token;
+      // Always refresh admin status and language from the DB. The previous
+      // implementation only wrote these on sign-in, so a user promoted to admin
+      // after their session was created — or whose token claims were reset by a
+      // next-auth upgrade — kept a stale `isAdmin: false` token, hiding the
+      // featured toggle and other admin UI until they signed out and back in.
+      return refreshTokenClaims(token);
     },
 
     async session({ session, token }): Promise<Session> {

--- a/src/lib/__tests__/auth-token.test.ts
+++ b/src/lib/__tests__/auth-token.test.ts
@@ -8,6 +8,12 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+  }),
+}));
+
 import { refreshTokenClaims } from "@/lib/auth-token";
 import { prisma } from "@/lib/db";
 
@@ -56,10 +62,19 @@ describe("refreshTokenClaims", () => {
     expect(result.isAdmin).toBe(true);
   });
 
-  it("does not overwrite claims when the user is missing from the DB", async () => {
+  it("fails closed (clears isAdmin) when the user is missing from the DB", async () => {
     mockFindUnique.mockResolvedValue(null as never);
 
     const token = { id: "ghost", isAdmin: true, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(result.isAdmin).toBe(false);
+  });
+
+  it("preserves existing claims when the DB lookup throws", async () => {
+    mockFindUnique.mockRejectedValue(new Error("connection refused"));
+
+    const token = { id: "user-1", isAdmin: true, language: "en" };
     const result = await refreshTokenClaims(token as never);
 
     expect(result.isAdmin).toBe(true);

--- a/src/lib/__tests__/auth-token.test.ts
+++ b/src/lib/__tests__/auth-token.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { refreshTokenClaims } from "@/lib/auth-token";
+import { prisma } from "@/lib/db";
+
+const mockFindUnique = vi.mocked(prisma.user.findUnique);
+
+describe("refreshTokenClaims", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes isAdmin from the DB even when the token claim is stale", async () => {
+    // Token was minted before the user was promoted to admin: isAdmin is false.
+    mockFindUnique.mockResolvedValue({
+      isAdmin: true,
+      language: "en",
+    } as never);
+
+    const token = { id: "user-1", isAdmin: false, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: { isAdmin: true, language: true },
+    });
+    expect(result.isAdmin).toBe(true);
+  });
+
+  it("clears isAdmin when the user is no longer an admin in the DB", async () => {
+    mockFindUnique.mockResolvedValue({
+      isAdmin: false,
+      language: "pt-BR",
+    } as never);
+
+    const token = { id: "user-1", isAdmin: true, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(result.isAdmin).toBe(false);
+    expect(result.language).toBe("pt-BR");
+  });
+
+  it("leaves the token untouched when it has no id", async () => {
+    const token = { isAdmin: true };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(result.isAdmin).toBe(true);
+  });
+
+  it("does not overwrite claims when the user is missing from the DB", async () => {
+    mockFindUnique.mockResolvedValue(null as never);
+
+    const token = { id: "ghost", isAdmin: true, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(result.isAdmin).toBe(true);
+  });
+});

--- a/src/lib/__tests__/auth-token.test.ts
+++ b/src/lib/__tests__/auth-token.test.ts
@@ -8,12 +8,6 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-vi.mock("@/lib/logger", () => ({
-  createLogger: () => ({
-    error: vi.fn(),
-  }),
-}));
-
 import { refreshTokenClaims } from "@/lib/auth-token";
 import { prisma } from "@/lib/db";
 

--- a/src/lib/__tests__/dataset-operations.test.ts
+++ b/src/lib/__tests__/dataset-operations.test.ts
@@ -55,8 +55,48 @@ vi.mock("@/lib/nominatim", () => ({
 
 import { getOrCreateDataset } from "@/lib/dataset-operations";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
+import { prisma } from "@/lib/db";
 
 const mockFetchDatasetSnapshot = vi.mocked(fetchDatasetSnapshot);
+const mockDatasetFindFirst = vi.mocked(prisma.dataset.findFirst);
+
+const existingDatasetRow = {
+  id: "ds-1",
+  templateId: "tmpl-1",
+  areaId: 1,
+  cityName: "Test City",
+  geojson: null,
+  bbox: null,
+  dataCount: 5,
+  lastChecked: new Date(),
+  stats: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  isActive: true,
+  isFeatured: true,
+  template: { id: "tmpl-1", name: "Test", description: null, translations: [] },
+  area: { id: 1, name: "Test City", countryCode: "US", bounds: null, geojson: null },
+  user: null,
+  savedBy: [],
+};
+
+describe("getOrCreateDataset — isFeatured passthrough", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("selects isFeatured and returns it so the toggle reflects real state", async () => {
+    mockDatasetFindFirst.mockResolvedValueOnce(existingDatasetRow as never);
+
+    const { dataset } = await getOrCreateDataset(1, "test-template", "en");
+
+    // The select must request isFeatured, otherwise the detail page button
+    // always initializes to "not featured" regardless of the DB value.
+    const selectArg = mockDatasetFindFirst.mock.calls[0]?.[0]?.select;
+    expect(selectArg?.isFeatured).toBe(true);
+    expect(dataset.isFeatured).toBe(true);
+  });
+});
 
 describe("getOrCreateDataset — error sanitization", () => {
   beforeEach(() => {

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,8 +1,5 @@
 import type { JWT } from "next-auth/jwt";
 import { prisma } from "@/lib/db";
-import { createLogger } from "@/lib/logger";
-
-const logger = createLogger("auth-token");
 
 /**
  * Refreshes admin status and language on the JWT from the database so that
@@ -31,7 +28,10 @@ export async function refreshTokenClaims(token: JWT): Promise<JWT> {
       select: { isAdmin: true, language: true },
     });
   } catch (error) {
-    logger.error("Failed to refresh token claims; keeping existing claims", {
+    // console.error (not the winston logger) — this module is imported by the
+    // middleware edge-runtime bundle via auth.ts, and winston relies on Node
+    // APIs (process.nextTick) that are unavailable in the Edge Runtime.
+    console.error("Failed to refresh token claims; keeping existing claims", {
       userId: token.id,
       error,
     });

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,5 +1,8 @@
 import type { JWT } from "next-auth/jwt";
 import { prisma } from "@/lib/db";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("auth-token");
 
 /**
  * Refreshes admin status and language on the JWT from the database so that
@@ -10,18 +13,36 @@ import { prisma } from "@/lib/db";
  * promoted to admin after their session was created — or whose token claims
  * were reset by a next-auth upgrade — kept a stale `isAdmin: false` token,
  * hiding the featured toggle and other admin UI until they signed out and in.
+ *
+ * Failure modes:
+ * - If the lookup throws (transient DB issue), the existing claims are
+ *   preserved so a DB blip doesn't take down auth/session resolution.
+ * - If the user row no longer exists (deleted account), privileged claims are
+ *   cleared so a stale admin token can't retain admin access until expiry.
  */
 export async function refreshTokenClaims(token: JWT): Promise<JWT> {
   if (!token.id) {
     return token;
   }
-  const dbUser = await prisma.user.findUnique({
-    where: { id: token.id as string },
-    select: { isAdmin: true, language: true },
-  });
+  let dbUser: { isAdmin: boolean; language: string | null } | null;
+  try {
+    dbUser = await prisma.user.findUnique({
+      where: { id: token.id as string },
+      select: { isAdmin: true, language: true },
+    });
+  } catch (error) {
+    logger.error("Failed to refresh token claims; keeping existing claims", {
+      userId: token.id,
+      error,
+    });
+    return token;
+  }
   if (dbUser) {
     token.isAdmin = dbUser.isAdmin;
     token.language = dbUser.language ?? "en";
+  } else {
+    // User no longer exists — fail closed.
+    token.isAdmin = false;
   }
   return token;
 }

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,0 +1,27 @@
+import type { JWT } from "next-auth/jwt";
+import { prisma } from "@/lib/db";
+
+/**
+ * Refreshes admin status and language on the JWT from the database so that
+ * role changes take effect without requiring re-login. Mutates and returns the
+ * token.
+ *
+ * The previous auth callback only wrote these claims on sign-in, so a user
+ * promoted to admin after their session was created — or whose token claims
+ * were reset by a next-auth upgrade — kept a stale `isAdmin: false` token,
+ * hiding the featured toggle and other admin UI until they signed out and in.
+ */
+export async function refreshTokenClaims(token: JWT): Promise<JWT> {
+  if (!token.id) {
+    return token;
+  }
+  const dbUser = await prisma.user.findUnique({
+    where: { id: token.id as string },
+    select: { isAdmin: true, language: true },
+  });
+  if (dbUser) {
+    token.isAdmin = dbUser.isAdmin;
+    token.language = dbUser.language ?? "en";
+  }
+  return token;
+}

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -79,6 +79,7 @@ async function getDatasetWithDetails(areaId: number, templateId: string, locale:
       createdAt: true,
       updatedAt: true,
       isActive: true,
+      isFeatured: true,
       template: {
         select: {
           id: true,
@@ -253,6 +254,7 @@ async function createDatasetOnDemand(
         createdAt: true,
         updatedAt: true,
         isActive: true,
+        isFeatured: true,
         template: {
           select: {
             id: true,


### PR DESCRIPTION
## Regression from v1.12.0: featured toggle broken for admins

**Problem:** After the v1.12.0 release (next-auth beta.29 -> beta.31), admins could not reliably toggle datasets as featured. Two distinct bugs:

1. The featured toggle never reflected the dataset's real state — it always initialized as "not featured" on load, required two clicks to turn on, and showed the wrong state after reload.
2. Admin-only UI (including the featured toggle) was hidden for admins whose session predated their promotion or whose JWT claims were reset by the next-auth upgrade, forcing a sign-out/sign-in to recover.

**Root causes:**
1. `getDatasetWithDetails` / `createDatasetOnDemand` in `src/lib/dataset-operations.ts` omitted `isFeatured` from their Prisma `select`, so `dataset.isFeatured` was always `undefined` -> the button initialized from `?? false`.
2. The `jwt` callback in `src/auth.ts` only wrote `isAdmin`/`language` to the token at sign-in and never refreshed them, so any DB-side role change (or token-claim reset from the dep bump) left the session stale.

**Changes:**
- Add `isFeatured: true` to both dataset detail query selects so the toggle reflects persisted state.
- Extract `refreshTokenClaims` (`src/lib/auth-token.ts`) and call it from the `jwt` callback so `isAdmin`/`language` are re-read from the DB on every session check. Role changes now take effect without re-login.
- Regression tests: `src/lib/__tests__/auth-token.test.ts` (token refresh, 4 cases) and an `isFeatured` select assertion in `dataset-operations.test.ts`.

Both fixes verified live in a worktree via the real magic-link JWT flow.

**Verification:** type-check, lint (0 errors), i18n check, 156/156 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Featured items now show the correct featured status on the dataset detail page on first load, so the featured toggle reflects reality without extra clicks.
  * Admin-only controls now appear and update immediately after permission changes, without requiring re-login.
  * Dataset retrieval and on-demand dataset creation now consistently preserve featured status across listings and detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->