### PR TITLE
fix(analytics): geolocate server-side Umami events to the real visitor

### DIFF
--- a/src/lib/__tests__/umami.test.ts
+++ b/src/lib/__tests__/umami.test.ts
@@ -68,13 +68,13 @@ describe("trackEvent", () => {
     expect(body.payload.website).toBe("test-website-id");
   });
 
-  it("forwards ip and userAgent as headers when clientInfo provided", async () => {
+  it("forwards ip as x-umami-client-ip and userAgent as headers when clientInfo provided", async () => {
     const clientInfo: ClientInfo = { ip: "1.2.3.4", userAgent: "TestAgent/1" };
     await trackEvent("sign_up", "/sign-up", clientInfo);
 
     const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect((opts as RequestInit).headers).toMatchObject({
-      "x-forwarded-for": "1.2.3.4",
+      "x-umami-client-ip": "1.2.3.4",
       "user-agent": "TestAgent/1",
     });
   });

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -59,7 +59,7 @@ export async function trackEvent(
     "Content-Type": "application/json",
   };
 
-  if (clientInfo?.ip) fetchHeaders["x-forwarded-for"] = clientInfo.ip;
+  if (clientInfo?.ip) fetchHeaders["x-umami-client-ip"] = clientInfo.ip;
   if (clientInfo?.userAgent) fetchHeaders["user-agent"] = clientInfo.userAgent;
 
   try {


### PR DESCRIPTION
## Server-side Umami events geolocate to the server region

**Problem:** All server-side custom events (dataset create/save, sign-up, page views, etc.) show up in the analytics dashboard as originating from the server's location instead of the real visitor. The visitor IP was forwarded in a header that does not survive the request path to the analytics service, so it fell back to the server IP.

**Acceptance Criteria:**
- [ ] Server-side events geolocate to the real visitor
- [ ] Browser page-view geolocation unaffected
- [ ] Unit tests cover the forwarded header

**Changes:**
Forward the visitor IP under a dedicated `x-umami-client-ip` header (single value) that reaches the analytics service intact, instead of the previous header. Updated the unit test assertion accordingly.

Requires a matching analytics-server config change (handled in infra) to read this header; deployed to staging first for verification.

Unit tests pass (9/9), type-check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event tracking to send the client IP in the correct request header.
  * Continued to include the user agent while keeping other tracking behavior unchanged.
  * Adjusted automated coverage to match the updated header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->