### PR TITLE
fix(analytics): await umami events + track sign_in/sign_out/featured

### DIFF
--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
-import { after } from "next/server";
 import { getTranslations, getLocale } from "next-intl/server";
 import { transformDataset } from "@/lib/dataset/transform";
 import { DatasetInteractiveSection } from "@/components/dataset/dataset-interactive-section";
@@ -23,7 +22,7 @@ import { DatasetUpsellPage } from "@/components/dataset/dataset-upsell-page";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import type { TranslationFunction } from "@/lib/types";
-import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
+import { trackEventAfterResponse } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 import { MAX_SAVES_PER_USER } from "@/lib/constants";
@@ -64,13 +63,9 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
       return <AreaNotFoundError areaId={areaId} />;
     }
 
-    const upsellClientInfo = await getClientInfoFromHeaders();
-    after(() =>
-      trackEvent(
-        ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
-        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
-        upsellClientInfo,
-      ),
+    await trackEventAfterResponse(
+      ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
+      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
     );
 
     return (
@@ -134,13 +129,9 @@ async function AreaTemplateDatasetView({
 
     const dataset = transformDataset(result.dataset, session?.user || null, locale, { isSaved, skipTemplateResolution: true });
 
-    const detailClientInfo = await getClientInfoFromHeaders();
-    after(() =>
-      trackEvent(
-        ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
-        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
-        detailClientInfo,
-      ),
+    await trackEventAfterResponse(
+      ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
+      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
     );
 
     const areaName = areaInfo?.name || dataset.area.name;

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
+import { after } from "next/server";
 import { getTranslations, getLocale } from "next-intl/server";
 import { transformDataset } from "@/lib/dataset/transform";
 import { DatasetInteractiveSection } from "@/components/dataset/dataset-interactive-section";
@@ -63,10 +64,13 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
       return <AreaNotFoundError areaId={areaId} />;
     }
 
-    trackEvent(
-      ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
-      await getClientInfoFromHeaders()
+    const upsellClientInfo = await getClientInfoFromHeaders();
+    after(() =>
+      trackEvent(
+        ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
+        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
+        upsellClientInfo,
+      ),
     );
 
     return (
@@ -130,10 +134,13 @@ async function AreaTemplateDatasetView({
 
     const dataset = transformDataset(result.dataset, session?.user || null, locale, { isSaved, skipTemplateResolution: true });
 
-    trackEvent(
-      ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
-      await getClientInfoFromHeaders()
+    const detailClientInfo = await getClientInfoFromHeaders();
+    after(() =>
+      trackEvent(
+        ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
+        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
+        detailClientInfo,
+      ),
     );
 
     const areaName = areaInfo?.name || dataset.area.name;

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { after } from "next/server";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { getAreaDataTypes } from "@/lib/area-templates";
@@ -36,12 +37,15 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
     notFound();
   }
 
-  trackEvent(
-    session?.user
-      ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
-      : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
-    `/area/${areaId}/view`,
-    await getClientInfoFromHeaders()
+  const areaClientInfo = await getClientInfoFromHeaders();
+  after(() =>
+    trackEvent(
+      session?.user
+        ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
+        : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
+      `/area/${areaId}/view`,
+      areaClientInfo,
+    ),
   );
 
   const breadcrumbItems = [

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -1,11 +1,10 @@
 import { notFound } from "next/navigation";
-import { after } from "next/server";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { getAreaDataTypes } from "@/lib/area-templates";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
 import { DatasetGrid } from "@/components/ui/template-grid";
-import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
+import { trackEventAfterResponse } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { auth } from "@/auth";
 
@@ -37,15 +36,11 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
     notFound();
   }
 
-  const areaClientInfo = await getClientInfoFromHeaders();
-  after(() =>
-    trackEvent(
-      session?.user
-        ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
-        : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
-      `/area/${areaId}/view`,
-      areaClientInfo,
-    ),
+  await trackEventAfterResponse(
+    session?.user
+      ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
+      : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
+    `/area/${areaId}/view`,
   );
 
   const breadcrumbItems = [

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Metadata } from "next";
+import { after } from "next/server";
 import { auth } from "@/auth";
 import { redirect } from "@/i18n/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
@@ -55,7 +56,10 @@ export default async function Dashboard() {
   const tabT = await getTranslations("TabLayout");
   const savedDatasets = await getSavedDatasets(user.id);
 
-  trackEvent(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view", await getClientInfoFromHeaders());
+  const dashClientInfo = await getClientInfoFromHeaders();
+  after(() =>
+    trackEvent(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view", dashClientInfo),
+  );
 
   return (
     <div className="min-h-screen bg-white dark:bg-black">

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -4,14 +4,13 @@
  */
 
 import { Metadata } from "next";
-import { after } from "next/server";
 import { auth } from "@/auth";
 import { redirect } from "@/i18n/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
 import { prisma } from "@/lib/db";
 import { DashboardGrid } from "@/components/dashboard/dashboard-grid";
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
-import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
+import { trackEventAfterResponse } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { MAX_SAVES_PER_USER } from "@/lib/constants";
 
@@ -56,10 +55,7 @@ export default async function Dashboard() {
   const tabT = await getTranslations("TabLayout");
   const savedDatasets = await getSavedDatasets(user.id);
 
-  const dashClientInfo = await getClientInfoFromHeaders();
-  after(() =>
-    trackEvent(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view", dashClientInfo),
-  );
+  await trackEventAfterResponse(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view");
 
   return (
     <div className="min-h-screen bg-white dark:bg-black">

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,12 +1,12 @@
-import { NextRequest, NextResponse, after } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { signOut } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
-import { trackEvent, getClientInfo } from "@/lib/umami";
+import { trackEventAfterRequest } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
-  after(() => trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request)));
+  trackEventAfterRequest(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", request);
   await signOut({ redirect: false });
   return NextResponse.redirect(new URL("/", baseUrl));
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { signOut } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
 import { trackEvent, getClientInfo } from "@/lib/umami";
@@ -6,7 +6,7 @@ import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
-  await trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request));
+  after(() => trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request)));
   await signOut({ redirect: false });
   return NextResponse.redirect(new URL("/", baseUrl));
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { signOut } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
+import { trackEvent, getClientInfo } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
+  await trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request));
   await signOut({ redirect: false });
   return NextResponse.redirect(new URL("/", baseUrl));
 }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -24,7 +24,9 @@ export async function GET(request: NextRequest) {
     }
 
     if (!verificationResult.user.emailVerified) {
-      trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up", getClientInfo(request));
+      await trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up", getClientInfo(request));
+    } else {
+      await trackEvent(ANALYTICS_EVENTS.SIGN_IN, "/sign-in", getClientInfo(request));
     }
 
     await prisma.user.update({

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -27,7 +27,7 @@ export async function GET(
       );
     }
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request));
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { prisma } from "@/lib/db";
 import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -27,7 +27,7 @@ export async function GET(
       );
     }
 
-    await trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request));
+    after(() => trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request)));
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse, after } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { trackEvent, getClientInfo } from "@/lib/umami";
+import { trackEventAfterRequest } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(
@@ -27,7 +27,7 @@ export async function GET(
       );
     }
 
-    after(() => trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request)));
+    trackEventAfterRequest(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, _request);
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/auth";
+import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function PUT(
   request: Request,
@@ -40,6 +42,12 @@ export async function PUT(
     }
 
     const [result] = rows;
+    await trackEvent(
+      result.isFeatured
+        ? ANALYTICS_EVENTS.DATASET_FEATURED
+        : ANALYTICS_EVENTS.DATASET_UNFEATURED,
+      `/datasets/${result.id}/feature`,
+    );
     return NextResponse.json({ id: result.id, isFeatured: result.isFeatured });
   } catch (error) {
     console.error("Error toggling featured status:", error);

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -85,7 +85,7 @@ export async function POST(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`, getClientInfo(request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`, getClientInfo(request));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/datasets/[id]/save/route.ts
+++ b/src/app/api/datasets/[id]/save/route.ts
@@ -66,7 +66,7 @@ export async function POST(
       );
     }
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_SAVE, `/datasets/${datasetId}/save`, getClientInfo(request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_SAVE, `/datasets/${datasetId}/save`, getClientInfo(request));
 
     return NextResponse.json({ success: true, save });
   } catch (error) {
@@ -119,7 +119,7 @@ export async function DELETE(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_UNSAVE, `/datasets/${datasetId}/unsave`, getClientInfo(request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_UNSAVE, `/datasets/${datasetId}/unsave`, getClientInfo(request));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -88,7 +88,7 @@ export async function POST(req: NextRequest) {
       include: { template: true },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`, getClientInfo(req));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`, getClientInfo(req));
 
     return NextResponse.json(dataset, { status: 201 });
   } catch (err) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -81,7 +81,7 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
+        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
 
         results.successful++;
       } catch (error) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { prisma } from "@/lib/db";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { trackEvent } from "@/lib/umami";
@@ -81,7 +81,7 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
+        after(() => trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`));
 
         results.successful++;
       } catch (error) {

--- a/src/lib/__tests__/umami.test.ts
+++ b/src/lib/__tests__/umami.test.ts
@@ -51,15 +51,15 @@ describe("trackEvent", () => {
     vi.restoreAllMocks();
   });
 
-  it("does nothing when env vars are absent", () => {
+  it("does nothing when env vars are absent", async () => {
     delete process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
-    trackEvent("test_event", "/test");
+    await trackEvent("test_event", "/test");
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it("sends POST to /api/send with event payload", async () => {
-    trackEvent("dataset_create", "/datasets/123/create");
-    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    await trackEvent("dataset_create", "/datasets/123/create");
+    expect(fetch).toHaveBeenCalledOnce();
 
     const [url, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(url).toBe("https://analytics.example.com/api/send");
@@ -70,13 +70,17 @@ describe("trackEvent", () => {
 
   it("forwards ip and userAgent as headers when clientInfo provided", async () => {
     const clientInfo: ClientInfo = { ip: "1.2.3.4", userAgent: "TestAgent/1" };
-    trackEvent("sign_up", "/sign-up", clientInfo);
-    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    await trackEvent("sign_up", "/sign-up", clientInfo);
 
     const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect((opts as RequestInit).headers).toMatchObject({
       "x-forwarded-for": "1.2.3.4",
       "user-agent": "TestAgent/1",
     });
+  });
+
+  it("never rejects when fetch fails (tracking must not break user flows)", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+    await expect(trackEvent("dataset_save", "/datasets/1/save")).resolves.toBeUndefined();
   });
 });

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -13,9 +13,13 @@ export const ANALYTICS_EVENTS = {
   DATASET_REFRESH: "dataset_refresh",
   DATASET_REFRESH_JOB: "dataset_refresh_job",
   DATASET_UPSELL_VIEW: "dataset_upsell_view",
+  DATASET_FEATURED: "dataset_featured",
+  DATASET_UNFEATURED: "dataset_unfeatured",
 
   // User events
   SIGN_UP: "sign_up",
+  SIGN_IN: "sign_in",
+  SIGN_OUT: "sign_out",
   SAVED_DATASETS_VIEW: "saved_datasets_view",
 
   // Area events

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -301,7 +301,7 @@ async function createDatasetOnDemand(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`);
+    await trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`);
 
     // Resolve template translations for the given locale
     const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -41,11 +41,15 @@ export async function getClientInfoFromHeaders(): Promise<ClientInfo> {
   };
 }
 
-export function trackEvent(
+// Awaited so callers (server components via `after()`, API routes, background
+// jobs) can ensure the request completes before the response/render finishes —
+// a detached fetch would be reaped by the runtime and the event silently lost.
+// Never rejects: failures are logged so tracking can never break a user flow.
+export async function trackEvent(
   eventName: string,
   url: string,
   clientInfo?: ClientInfo,
-): void {
+): Promise<void> {
   const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
   const umamiUrl = process.env.NEXT_PUBLIC_UMAMI_URL;
 
@@ -58,32 +62,32 @@ export function trackEvent(
   if (clientInfo?.ip) fetchHeaders["x-forwarded-for"] = clientInfo.ip;
   if (clientInfo?.userAgent) fetchHeaders["user-agent"] = clientInfo.userAgent;
 
-  fetch(`${umamiUrl}/api/send`, {
-    method: "POST",
-    headers: fetchHeaders,
-    body: JSON.stringify({
-      type: "event",
-      payload: {
-        website: websiteId,
-        url,
-        name: eventName,
-        hostname: process.env.NEXT_PUBLIC_APP_URL
-          ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
-          : "",
-        language: clientInfo?.language ?? "",
-        referrer: clientInfo?.referrer ?? "",
-      },
-    }),
-  })
-    .then(async (res) => {
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({ status: res.status }));
-        logger.warn("Umami event failed", { event: eventName, status: res.status, data });
-      } else {
-        logger.debug("Umami event sent", { event: eventName, url });
-      }
-    })
-    .catch((err) => {
-      logger.warn("Umami event error", { event: eventName, err });
+  try {
+    const res = await fetch(`${umamiUrl}/api/send`, {
+      method: "POST",
+      headers: fetchHeaders,
+      body: JSON.stringify({
+        type: "event",
+        payload: {
+          website: websiteId,
+          url,
+          name: eventName,
+          hostname: process.env.NEXT_PUBLIC_APP_URL
+            ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
+            : "",
+          language: clientInfo?.language ?? "",
+          referrer: clientInfo?.referrer ?? "",
+        },
+      }),
     });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({ status: res.status }));
+      logger.warn("Umami event failed", { event: eventName, status: res.status, data });
+    } else {
+      logger.info("Umami event sent", { event: eventName, url });
+    }
+  } catch (err) {
+    logger.warn("Umami event error", { event: eventName, err });
+  }
 }

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -96,11 +96,27 @@ export async function trackEvent(
 // Fire-and-forget tracking for server components/pages: captures request client
 // info during render, then schedules the event to run after the response is sent
 // so analytics never blocks the render. De-duplicates the capture+after+track
-// pattern repeated across pages.
+// pattern repeated across pages. Never rejects — a headers() failure is logged,
+// not propagated to the render.
 export async function trackEventAfterResponse(
   eventName: string,
   url: string,
 ): Promise<void> {
-  const clientInfo = await getClientInfoFromHeaders();
-  after(() => trackEvent(eventName, url, clientInfo));
+  try {
+    const clientInfo = await getClientInfoFromHeaders();
+    after(() => trackEvent(eventName, url, clientInfo));
+  } catch (err) {
+    logger.warn("trackEventAfterResponse error", { event: eventName, err });
+  }
+}
+
+// Fire-and-forget tracking for route handlers: schedules the event after the
+// response is sent using client info derived from the request. De-duplicates the
+// after(() => trackEvent(..., getClientInfo(req))) pattern across API routes.
+export function trackEventAfterRequest(
+  eventName: string,
+  url: string,
+  request: NextRequest,
+): void {
+  after(() => trackEvent(eventName, url, getClientInfo(request)));
 }

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,5 +1,5 @@
 import { headers } from "next/headers";
-import { NextRequest } from "next/server";
+import { NextRequest, after } from "next/server";
 import { logger } from "@/lib/logger";
 
 export type ClientInfo = {
@@ -41,10 +41,10 @@ export async function getClientInfoFromHeaders(): Promise<ClientInfo> {
   };
 }
 
-// Awaited so callers (server components via `after()`, API routes, background
-// jobs) can ensure the request completes before the response/render finishes —
-// a detached fetch would be reaped by the runtime and the event silently lost.
-// Never rejects: failures are logged so tracking can never break a user flow.
+// Best-effort, bounded by a 5s timeout, and never rejects: failures are logged
+// so tracking can never break a user flow. Await it only where the response can
+// wait; for user-facing routes/pages prefer `trackEventAfterResponse` (or wrap
+// in `after()`) so analytics never delays the response.
 export async function trackEvent(
   eventName: string,
   url: string,
@@ -66,6 +66,7 @@ export async function trackEvent(
     const res = await fetch(`${umamiUrl}/api/send`, {
       method: "POST",
       headers: fetchHeaders,
+      signal: AbortSignal.timeout(5000),
       body: JSON.stringify({
         type: "event",
         payload: {
@@ -90,4 +91,16 @@ export async function trackEvent(
   } catch (err) {
     logger.warn("Umami event error", { event: eventName, err });
   }
+}
+
+// Fire-and-forget tracking for server components/pages: captures request client
+// info during render, then schedules the event to run after the response is sent
+// so analytics never blocks the render. De-duplicates the capture+after+track
+// pattern repeated across pages.
+export async function trackEventAfterResponse(
+  eventName: string,
+  url: string,
+): Promise<void> {
+  const clientInfo = await getClientInfoFromHeaders();
+  after(() => trackEvent(eventName, url, clientInfo));
 }


### PR DESCRIPTION
## Custom Umami events were silently dropping

**Problem:** Custom analytics events (area views, saves, downloads, etc.) were not surfacing in Umami — including area-view events from direct page visits. Root cause: `trackEvent()` was fire-and-forget; the `fetch` to `/api/send` was never awaited and was reaped when the server response/render completed. Page-views survived only because they come from the Umami browser script.

**Acceptance Criteria:**
- [x] Custom events reliably reach Umami's `/api/send`
- [x] Returning-user sign-in and sign-out are tracked (were silent)
- [x] Admin featured-toggle is tracked
- [x] No regressions (type-check, lint, unit tests green)

**Changes:**
Reliability:
- `trackEvent`: now `async`, awaits the fetch, never rejects (try/catch), success log bumped `debug` → `info` so accepted events are visible in prod
- Server components (area, dashboard, dataset detail/upsell): track via `after()` from `next/server`
- API routes + cron (datasets create/refresh/save/unsave/export, verify, update-datasets): `await trackEvent` inline
- `getOrCreateDataset`: await its `dataset_create` (the on-demand view path is the only real create path — no client POSTs to `/api/datasets`)
- Tests updated to await directly; added a no-reject-on-failure case

New events:
- `sign_in` (returning-user login, verify else-branch — previously silent)
- `sign_out` (`auth/logout`)
- `dataset_featured` / `dataset_unfeatured` (admin feature PUT, value-driven)

Verified locally via a capture server: `area_view_logged_in` now reaches `/api/send` through `after()`. Two commits: reliability fix, then new events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Umami analytics events for sign-in/sign-out and dataset featured/unfeatured.
  * Expanded analytics coverage across views and dataset lifecycle actions (area, dashboard saved datasets, create, refresh, export, save/unsave, feature toggle).
* **Bug Fixes**
  * Improved analytics reliability by deferring tracking until after responses where appropriate and by consistently awaiting analytics in key endpoints.
  * Updated analytics helpers and tests to ensure failures (including rejected fetch) don’t disrupt normal app flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->