### PR TITLE
feat(dataset): restrict manual refresh to admins, show last-fetched time

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -174,6 +174,8 @@
     "basicInfo": "Basic Information",
     "refreshData": "Refresh Data",
     "refreshing": "Refreshing...",
+    "dataFetched": "Data fetched {time}",
+    "dataNotFetched": "Data not yet fetched",
     "save": "Save",
     "unsave": "Unsave",
     "saveTooltip": "Save to revisit later",

--- a/messages/es.json
+++ b/messages/es.json
@@ -173,6 +173,8 @@
     "basicInfo": "Información Básica",
     "refreshData": "Actualizar Datos",
     "refreshing": "Actualizando...",
+    "dataFetched": "Datos obtenidos {time}",
+    "dataNotFetched": "Datos aún no obtenidos",
     "save": "Guardar",
     "unsave": "Quitar",
     "saveTooltip": "Guardar para visitar más tarde",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -173,6 +173,8 @@
     "basicInfo": "Informações Básicas",
     "refreshData": "Atualizar Dados",
     "refreshing": "Atualizando...",
+    "dataFetched": "Dados obtidos {time}",
+    "dataNotFetched": "Dados ainda não obtidos",
     "save": "Salvar",
     "unsave": "Remover",
     "saveTooltip": "Salvar para visitar depois",

--- a/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: { dataset: { findUnique: vi.fn() } },
+}));
+
+import { POST } from "../route";
+
+type Session = Awaited<ReturnType<typeof auth>>;
+
+const session = (isAdmin: boolean | null): Session =>
+  isAdmin === null
+    ? null
+    : ({
+        user: { id: "user-1", email: "user@test.com", isAdmin },
+      } as unknown as Session);
+
+const call = () =>
+  POST(
+    new NextRequest("http://localhost:3000/api/datasets/does-not-exist/refresh", {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: "does-not-exist" }) }
+  );
+
+describe("POST /api/datasets/[id]/refresh", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.dataset.findUnique).mockResolvedValue(null);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(auth).mockResolvedValueOnce(session(null));
+    const res = await call();
+    expect(res.status).toBe(401);
+    expect(prisma.dataset.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-admin users (no dataset lookup)", async () => {
+    vi.mocked(auth).mockResolvedValueOnce(session(false));
+    const res = await call();
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("Forbidden");
+    expect(prisma.dataset.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("lets admins past the gate to the dataset lookup (404 for a missing dataset)", async () => {
+    vi.mocked(auth).mockResolvedValueOnce(session(true));
+    const res = await call();
+    expect(res.status).toBe(404);
+    expect(prisma.dataset.findUnique).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
@@ -55,5 +55,9 @@ describe("POST /api/datasets/[id]/refresh", () => {
     const res = await call();
     expect(res.status).toBe(404);
     expect(prisma.dataset.findUnique).toHaveBeenCalledOnce();
+    expect(prisma.dataset.findUnique).toHaveBeenCalledWith({
+      where: { id: "does-not-exist" },
+      include: expect.any(Object),
+    });
   });
 });

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -17,12 +17,17 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // Manual refresh is an admin-only action. Regular users see the last-fetched
+    // timestamp instead of a refresh control.
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const { id: datasetId } = await params;
 
-    const dataset = await prisma.dataset.findFirst({
+    const dataset = await prisma.dataset.findUnique({
       where: {
         id: datasetId,
-        userId: user.id,
       },
       include: {
         template: {

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -96,6 +96,7 @@ export async function POST(
       success: true,
       dataset: updatedDataset,
       dataCount: snapshot.dataCount,
+      lastChecked: updatedDataset.lastChecked,
     });
   } catch (error) {
     console.error("Error refreshing dataset:", error);

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, after } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { trackEvent } from "@/lib/umami";
@@ -81,7 +81,11 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        after(() => trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`));
+        // Await inline (not after()): after() callbacks in this route handler
+        // were dropped, so scheduled refreshes never tracked. This is a
+        // background cron with no client waiting, so blocking on the bounded,
+        // non-throwing event is fine.
+        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
 
         results.successful++;
       } catch (error) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -58,6 +58,11 @@ export async function POST(req: NextRequest) {
       errors: [] as string[],
     };
 
+    // Tracking runs inline (not after(), whose callbacks were dropped) but is
+    // collected and settled after the loop so a slow Umami call never delays the
+    // next dataset. trackEvent is bounded (5s) and never rejects.
+    const analyticsEvents: Promise<void>[] = [];
+
     for (const dataset of datasetsToUpdate) {
       try {
 
@@ -81,11 +86,12 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        // Await inline (not after()): after() callbacks in this route handler
-        // were dropped, so scheduled refreshes never tracked. This is a
-        // background cron with no client waiting, so blocking on the bounded,
-        // non-throwing event is fine.
-        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
+        analyticsEvents.push(
+          trackEvent(
+            ANALYTICS_EVENTS.DATASET_REFRESH_JOB,
+            `/jobs/datasets/${dataset.id}/refresh`
+          )
+        );
 
         results.successful++;
       } catch (error) {
@@ -99,6 +105,8 @@ export async function POST(req: NextRequest) {
         results.errors.push(`Dataset ${dataset.id}: ${errorMessage}`);
       }
     }
+
+    await Promise.allSettled(analyticsEvents);
 
     return NextResponse.json({
       success: true,

--- a/src/components/dataset/dataset-actions-section.tsx
+++ b/src/components/dataset/dataset-actions-section.tsx
@@ -30,6 +30,7 @@ export function DatasetActionsSection({
   const [isSaved, setIsSaved] = useState(dataset.isSaved || false);
   const [saveCount, setSaveCount] = useState(savedCount);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [lastChecked, setLastChecked] = useState(dataset.lastChecked);
   const [isFeatured, setIsFeatured] = useState(dataset.isFeatured ?? false);
   const [isFeaturingLoading, setIsFeaturingLoading] = useState(false);
   const [hasFeatureError, setHasFeatureError] = useState(false);
@@ -87,7 +88,9 @@ export function DatasetActionsSection({
     setIsRefreshing(true);
     try {
       const result = await refreshDataset(dataset.id);
-      if (!result.success) {
+      if (result.success) {
+        setLastChecked(result.lastChecked ?? new Date());
+      } else {
         console.error("Failed to refresh dataset:", result.error);
       }
     } catch (error) {
@@ -206,9 +209,9 @@ export function DatasetActionsSection({
         {/* Last-fetched caption, shown to everyone (admins also get the refresh control) */}
         <p className="flex items-center gap-1 pt-1 text-xs text-muted-foreground">
           <Clock className="h-3 w-3" />
-          {dataset.lastChecked
+          {lastChecked
             ? t("dataFetched", {
-                time: formatRelativeTime(dataset.lastChecked, locale),
+                time: formatRelativeTime(lastChecked, locale),
               })
             : t("dataNotFetched")}
         </p>

--- a/src/components/dataset/dataset-actions-section.tsx
+++ b/src/components/dataset/dataset-actions-section.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/components/ui/link";
-import { Download, RefreshCw, Bookmark, BookmarkMinus, Star } from "lucide-react";
+import { Download, RefreshCw, Bookmark, BookmarkMinus, Star, Clock } from "lucide-react";
 import type { Dataset } from "@/schemas/dataset";
 import { useDatasetDownload } from "@/hooks/useDatasetDownload";
 import { useDatasetActions } from "@/hooks/useDatasetActions";
+import { formatRelativeTime } from "@/lib/dataset-stats";
 import { useState } from "react";
 
 type DatasetActionsSectionProps = {
@@ -21,6 +22,7 @@ export function DatasetActionsSection({
   saveLimit,
 }: DatasetActionsSectionProps) {
   const t = useTranslations("DatasetPage");
+  const locale = useLocale();
   const { downloadDataset } = useDatasetDownload();
   const { saveDataset, unsaveDataset, refreshDataset, isLoading } =
     useDatasetActions();
@@ -126,23 +128,25 @@ export function DatasetActionsSection({
           </>
         )}
 
-        {/* Refresh Button */}
-        <Button
-          onClick={handleRefresh}
-          disabled={!dataset.isActive || isRefreshing}
-          className="flex items-center gap-2 w-full h-10"
-          variant="outline"
-          title={
-            !dataset.isActive
-              ? "Only active datasets can be refreshed"
-              : "Update dataset with latest OpenStreetMap data"
-          }
-        >
-          <RefreshCw
-            className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
-          />
-          {isRefreshing ? t("refreshing") : t("refreshData")}
-        </Button>
+        {/* Refresh is an admin-only control */}
+        {dataset.canRefresh && (
+          <Button
+            onClick={handleRefresh}
+            disabled={!dataset.isActive || isRefreshing}
+            className="flex items-center gap-2 w-full h-10"
+            variant="outline"
+            title={
+              !dataset.isActive
+                ? "Only active datasets can be refreshed"
+                : "Update dataset with latest OpenStreetMap data"
+            }
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
+            />
+            {isRefreshing ? t("refreshing") : t("refreshData")}
+          </Button>
+        )}
 
         {/* Download Button */}
         <Button
@@ -198,6 +202,16 @@ export function DatasetActionsSection({
             })}
           </p>
         )}
+
+        {/* Last-fetched caption, shown to everyone (admins also get the refresh control) */}
+        <p className="flex items-center gap-1 pt-1 text-xs text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          {dataset.lastChecked
+            ? t("dataFetched", {
+                time: formatRelativeTime(dataset.lastChecked, locale),
+              })
+            : t("dataNotFetched")}
+        </p>
       </div>
     </div>
   );

--- a/src/hooks/useDatasetActions.ts
+++ b/src/hooks/useDatasetActions.ts
@@ -82,7 +82,12 @@ export function useDatasetActions() {
 
   const refreshDataset = async (
     datasetId: string
-  ): Promise<{ success: boolean; error?: string; dataCount?: number }> => {
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    dataCount?: number;
+    lastChecked?: Date;
+  }> => {
     setIsLoading(true);
     try {
       const result: RefreshResponse = await apiClient.post(
@@ -92,6 +97,7 @@ export function useDatasetActions() {
       return {
         success: result.success,
         dataCount: result.dataCount,
+        lastChecked: result.lastChecked,
       };
     } catch (error) {
       console.error("Error refreshing dataset:", error);

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -28,6 +28,7 @@ type RawDataset = {
 function calculatePermissions(rawDataset: RawDataset, user: User | null) {
   return {
     canFeature: user?.isAdmin ?? false,
+    canRefresh: user?.isAdmin ?? false,
     canDelete: false,
     isFeatured: rawDataset.isFeatured ?? false,
   };

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -93,6 +93,7 @@ export const DatasetSchema = z.object({
   canDelete: z.boolean().optional(),
   isFeatured: z.boolean().optional(),
   canFeature: z.boolean().optional(),
+  canRefresh: z.boolean().optional(),
 });
 
 export type Dataset = z.infer<typeof DatasetSchema>;


### PR DESCRIPTION
## Dataset refresh: admins-only control + last-fetched timestamp

**Problem:**
- Manual dataset refresh was gated by an owner-only DB lookup (`findFirst({ id, userId })`), but datasets have no owner (`userId` is null). So manual refresh returned **404 for every user** and its analytics event (`dataset_refresh`) never fired.
- The refresh button was shown to all users despite never working for them.
- Scheduled refreshes (`dataset_refresh_job`) also never tracked: the cron used `after()` inside a route handler, whose callbacks were being dropped (same bug class as the download event).
- Product decision: manual refresh should be an admin action; regular users should just see when the data was last fetched.

**Changes:**
- Gate the refresh API to admins (`isAdmin`, 403 otherwise) and look the dataset up by id (`findUnique`) so an admin can refresh any dataset.
- Show the refresh button only to admins (`canRefresh` DTO flag, mirrors `canFeature`). Add a small muted "Data fetched <time ago>" caption at the bottom of the actions panel for all users (from `lastChecked`, via the existing `formatRelativeTime`).
- Fix cron tracking: `dataset_refresh_job` now uses inline `await trackEvent` instead of `after()`.
- i18n: `dataFetched` / `dataNotFetched` (en/es/pt-BR).

**Verification:**
- `pnpm i18n:check`, `pnpm type-check`, `pnpm lint` clean; `umami.test.ts` 11/11.
- Verified live on a real dataset: admin sees the refresh button + caption and refresh now succeeds; non-admin sees only the caption; refresh API returns 403 for non-admins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized “last fetched” caption to dataset actions (relative time when available, otherwise “not fetched yet”).
  * Refresh controls now reflect whether the current user can refresh datasets.
* **Bug Fixes**
  * Refresh is now admin-only; unauthorized users receive 401/403 and are blocked before dataset lookup.
  * After a successful refresh, the UI updates to show the latest “last checked” time.
* **Tests**
  * Added route tests covering authorization behavior and missing-dataset handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->