### PR TITLE
fix(analytics): resolve city geolocation and reliably track downloads

### DIFF
--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { trackEventAfterRequest } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(
@@ -27,7 +27,14 @@ export async function GET(
       );
     }
 
-    trackEventAfterRequest(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, _request);
+    // Await inline (not after()): after() callbacks in this route handler were
+    // unreliable and the download event was dropped. Save/unsave await inline and
+    // land reliably; match that. The event fetch is bounded to 5s and never throws.
+    await trackEvent(
+      ANALYTICS_EVENTS.DATASET_DOWNLOAD,
+      `/datasets/${id}/download`,
+      getClientInfo(_request),
+    );
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 
 vi.mock("@/auth", () => ({
@@ -40,7 +41,7 @@ describe("PUT /api/datasets/[id]/feature", () => {
     const { auth } = await import("@/auth");
     vi.mocked(auth).mockResolvedValueOnce(null);
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/datasets/" + testDatasetId + "/feature",
       { method: "PUT" }
     );
@@ -55,7 +56,7 @@ describe("PUT /api/datasets/[id]/feature", () => {
   });
 
   it("should return 404 for non-existent dataset", async () => {
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/datasets/invalid-id/feature",
       { method: "PUT" }
     );
@@ -75,7 +76,7 @@ describe("PUT /api/datasets/[id]/feature", () => {
       select: { isFeatured: true },
     });
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/datasets/" + testDatasetId + "/feature",
       { method: "PUT" }
     );

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/auth";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function PUT(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -47,6 +47,7 @@ export async function PUT(
         ? ANALYTICS_EVENTS.DATASET_FEATURED
         : ANALYTICS_EVENTS.DATASET_UNFEATURED,
       `/datasets/${result.id}/feature`,
+      getClientInfo(request),
     );
     return NextResponse.json({ id: result.id, isFeatured: result.isFeatured });
   } catch (error) {

--- a/src/lib/__tests__/umami.test.ts
+++ b/src/lib/__tests__/umami.test.ts
@@ -79,6 +79,25 @@ describe("trackEvent", () => {
     });
   });
 
+  it("also sends ip and userAgent in the payload so Umami resolves full city", async () => {
+    const clientInfo: ClientInfo = { ip: "1.2.3.4", userAgent: "TestAgent/1" };
+    await trackEvent("sign_up", "/sign-up", clientInfo);
+
+    const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body.payload.ip).toBe("1.2.3.4");
+    expect(body.payload.userAgent).toBe("TestAgent/1");
+  });
+
+  it("omits ip/userAgent from payload when clientInfo is absent", async () => {
+    await trackEvent("dataset_refresh_job", "/datasets/refresh");
+
+    const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body.payload.ip).toBeUndefined();
+    expect(body.payload.userAgent).toBeUndefined();
+  });
+
   it("never rejects when fetch fails (tracking must not break user flows)", async () => {
     vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
     await expect(trackEvent("dataset_save", "/datasets/1/save")).resolves.toBeUndefined();

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -78,6 +78,13 @@ export async function trackEvent(
             : "",
           language: clientInfo?.language ?? "",
           referrer: clientInfo?.referrer ?? "",
+          // Pass the visitor IP/UA in the payload (not just headers): Umami runs a
+          // full MaxMind lookup on payload.ip and skips its provider-header
+          // shortcut, so server-side events resolve country + region + city
+          // (headers alone yielded country only). This is Umami's documented
+          // server-side tracking pattern.
+          ...(clientInfo?.ip ? { ip: clientInfo.ip } : {}),
+          ...(clientInfo?.userAgent ? { userAgent: clientInfo.userAgent } : {}),
         },
       }),
     });


### PR DESCRIPTION
## Analytics: server-side event geolocation and reliability

**Problem:**
- Server-side Umami events resolved only to country (e.g. "Portugal") and never to a city, even though the geo database resolves city fine. Umami runs a full geo-DB lookup only when the visitor IP is in the event payload; sending it via header alone made Umami take a country-only shortcut.
- `dataset_download` events were unreliable — tracking ran in a deferred post-response callback inside the route handler and the event was frequently dropped (absent on staging, intermittent on prod).
- Featured/unfeatured toggle events carried no visitor info, so they could not geolocate.

**Changes:**
- `trackEvent`: also include `ip` and `userAgent` in the event payload (Umami's documented server-side pattern), so events resolve country + region + city. Headers are still sent for backward compatibility.
- Download export route: replace the deferred post-response callback with an inline awaited `trackEvent` (bounded to 5s, never throws), matching the save/unsave routes that land reliably.
- Feature route: pass client info (switched `Request` -> `NextRequest`) so featured/unfeatured toggles are attributed to the visitor.
- Tests: assert payload now carries `ip`/`userAgent` and is omitted when absent; update feature route test mocks to `NextRequest`.

**Verification:**
- `pnpm type-check` clean; `umami.test.ts` 11/11 pass.
- End-to-end city + event verification to be confirmed on staging before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downloading dataset GeoJSON and toggling featured datasets now capture richer request details for more reliable analytics.
* **Bug Fixes**
  * Fixed analytics logging for dataset GeoJSON downloads so events are recorded more consistently.
  * Improved handling of dataset feature updates by using a request type that works better with these API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->