### PR TITLE
Release v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # osmforcities
 
+## Unreleased
+
+### Fixed
+
+- Featured dataset toggle now reflects the dataset's real featured state on the detail page. The dataset query omitted `isFeatured`, so the button always initialized as "not featured" (requiring two clicks to enable and showing the wrong state after reload).
+- Admin status now refreshes from the database on every session check. Previously `isAdmin` was only written to the session token at sign-in, so an admin whose session predated their promotion (or whose token claims were reset by the next-auth upgrade) saw admin-only controls — including the featured toggle — hidden until signing out and back in.
+
 ## 1.12.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,34 @@
 # osmforcities
 
-## Unreleased
+## 1.13.0
+
+### Added
+
+- Admin-only manual dataset refresh with last-fetched timestamp caption [#346]
+- Analytics: track sign-in, sign-out, downloads, page views, and featured-toggle events [#335], [#336], [#344], [#345]
+
+### Changed
+
+- Send visitor IP via `x-umami-client-ip` so server-side events resolve the right city [#344]
+- Bound Umami fetch timeout and make event tracking non-blocking in routes [#335], [#336]
+- Batch cron refresh tracking and gate manual dataset refresh to admins [#346]
 
 ### Fixed
 
-- Featured dataset toggle now reflects the dataset's real featured state on the detail page. The dataset query omitted `isFeatured`, so the button always initialized as "not featured" (requiring two clicks to enable and showing the wrong state after reload).
-- Admin status now refreshes from the database on every session check. Previously `isAdmin` was only written to the session token at sign-in, so an admin whose session predated their promotion (or whose token claims were reset by the next-auth upgrade) saw admin-only controls — including the featured toggle — hidden until signing out and back in.
+- Featured dataset toggle now reflects the dataset's real featured state on the detail page. The dataset query omitted `isFeatured`, so the button always initialized as "not featured" (requiring two clicks to enable and showing the wrong state after reload) [#335]
+- Admin status now refreshes from the database on every session check. Previously `isAdmin` was only written to the session token at sign-in, so an admin whose session predated their promotion (or whose token claims were reset by the next-auth upgrade) saw admin-only controls — including the featured toggle — hidden until signing out and back in [#335]
+- Token refresh now fails closed on deleted users and uses edge-runtime-safe logging [#335]
+
+### Security
+
+- Bump js-yaml to 4.2.0 (DoS fix in the merge operator) [#337]
+
+[#335]: https://github.com/osmforcities/osmforcities/pull/335
+[#336]: https://github.com/osmforcities/osmforcities/pull/336
+[#337]: https://github.com/osmforcities/osmforcities/pull/337
+[#344]: https://github.com/osmforcities/osmforcities/pull/344
+[#345]: https://github.com/osmforcities/osmforcities/pull/345
+[#346]: https://github.com/osmforcities/osmforcities/pull/346
 
 ## 1.12.0
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -174,6 +174,8 @@
     "basicInfo": "Basic Information",
     "refreshData": "Refresh Data",
     "refreshing": "Refreshing...",
+    "dataFetched": "Data fetched {time}",
+    "dataNotFetched": "Data not yet fetched",
     "save": "Save",
     "unsave": "Unsave",
     "saveTooltip": "Save to revisit later",

--- a/messages/es.json
+++ b/messages/es.json
@@ -173,6 +173,8 @@
     "basicInfo": "Información Básica",
     "refreshData": "Actualizar Datos",
     "refreshing": "Actualizando...",
+    "dataFetched": "Datos obtenidos {time}",
+    "dataNotFetched": "Datos aún no obtenidos",
     "save": "Guardar",
     "unsave": "Quitar",
     "saveTooltip": "Guardar para visitar más tarde",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -173,6 +173,8 @@
     "basicInfo": "Informações Básicas",
     "refreshData": "Atualizar Dados",
     "refreshing": "Atualizando...",
+    "dataFetched": "Dados obtidos {time}",
+    "dataNotFetched": "Dados ainda não obtidos",
     "save": "Salvar",
     "unsave": "Remover",
     "saveTooltip": "Salvar para visitar depois",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "html-to-text": "^9.0.5",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.2.0",
     "lucide-react": "^0.513.0",
     "maplibre-gl": "^5.6.0",
     "next": "15.5.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmforcities",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "scripts": {
     "dev": "COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null || echo 'unknown') next dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: ^9.0.5
         version: 9.0.5
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.2.0
+        version: 4.2.0
       lucide-react:
         specifier: ^0.513.0
         version: 0.513.0(react@19.2.3)
@@ -142,13 +142,13 @@ importers:
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: ^10.4.3
-        version: 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
+        version: 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       '@storybook/addon-vitest':
         specifier: ^10.4.3
         version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9)(@vitest/runner@4.1.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.9)
       '@storybook/nextjs-vite':
         specifier: ^10.4.3
-        version: 10.4.6(@babel/core@7.28.6)(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.2)(next@15.5.18(@babel/core@7.28.6)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
+        version: 10.4.6(@babel/core@7.28.6)(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.7)(next@15.5.18(@babel/core@7.28.6)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       '@storybook/react':
         specifier: ^10.4.3
         version: 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
@@ -456,6 +456,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.5':
     resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
     engines: {node: '>=18'}
@@ -464,6 +470,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -480,6 +492,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.5':
     resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
     engines: {node: '>=18'}
@@ -488,6 +506,12 @@ packages:
 
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -504,6 +528,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.5':
     resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
     engines: {node: '>=18'}
@@ -512,6 +542,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.2':
     resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -528,6 +564,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.5':
     resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
     engines: {node: '>=18'}
@@ -536,6 +578,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.2':
     resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -552,6 +600,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.5':
     resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
     engines: {node: '>=18'}
@@ -560,6 +614,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.2':
     resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -576,6 +636,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.5':
     resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
     engines: {node: '>=18'}
@@ -584,6 +650,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.2':
     resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -600,6 +672,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.5':
     resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
     engines: {node: '>=18'}
@@ -608,6 +686,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.2':
     resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -624,6 +708,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.5':
     resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
     engines: {node: '>=18'}
@@ -632,6 +722,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -648,6 +744,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.5':
     resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
@@ -656,6 +758,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -672,6 +780,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.5':
     resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
@@ -680,6 +794,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -696,8 +816,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -714,6 +846,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.5':
     resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
     engines: {node: '>=18'}
@@ -722,6 +860,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -738,6 +882,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.5':
     resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
     engines: {node: '>=18'}
@@ -746,6 +896,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3052,8 +3208,8 @@ packages:
     resolution: {integrity: sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@ungap/structured-clone@1.3.1':
-    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+  '@ungap/structured-clone@1.3.2':
+    resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
 
   '@unrs/resolver-binding-darwin-arm64@1.7.9':
     resolution: {integrity: sha512-hWbcVTcNqgUirY5DC3heOLrz35D926r2izfxveBmuIgDwx9KkUHfqd93g8PtROJX01lvhmyAc3E09/ma6jhyqQ==}
@@ -3251,6 +3407,11 @@ packages:
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3918,6 +4079,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -4422,6 +4588,7 @@ packages:
   i18next-parser@9.3.0:
     resolution: {integrity: sha512-VaQqk/6nLzTFx1MDiCZFtzZXKKyBV6Dv0cJMFM/hOt4/BWHWRgYafzYfVQRUzotwUwjqeNCprWnutzD/YAGczg==}
     engines: {node: ^18.0.0 || ^20.0.0 || ^22.0.0, npm: '>=6', yarn: '>=1'}
+    deprecated: Project is deprecated, use i18next-cli instead
     hasBin: true
 
   i18next@24.2.3:
@@ -4721,12 +4888,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5434,6 +5601,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -5466,6 +5637,10 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postmark@4.0.5:
@@ -6085,6 +6260,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
@@ -6421,6 +6600,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -6786,7 +6966,7 @@ snapshots:
   '@changesets/parse@0.4.1':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 3.14.1
+      js-yaml: 3.15.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -6883,10 +7063,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.25.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.25.5':
@@ -6895,10 +7081,16 @@ snapshots:
   '@esbuild/android-arm@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.25.5':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.5':
@@ -6907,10 +7099,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.5':
@@ -6919,10 +7117,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.25.5':
@@ -6931,10 +7135,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.25.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.25.5':
@@ -6943,10 +7153,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.5':
@@ -6955,10 +7171,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.5':
@@ -6967,10 +7189,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.5':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.25.5':
@@ -6979,10 +7207,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.5':
@@ -6991,10 +7225,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.5':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.5':
@@ -7003,7 +7243,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.25.5':
@@ -7012,10 +7258,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.25.5':
@@ -7024,10 +7276,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(jiti@2.4.2))':
@@ -7068,7 +7326,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.2.0
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7416,7 +7674,7 @@ snapshots:
       commander: 12.1.0
       glob: 11.1.0
       i18next-parser: 9.3.0
-      js-yaml: 4.1.0
+      js-yaml: 4.2.0
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@glimmer/env'
@@ -7498,7 +7756,7 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.14
-      acorn: 8.16.0
+      acorn: 8.17.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -7507,7 +7765,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-jsx: 1.0.1(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -8992,10 +9250,10 @@ snapshots:
       axe-core: 4.10.3
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.1.6)(react@19.2.3)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
@@ -9025,9 +9283,9 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0)
@@ -9036,12 +9294,12 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       rollup: 4.62.2
       vite: 7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0)
 
@@ -9052,11 +9310,11 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/nextjs-vite@10.4.6(@babel/core@7.28.6)(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.2)(next@15.5.18(@babel/core@7.28.6)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
+  '@storybook/nextjs-vite@10.4.6(@babel/core@7.28.6)(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.7)(next@15.5.18(@babel/core@7.28.6)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/builder-vite': 10.4.6(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       '@storybook/react': 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
-      '@storybook/react-vite': 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
+      '@storybook/react-vite': 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       next: 15.5.18(@babel/core@7.28.6)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -9085,11 +9343,11 @@ snapshots:
       '@types/react': 19.1.6
       '@types/react-dom': 19.1.6(@types/react@19.1.6)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.8.3)(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.27.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0))
       '@storybook/react': 10.4.6(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.1.6)(prettier@2.8.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -9652,7 +9910,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       eslint-visitor-keys: 4.2.1
 
-  '@ungap/structured-clone@1.3.1':
+  '@ungap/structured-clone@1.3.2':
     optional: true
 
   '@unrs/resolver-binding-darwin-arm64@1.7.9':
@@ -9843,14 +10101,17 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
     optional: true
 
   acorn@8.14.1: {}
 
   acorn@8.16.0: {}
+
+  acorn@8.17.0:
+    optional: true
 
   agent-base@6.0.2:
     dependencies:
@@ -10584,7 +10845,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.16.0
+      acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
     optional: true
@@ -10645,6 +10906,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -10968,6 +11258,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fecha@4.2.3: {}
 
@@ -11346,7 +11640,7 @@ snapshots:
       fs-extra: 11.3.0
       gulp-sort: 2.0.0
       i18next: 24.2.3(typescript@5.8.3)
-      js-yaml: 4.1.0
+      js-yaml: 4.2.0
       lilconfig: 3.1.3
       rsvp: 4.8.5
       sort-keys: 5.1.0
@@ -11633,12 +11927,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -11978,7 +12272,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.1
+      '@ungap/structured-clone': 1.3.2
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -12073,8 +12367,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -12616,6 +12910,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pidtree@0.6.0: {}
 
   pify@4.0.1: {}
@@ -12635,6 +12931,12 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.16:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -12856,7 +13158,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.1
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -12898,10 +13200,10 @@ snapshots:
       vfile: 6.0.3
     optional: true
 
-  recma-jsx@1.0.1(acorn@8.16.0):
+  recma-jsx@1.0.1(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -13507,6 +13809,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyqueue@3.0.0: {}
 
   tinyrainbow@2.0.0: {}
@@ -13832,12 +14139,12 @@ snapshots:
 
   vite@7.3.1(@types/node@20.19.43)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.15
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.16
       rollup: 4.62.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.43
       fsevents: 2.3.3

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
-import { after } from "next/server";
 import { getTranslations, getLocale } from "next-intl/server";
 import { transformDataset } from "@/lib/dataset/transform";
 import { DatasetInteractiveSection } from "@/components/dataset/dataset-interactive-section";
@@ -23,7 +22,7 @@ import { DatasetUpsellPage } from "@/components/dataset/dataset-upsell-page";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
 import type { TranslationFunction } from "@/lib/types";
-import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
+import { trackEventAfterResponse } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 import { MAX_SAVES_PER_USER } from "@/lib/constants";
@@ -64,13 +63,9 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
       return <AreaNotFoundError areaId={areaId} />;
     }
 
-    const upsellClientInfo = await getClientInfoFromHeaders();
-    after(() =>
-      trackEvent(
-        ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
-        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
-        upsellClientInfo,
-      ),
+    await trackEventAfterResponse(
+      ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
+      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
     );
 
     return (
@@ -134,13 +129,9 @@ async function AreaTemplateDatasetView({
 
     const dataset = transformDataset(result.dataset, session?.user || null, locale, { isSaved, skipTemplateResolution: true });
 
-    const detailClientInfo = await getClientInfoFromHeaders();
-    after(() =>
-      trackEvent(
-        ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
-        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
-        detailClientInfo,
-      ),
+    await trackEventAfterResponse(
+      ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
+      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
     );
 
     const areaName = areaInfo?.name || dataset.area.name;

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
+import { after } from "next/server";
 import { getTranslations, getLocale } from "next-intl/server";
 import { transformDataset } from "@/lib/dataset/transform";
 import { DatasetInteractiveSection } from "@/components/dataset/dataset-interactive-section";
@@ -63,10 +64,13 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
       return <AreaNotFoundError areaId={areaId} />;
     }
 
-    trackEvent(
-      ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
-      await getClientInfoFromHeaders()
+    const upsellClientInfo = await getClientInfoFromHeaders();
+    after(() =>
+      trackEvent(
+        ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
+        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
+        upsellClientInfo,
+      ),
     );
 
     return (
@@ -130,10 +134,13 @@ async function AreaTemplateDatasetView({
 
     const dataset = transformDataset(result.dataset, session?.user || null, locale, { isSaved, skipTemplateResolution: true });
 
-    trackEvent(
-      ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
-      await getClientInfoFromHeaders()
+    const detailClientInfo = await getClientInfoFromHeaders();
+    after(() =>
+      trackEvent(
+        ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
+        `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
+        detailClientInfo,
+      ),
     );
 
     const areaName = areaInfo?.name || dataset.area.name;

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { after } from "next/server";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { getAreaDataTypes } from "@/lib/area-templates";
@@ -36,12 +37,15 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
     notFound();
   }
 
-  trackEvent(
-    session?.user
-      ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
-      : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
-    `/area/${areaId}/view`,
-    await getClientInfoFromHeaders()
+  const areaClientInfo = await getClientInfoFromHeaders();
+  after(() =>
+    trackEvent(
+      session?.user
+        ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
+        : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
+      `/area/${areaId}/view`,
+      areaClientInfo,
+    ),
   );
 
   const breadcrumbItems = [

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -1,11 +1,10 @@
 import { notFound } from "next/navigation";
-import { after } from "next/server";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { getAreaDataTypes } from "@/lib/area-templates";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
 import { DatasetGrid } from "@/components/ui/template-grid";
-import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
+import { trackEventAfterResponse } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { auth } from "@/auth";
 
@@ -37,15 +36,11 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
     notFound();
   }
 
-  const areaClientInfo = await getClientInfoFromHeaders();
-  after(() =>
-    trackEvent(
-      session?.user
-        ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
-        : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
-      `/area/${areaId}/view`,
-      areaClientInfo,
-    ),
+  await trackEventAfterResponse(
+    session?.user
+      ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
+      : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
+    `/area/${areaId}/view`,
   );
 
   const breadcrumbItems = [

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Metadata } from "next";
+import { after } from "next/server";
 import { auth } from "@/auth";
 import { redirect } from "@/i18n/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
@@ -55,7 +56,10 @@ export default async function Dashboard() {
   const tabT = await getTranslations("TabLayout");
   const savedDatasets = await getSavedDatasets(user.id);
 
-  trackEvent(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view", await getClientInfoFromHeaders());
+  const dashClientInfo = await getClientInfoFromHeaders();
+  after(() =>
+    trackEvent(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view", dashClientInfo),
+  );
 
   return (
     <div className="min-h-screen bg-white dark:bg-black">

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -4,14 +4,13 @@
  */
 
 import { Metadata } from "next";
-import { after } from "next/server";
 import { auth } from "@/auth";
 import { redirect } from "@/i18n/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
 import { prisma } from "@/lib/db";
 import { DashboardGrid } from "@/components/dashboard/dashboard-grid";
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
-import { trackEvent, getClientInfoFromHeaders } from "@/lib/umami";
+import { trackEventAfterResponse } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { MAX_SAVES_PER_USER } from "@/lib/constants";
 
@@ -56,10 +55,7 @@ export default async function Dashboard() {
   const tabT = await getTranslations("TabLayout");
   const savedDatasets = await getSavedDatasets(user.id);
 
-  const dashClientInfo = await getClientInfoFromHeaders();
-  after(() =>
-    trackEvent(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view", dashClientInfo),
-  );
+  await trackEventAfterResponse(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view");
 
   return (
     <div className="min-h-screen bg-white dark:bg-black">

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,12 +1,12 @@
-import { NextRequest, NextResponse, after } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { signOut } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
-import { trackEvent, getClientInfo } from "@/lib/umami";
+import { trackEventAfterRequest } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
-  after(() => trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request)));
+  trackEventAfterRequest(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", request);
   await signOut({ redirect: false });
   return NextResponse.redirect(new URL("/", baseUrl));
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { signOut } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
 import { trackEvent, getClientInfo } from "@/lib/umami";
@@ -6,7 +6,7 @@ import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
-  await trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request));
+  after(() => trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request)));
   await signOut({ redirect: false });
   return NextResponse.redirect(new URL("/", baseUrl));
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { signOut } from "@/auth";
 import { getBaseUrl } from "@/lib/utils";
+import { trackEvent, getClientInfo } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function POST(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
+  await trackEvent(ANALYTICS_EVENTS.SIGN_OUT, "/sign-out", getClientInfo(request));
   await signOut({ redirect: false });
   return NextResponse.redirect(new URL("/", baseUrl));
 }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -24,7 +24,9 @@ export async function GET(request: NextRequest) {
     }
 
     if (!verificationResult.user.emailVerified) {
-      trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up", getClientInfo(request));
+      await trackEvent(ANALYTICS_EVENTS.SIGN_UP, "/sign-up", getClientInfo(request));
+    } else {
+      await trackEvent(ANALYTICS_EVENTS.SIGN_IN, "/sign-in", getClientInfo(request));
     }
 
     await prisma.user.update({

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -27,7 +27,7 @@ export async function GET(
       );
     }
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request));
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { prisma } from "@/lib/db";
 import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -27,7 +27,7 @@ export async function GET(
       );
     }
 
-    await trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request));
+    after(() => trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request)));
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse, after } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { trackEvent, getClientInfo } from "@/lib/umami";
+import { trackEventAfterRequest } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(
@@ -27,7 +27,7 @@ export async function GET(
       );
     }
 
-    after(() => trackEvent(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, getClientInfo(_request)));
+    trackEventAfterRequest(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, _request);
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { trackEventAfterRequest } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function GET(
@@ -27,7 +27,14 @@ export async function GET(
       );
     }
 
-    trackEventAfterRequest(ANALYTICS_EVENTS.DATASET_DOWNLOAD, `/datasets/${id}/download`, _request);
+    // Await inline (not after()): after() callbacks in this route handler were
+    // unreliable and the download event was dropped. Save/unsave await inline and
+    // land reliably; match that. The event fetch is bounded to 5s and never throws.
+    await trackEvent(
+      ANALYTICS_EVENTS.DATASET_DOWNLOAD,
+      `/datasets/${id}/download`,
+      getClientInfo(_request),
+    );
 
     const safeName = `${dataset.template.name}-${dataset.cityName}.geojson`.replace(
       /[^\w.\-]+/g,

--- a/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/feature/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 
 vi.mock("@/auth", () => ({
@@ -40,7 +41,7 @@ describe("PUT /api/datasets/[id]/feature", () => {
     const { auth } = await import("@/auth");
     vi.mocked(auth).mockResolvedValueOnce(null);
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/datasets/" + testDatasetId + "/feature",
       { method: "PUT" }
     );
@@ -55,7 +56,7 @@ describe("PUT /api/datasets/[id]/feature", () => {
   });
 
   it("should return 404 for non-existent dataset", async () => {
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/datasets/invalid-id/feature",
       { method: "PUT" }
     );
@@ -75,7 +76,7 @@ describe("PUT /api/datasets/[id]/feature", () => {
       select: { isFeatured: true },
     });
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/datasets/" + testDatasetId + "/feature",
       { method: "PUT" }
     );

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/auth";
+import { trackEvent } from "@/lib/umami";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function PUT(
   request: Request,
@@ -40,6 +42,12 @@ export async function PUT(
     }
 
     const [result] = rows;
+    await trackEvent(
+      result.isFeatured
+        ? ANALYTICS_EVENTS.DATASET_FEATURED
+        : ANALYTICS_EVENTS.DATASET_UNFEATURED,
+      `/datasets/${result.id}/feature`,
+    );
     return NextResponse.json({ id: result.id, isFeatured: result.isFeatured });
   } catch (error) {
     console.error("Error toggling featured status:", error);

--- a/src/app/api/datasets/[id]/feature/route.ts
+++ b/src/app/api/datasets/[id]/feature/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/auth";
-import { trackEvent } from "@/lib/umami";
+import { trackEvent, getClientInfo } from "@/lib/umami";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export async function PUT(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -47,6 +47,7 @@ export async function PUT(
         ? ANALYTICS_EVENTS.DATASET_FEATURED
         : ANALYTICS_EVENTS.DATASET_UNFEATURED,
       `/datasets/${result.id}/feature`,
+      getClientInfo(request),
     );
     return NextResponse.json({ id: result.id, isFeatured: result.isFeatured });
   } catch (error) {

--- a/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: { dataset: { findUnique: vi.fn() } },
+}));
+
+import { POST } from "../route";
+
+type Session = Awaited<ReturnType<typeof auth>>;
+
+const session = (isAdmin: boolean | null): Session =>
+  isAdmin === null
+    ? null
+    : ({
+        user: { id: "user-1", email: "user@test.com", isAdmin },
+      } as unknown as Session);
+
+const call = () =>
+  POST(
+    new NextRequest("http://localhost:3000/api/datasets/does-not-exist/refresh", {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: "does-not-exist" }) }
+  );
+
+describe("POST /api/datasets/[id]/refresh", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.dataset.findUnique).mockResolvedValue(null);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(auth).mockResolvedValueOnce(session(null));
+    const res = await call();
+    expect(res.status).toBe(401);
+    expect(prisma.dataset.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-admin users (no dataset lookup)", async () => {
+    vi.mocked(auth).mockResolvedValueOnce(session(false));
+    const res = await call();
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("Forbidden");
+    expect(prisma.dataset.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("lets admins past the gate to the dataset lookup (404 for a missing dataset)", async () => {
+    vi.mocked(auth).mockResolvedValueOnce(session(true));
+    const res = await call();
+    expect(res.status).toBe(404);
+    expect(prisma.dataset.findUnique).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
+++ b/src/app/api/datasets/[id]/refresh/__tests__/route.test.ts
@@ -55,5 +55,9 @@ describe("POST /api/datasets/[id]/refresh", () => {
     const res = await call();
     expect(res.status).toBe(404);
     expect(prisma.dataset.findUnique).toHaveBeenCalledOnce();
+    expect(prisma.dataset.findUnique).toHaveBeenCalledWith({
+      where: { id: "does-not-exist" },
+      include: expect.any(Object),
+    });
   });
 });

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -85,7 +85,7 @@ export async function POST(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`, getClientInfo(request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH, `/datasets/${datasetId}/refresh`, getClientInfo(request));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -17,12 +17,17 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // Manual refresh is an admin-only action. Regular users see the last-fetched
+    // timestamp instead of a refresh control.
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const { id: datasetId } = await params;
 
-    const dataset = await prisma.dataset.findFirst({
+    const dataset = await prisma.dataset.findUnique({
       where: {
         id: datasetId,
-        userId: user.id,
       },
       include: {
         template: {

--- a/src/app/api/datasets/[id]/refresh/route.ts
+++ b/src/app/api/datasets/[id]/refresh/route.ts
@@ -96,6 +96,7 @@ export async function POST(
       success: true,
       dataset: updatedDataset,
       dataCount: snapshot.dataCount,
+      lastChecked: updatedDataset.lastChecked,
     });
   } catch (error) {
     console.error("Error refreshing dataset:", error);

--- a/src/app/api/datasets/[id]/save/route.ts
+++ b/src/app/api/datasets/[id]/save/route.ts
@@ -66,7 +66,7 @@ export async function POST(
       );
     }
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_SAVE, `/datasets/${datasetId}/save`, getClientInfo(request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_SAVE, `/datasets/${datasetId}/save`, getClientInfo(request));
 
     return NextResponse.json({ success: true, save });
   } catch (error) {
@@ -119,7 +119,7 @@ export async function DELETE(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_UNSAVE, `/datasets/${datasetId}/unsave`, getClientInfo(request));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_UNSAVE, `/datasets/${datasetId}/unsave`, getClientInfo(request));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -88,7 +88,7 @@ export async function POST(req: NextRequest) {
       include: { template: true },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`, getClientInfo(req));
+    await trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`, getClientInfo(req));
 
     return NextResponse.json(dataset, { status: 201 });
   } catch (err) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -81,7 +81,7 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
+        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
 
         results.successful++;
       } catch (error) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { prisma } from "@/lib/db";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { trackEvent } from "@/lib/umami";
@@ -81,7 +81,7 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
+        after(() => trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`));
 
         results.successful++;
       } catch (error) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, after } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { trackEvent } from "@/lib/umami";
@@ -81,7 +81,11 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        after(() => trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`));
+        // Await inline (not after()): after() callbacks in this route handler
+        // were dropped, so scheduled refreshes never tracked. This is a
+        // background cron with no client waiting, so blocking on the bounded,
+        // non-throwing event is fine.
+        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
 
         results.successful++;
       } catch (error) {

--- a/src/app/api/tasks/update-datasets/route.ts
+++ b/src/app/api/tasks/update-datasets/route.ts
@@ -58,6 +58,11 @@ export async function POST(req: NextRequest) {
       errors: [] as string[],
     };
 
+    // Tracking runs inline (not after(), whose callbacks were dropped) but is
+    // collected and settled after the loop so a slow Umami call never delays the
+    // next dataset. trackEvent is bounded (5s) and never rejects.
+    const analyticsEvents: Promise<void>[] = [];
+
     for (const dataset of datasetsToUpdate) {
       try {
 
@@ -81,11 +86,12 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        // Await inline (not after()): after() callbacks in this route handler
-        // were dropped, so scheduled refreshes never tracked. This is a
-        // background cron with no client waiting, so blocking on the bounded,
-        // non-throwing event is fine.
-        await trackEvent(ANALYTICS_EVENTS.DATASET_REFRESH_JOB, `/jobs/datasets/${dataset.id}/refresh`);
+        analyticsEvents.push(
+          trackEvent(
+            ANALYTICS_EVENTS.DATASET_REFRESH_JOB,
+            `/jobs/datasets/${dataset.id}/refresh`
+          )
+        );
 
         results.successful++;
       } catch (error) {
@@ -99,6 +105,8 @@ export async function POST(req: NextRequest) {
         results.errors.push(`Dataset ${dataset.id}: ${errorMessage}`);
       }
     }
+
+    await Promise.allSettled(analyticsEvents);
 
     return NextResponse.json({
       success: true,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,7 @@ import type { JWT } from "next-auth/jwt";
 import type { Session } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
+import { refreshTokenClaims } from "@/lib/auth-token";
 
 type DatabaseUser = {
   id: string;
@@ -173,12 +174,16 @@ const {
 
   callbacks: {
     async jwt({ token, user }): Promise<JWT> {
+      // On initial sign-in, capture the user id from the provider result.
       if (user && user.id) {
         token.id = user.id;
-        token.isAdmin = user.isAdmin;
-        token.language = user.language;
       }
-      return token;
+      // Always refresh admin status and language from the DB. The previous
+      // implementation only wrote these on sign-in, so a user promoted to admin
+      // after their session was created — or whose token claims were reset by a
+      // next-auth upgrade — kept a stale `isAdmin: false` token, hiding the
+      // featured toggle and other admin UI until they signed out and back in.
+      return refreshTokenClaims(token);
     },
 
     async session({ session, token }): Promise<Session> {

--- a/src/components/dataset/dataset-actions-section.tsx
+++ b/src/components/dataset/dataset-actions-section.tsx
@@ -30,6 +30,7 @@ export function DatasetActionsSection({
   const [isSaved, setIsSaved] = useState(dataset.isSaved || false);
   const [saveCount, setSaveCount] = useState(savedCount);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [lastChecked, setLastChecked] = useState(dataset.lastChecked);
   const [isFeatured, setIsFeatured] = useState(dataset.isFeatured ?? false);
   const [isFeaturingLoading, setIsFeaturingLoading] = useState(false);
   const [hasFeatureError, setHasFeatureError] = useState(false);
@@ -87,7 +88,9 @@ export function DatasetActionsSection({
     setIsRefreshing(true);
     try {
       const result = await refreshDataset(dataset.id);
-      if (!result.success) {
+      if (result.success) {
+        setLastChecked(result.lastChecked ?? new Date());
+      } else {
         console.error("Failed to refresh dataset:", result.error);
       }
     } catch (error) {
@@ -206,9 +209,9 @@ export function DatasetActionsSection({
         {/* Last-fetched caption, shown to everyone (admins also get the refresh control) */}
         <p className="flex items-center gap-1 pt-1 text-xs text-muted-foreground">
           <Clock className="h-3 w-3" />
-          {dataset.lastChecked
+          {lastChecked
             ? t("dataFetched", {
-                time: formatRelativeTime(dataset.lastChecked, locale),
+                time: formatRelativeTime(lastChecked, locale),
               })
             : t("dataNotFetched")}
         </p>

--- a/src/components/dataset/dataset-actions-section.tsx
+++ b/src/components/dataset/dataset-actions-section.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/components/ui/link";
-import { Download, RefreshCw, Bookmark, BookmarkMinus, Star } from "lucide-react";
+import { Download, RefreshCw, Bookmark, BookmarkMinus, Star, Clock } from "lucide-react";
 import type { Dataset } from "@/schemas/dataset";
 import { useDatasetDownload } from "@/hooks/useDatasetDownload";
 import { useDatasetActions } from "@/hooks/useDatasetActions";
+import { formatRelativeTime } from "@/lib/dataset-stats";
 import { useState } from "react";
 
 type DatasetActionsSectionProps = {
@@ -21,6 +22,7 @@ export function DatasetActionsSection({
   saveLimit,
 }: DatasetActionsSectionProps) {
   const t = useTranslations("DatasetPage");
+  const locale = useLocale();
   const { downloadDataset } = useDatasetDownload();
   const { saveDataset, unsaveDataset, refreshDataset, isLoading } =
     useDatasetActions();
@@ -126,23 +128,25 @@ export function DatasetActionsSection({
           </>
         )}
 
-        {/* Refresh Button */}
-        <Button
-          onClick={handleRefresh}
-          disabled={!dataset.isActive || isRefreshing}
-          className="flex items-center gap-2 w-full h-10"
-          variant="outline"
-          title={
-            !dataset.isActive
-              ? "Only active datasets can be refreshed"
-              : "Update dataset with latest OpenStreetMap data"
-          }
-        >
-          <RefreshCw
-            className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
-          />
-          {isRefreshing ? t("refreshing") : t("refreshData")}
-        </Button>
+        {/* Refresh is an admin-only control */}
+        {dataset.canRefresh && (
+          <Button
+            onClick={handleRefresh}
+            disabled={!dataset.isActive || isRefreshing}
+            className="flex items-center gap-2 w-full h-10"
+            variant="outline"
+            title={
+              !dataset.isActive
+                ? "Only active datasets can be refreshed"
+                : "Update dataset with latest OpenStreetMap data"
+            }
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
+            />
+            {isRefreshing ? t("refreshing") : t("refreshData")}
+          </Button>
+        )}
 
         {/* Download Button */}
         <Button
@@ -198,6 +202,16 @@ export function DatasetActionsSection({
             })}
           </p>
         )}
+
+        {/* Last-fetched caption, shown to everyone (admins also get the refresh control) */}
+        <p className="flex items-center gap-1 pt-1 text-xs text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          {dataset.lastChecked
+            ? t("dataFetched", {
+                time: formatRelativeTime(dataset.lastChecked, locale),
+              })
+            : t("dataNotFetched")}
+        </p>
       </div>
     </div>
   );

--- a/src/hooks/useDatasetActions.ts
+++ b/src/hooks/useDatasetActions.ts
@@ -82,7 +82,12 @@ export function useDatasetActions() {
 
   const refreshDataset = async (
     datasetId: string
-  ): Promise<{ success: boolean; error?: string; dataCount?: number }> => {
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    dataCount?: number;
+    lastChecked?: Date;
+  }> => {
     setIsLoading(true);
     try {
       const result: RefreshResponse = await apiClient.post(
@@ -92,6 +97,7 @@ export function useDatasetActions() {
       return {
         success: result.success,
         dataCount: result.dataCount,
+        lastChecked: result.lastChecked,
       };
     } catch (error) {
       console.error("Error refreshing dataset:", error);

--- a/src/lib/__tests__/auth-token.test.ts
+++ b/src/lib/__tests__/auth-token.test.ts
@@ -8,6 +8,12 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+  }),
+}));
+
 import { refreshTokenClaims } from "@/lib/auth-token";
 import { prisma } from "@/lib/db";
 
@@ -56,10 +62,19 @@ describe("refreshTokenClaims", () => {
     expect(result.isAdmin).toBe(true);
   });
 
-  it("does not overwrite claims when the user is missing from the DB", async () => {
+  it("fails closed (clears isAdmin) when the user is missing from the DB", async () => {
     mockFindUnique.mockResolvedValue(null as never);
 
     const token = { id: "ghost", isAdmin: true, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(result.isAdmin).toBe(false);
+  });
+
+  it("preserves existing claims when the DB lookup throws", async () => {
+    mockFindUnique.mockRejectedValue(new Error("connection refused"));
+
+    const token = { id: "user-1", isAdmin: true, language: "en" };
     const result = await refreshTokenClaims(token as never);
 
     expect(result.isAdmin).toBe(true);

--- a/src/lib/__tests__/auth-token.test.ts
+++ b/src/lib/__tests__/auth-token.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { refreshTokenClaims } from "@/lib/auth-token";
+import { prisma } from "@/lib/db";
+
+const mockFindUnique = vi.mocked(prisma.user.findUnique);
+
+describe("refreshTokenClaims", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes isAdmin from the DB even when the token claim is stale", async () => {
+    // Token was minted before the user was promoted to admin: isAdmin is false.
+    mockFindUnique.mockResolvedValue({
+      isAdmin: true,
+      language: "en",
+    } as never);
+
+    const token = { id: "user-1", isAdmin: false, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: { isAdmin: true, language: true },
+    });
+    expect(result.isAdmin).toBe(true);
+  });
+
+  it("clears isAdmin when the user is no longer an admin in the DB", async () => {
+    mockFindUnique.mockResolvedValue({
+      isAdmin: false,
+      language: "pt-BR",
+    } as never);
+
+    const token = { id: "user-1", isAdmin: true, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(result.isAdmin).toBe(false);
+    expect(result.language).toBe("pt-BR");
+  });
+
+  it("leaves the token untouched when it has no id", async () => {
+    const token = { isAdmin: true };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(result.isAdmin).toBe(true);
+  });
+
+  it("does not overwrite claims when the user is missing from the DB", async () => {
+    mockFindUnique.mockResolvedValue(null as never);
+
+    const token = { id: "ghost", isAdmin: true, language: "en" };
+    const result = await refreshTokenClaims(token as never);
+
+    expect(result.isAdmin).toBe(true);
+  });
+});

--- a/src/lib/__tests__/auth-token.test.ts
+++ b/src/lib/__tests__/auth-token.test.ts
@@ -8,12 +8,6 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-vi.mock("@/lib/logger", () => ({
-  createLogger: () => ({
-    error: vi.fn(),
-  }),
-}));
-
 import { refreshTokenClaims } from "@/lib/auth-token";
 import { prisma } from "@/lib/db";
 

--- a/src/lib/__tests__/dataset-operations.test.ts
+++ b/src/lib/__tests__/dataset-operations.test.ts
@@ -55,8 +55,48 @@ vi.mock("@/lib/nominatim", () => ({
 
 import { getOrCreateDataset } from "@/lib/dataset-operations";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
+import { prisma } from "@/lib/db";
 
 const mockFetchDatasetSnapshot = vi.mocked(fetchDatasetSnapshot);
+const mockDatasetFindFirst = vi.mocked(prisma.dataset.findFirst);
+
+const existingDatasetRow = {
+  id: "ds-1",
+  templateId: "tmpl-1",
+  areaId: 1,
+  cityName: "Test City",
+  geojson: null,
+  bbox: null,
+  dataCount: 5,
+  lastChecked: new Date(),
+  stats: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  isActive: true,
+  isFeatured: true,
+  template: { id: "tmpl-1", name: "Test", description: null, translations: [] },
+  area: { id: 1, name: "Test City", countryCode: "US", bounds: null, geojson: null },
+  user: null,
+  savedBy: [],
+};
+
+describe("getOrCreateDataset — isFeatured passthrough", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("selects isFeatured and returns it so the toggle reflects real state", async () => {
+    mockDatasetFindFirst.mockResolvedValueOnce(existingDatasetRow as never);
+
+    const { dataset } = await getOrCreateDataset(1, "test-template", "en");
+
+    // The select must request isFeatured, otherwise the detail page button
+    // always initializes to "not featured" regardless of the DB value.
+    const selectArg = mockDatasetFindFirst.mock.calls[0]?.[0]?.select;
+    expect(selectArg?.isFeatured).toBe(true);
+    expect(dataset.isFeatured).toBe(true);
+  });
+});
 
 describe("getOrCreateDataset — error sanitization", () => {
   beforeEach(() => {

--- a/src/lib/__tests__/umami.test.ts
+++ b/src/lib/__tests__/umami.test.ts
@@ -51,15 +51,15 @@ describe("trackEvent", () => {
     vi.restoreAllMocks();
   });
 
-  it("does nothing when env vars are absent", () => {
+  it("does nothing when env vars are absent", async () => {
     delete process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
-    trackEvent("test_event", "/test");
+    await trackEvent("test_event", "/test");
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it("sends POST to /api/send with event payload", async () => {
-    trackEvent("dataset_create", "/datasets/123/create");
-    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    await trackEvent("dataset_create", "/datasets/123/create");
+    expect(fetch).toHaveBeenCalledOnce();
 
     const [url, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(url).toBe("https://analytics.example.com/api/send");
@@ -70,13 +70,17 @@ describe("trackEvent", () => {
 
   it("forwards ip and userAgent as headers when clientInfo provided", async () => {
     const clientInfo: ClientInfo = { ip: "1.2.3.4", userAgent: "TestAgent/1" };
-    trackEvent("sign_up", "/sign-up", clientInfo);
-    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    await trackEvent("sign_up", "/sign-up", clientInfo);
 
     const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect((opts as RequestInit).headers).toMatchObject({
       "x-forwarded-for": "1.2.3.4",
       "user-agent": "TestAgent/1",
     });
+  });
+
+  it("never rejects when fetch fails (tracking must not break user flows)", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+    await expect(trackEvent("dataset_save", "/datasets/1/save")).resolves.toBeUndefined();
   });
 });

--- a/src/lib/__tests__/umami.test.ts
+++ b/src/lib/__tests__/umami.test.ts
@@ -79,6 +79,25 @@ describe("trackEvent", () => {
     });
   });
 
+  it("also sends ip and userAgent in the payload so Umami resolves full city", async () => {
+    const clientInfo: ClientInfo = { ip: "1.2.3.4", userAgent: "TestAgent/1" };
+    await trackEvent("sign_up", "/sign-up", clientInfo);
+
+    const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body.payload.ip).toBe("1.2.3.4");
+    expect(body.payload.userAgent).toBe("TestAgent/1");
+  });
+
+  it("omits ip/userAgent from payload when clientInfo is absent", async () => {
+    await trackEvent("dataset_refresh_job", "/datasets/refresh");
+
+    const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body.payload.ip).toBeUndefined();
+    expect(body.payload.userAgent).toBeUndefined();
+  });
+
   it("never rejects when fetch fails (tracking must not break user flows)", async () => {
     vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
     await expect(trackEvent("dataset_save", "/datasets/1/save")).resolves.toBeUndefined();

--- a/src/lib/__tests__/umami.test.ts
+++ b/src/lib/__tests__/umami.test.ts
@@ -68,13 +68,13 @@ describe("trackEvent", () => {
     expect(body.payload.website).toBe("test-website-id");
   });
 
-  it("forwards ip and userAgent as headers when clientInfo provided", async () => {
+  it("forwards ip as x-umami-client-ip and userAgent as headers when clientInfo provided", async () => {
     const clientInfo: ClientInfo = { ip: "1.2.3.4", userAgent: "TestAgent/1" };
     await trackEvent("sign_up", "/sign-up", clientInfo);
 
     const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect((opts as RequestInit).headers).toMatchObject({
-      "x-forwarded-for": "1.2.3.4",
+      "x-umami-client-ip": "1.2.3.4",
       "user-agent": "TestAgent/1",
     });
   });

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -13,9 +13,13 @@ export const ANALYTICS_EVENTS = {
   DATASET_REFRESH: "dataset_refresh",
   DATASET_REFRESH_JOB: "dataset_refresh_job",
   DATASET_UPSELL_VIEW: "dataset_upsell_view",
+  DATASET_FEATURED: "dataset_featured",
+  DATASET_UNFEATURED: "dataset_unfeatured",
 
   // User events
   SIGN_UP: "sign_up",
+  SIGN_IN: "sign_in",
+  SIGN_OUT: "sign_out",
   SAVED_DATASETS_VIEW: "saved_datasets_view",
 
   // Area events

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,8 +1,5 @@
 import type { JWT } from "next-auth/jwt";
 import { prisma } from "@/lib/db";
-import { createLogger } from "@/lib/logger";
-
-const logger = createLogger("auth-token");
 
 /**
  * Refreshes admin status and language on the JWT from the database so that
@@ -31,7 +28,10 @@ export async function refreshTokenClaims(token: JWT): Promise<JWT> {
       select: { isAdmin: true, language: true },
     });
   } catch (error) {
-    logger.error("Failed to refresh token claims; keeping existing claims", {
+    // console.error (not the winston logger) — this module is imported by the
+    // middleware edge-runtime bundle via auth.ts, and winston relies on Node
+    // APIs (process.nextTick) that are unavailable in the Edge Runtime.
+    console.error("Failed to refresh token claims; keeping existing claims", {
       userId: token.id,
       error,
     });

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,5 +1,8 @@
 import type { JWT } from "next-auth/jwt";
 import { prisma } from "@/lib/db";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("auth-token");
 
 /**
  * Refreshes admin status and language on the JWT from the database so that
@@ -10,18 +13,36 @@ import { prisma } from "@/lib/db";
  * promoted to admin after their session was created — or whose token claims
  * were reset by a next-auth upgrade — kept a stale `isAdmin: false` token,
  * hiding the featured toggle and other admin UI until they signed out and in.
+ *
+ * Failure modes:
+ * - If the lookup throws (transient DB issue), the existing claims are
+ *   preserved so a DB blip doesn't take down auth/session resolution.
+ * - If the user row no longer exists (deleted account), privileged claims are
+ *   cleared so a stale admin token can't retain admin access until expiry.
  */
 export async function refreshTokenClaims(token: JWT): Promise<JWT> {
   if (!token.id) {
     return token;
   }
-  const dbUser = await prisma.user.findUnique({
-    where: { id: token.id as string },
-    select: { isAdmin: true, language: true },
-  });
+  let dbUser: { isAdmin: boolean; language: string | null } | null;
+  try {
+    dbUser = await prisma.user.findUnique({
+      where: { id: token.id as string },
+      select: { isAdmin: true, language: true },
+    });
+  } catch (error) {
+    logger.error("Failed to refresh token claims; keeping existing claims", {
+      userId: token.id,
+      error,
+    });
+    return token;
+  }
   if (dbUser) {
     token.isAdmin = dbUser.isAdmin;
     token.language = dbUser.language ?? "en";
+  } else {
+    // User no longer exists — fail closed.
+    token.isAdmin = false;
   }
   return token;
 }

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,0 +1,27 @@
+import type { JWT } from "next-auth/jwt";
+import { prisma } from "@/lib/db";
+
+/**
+ * Refreshes admin status and language on the JWT from the database so that
+ * role changes take effect without requiring re-login. Mutates and returns the
+ * token.
+ *
+ * The previous auth callback only wrote these claims on sign-in, so a user
+ * promoted to admin after their session was created — or whose token claims
+ * were reset by a next-auth upgrade — kept a stale `isAdmin: false` token,
+ * hiding the featured toggle and other admin UI until they signed out and in.
+ */
+export async function refreshTokenClaims(token: JWT): Promise<JWT> {
+  if (!token.id) {
+    return token;
+  }
+  const dbUser = await prisma.user.findUnique({
+    where: { id: token.id as string },
+    select: { isAdmin: true, language: true },
+  });
+  if (dbUser) {
+    token.isAdmin = dbUser.isAdmin;
+    token.language = dbUser.language ?? "en";
+  }
+  return token;
+}

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -79,6 +79,7 @@ async function getDatasetWithDetails(areaId: number, templateId: string, locale:
       createdAt: true,
       updatedAt: true,
       isActive: true,
+      isFeatured: true,
       template: {
         select: {
           id: true,
@@ -253,6 +254,7 @@ async function createDatasetOnDemand(
         createdAt: true,
         updatedAt: true,
         isActive: true,
+        isFeatured: true,
         template: {
           select: {
             id: true,

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -301,7 +301,7 @@ async function createDatasetOnDemand(
       },
     });
 
-    trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`);
+    await trackEvent(ANALYTICS_EVENTS.DATASET_CREATE, `/datasets/${dataset.id}/create`);
 
     // Resolve template translations for the given locale
     const resolvedTemplate = resolveTemplateForLocale(dataset.template, locale);

--- a/src/lib/dataset/transform.ts
+++ b/src/lib/dataset/transform.ts
@@ -28,6 +28,7 @@ type RawDataset = {
 function calculatePermissions(rawDataset: RawDataset, user: User | null) {
   return {
     canFeature: user?.isAdmin ?? false,
+    canRefresh: user?.isAdmin ?? false,
     canDelete: false,
     isFeatured: rawDataset.isFeatured ?? false,
   };

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -41,11 +41,15 @@ export async function getClientInfoFromHeaders(): Promise<ClientInfo> {
   };
 }
 
-export function trackEvent(
+// Awaited so callers (server components via `after()`, API routes, background
+// jobs) can ensure the request completes before the response/render finishes —
+// a detached fetch would be reaped by the runtime and the event silently lost.
+// Never rejects: failures are logged so tracking can never break a user flow.
+export async function trackEvent(
   eventName: string,
   url: string,
   clientInfo?: ClientInfo,
-): void {
+): Promise<void> {
   const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
   const umamiUrl = process.env.NEXT_PUBLIC_UMAMI_URL;
 
@@ -58,32 +62,32 @@ export function trackEvent(
   if (clientInfo?.ip) fetchHeaders["x-forwarded-for"] = clientInfo.ip;
   if (clientInfo?.userAgent) fetchHeaders["user-agent"] = clientInfo.userAgent;
 
-  fetch(`${umamiUrl}/api/send`, {
-    method: "POST",
-    headers: fetchHeaders,
-    body: JSON.stringify({
-      type: "event",
-      payload: {
-        website: websiteId,
-        url,
-        name: eventName,
-        hostname: process.env.NEXT_PUBLIC_APP_URL
-          ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
-          : "",
-        language: clientInfo?.language ?? "",
-        referrer: clientInfo?.referrer ?? "",
-      },
-    }),
-  })
-    .then(async (res) => {
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({ status: res.status }));
-        logger.warn("Umami event failed", { event: eventName, status: res.status, data });
-      } else {
-        logger.debug("Umami event sent", { event: eventName, url });
-      }
-    })
-    .catch((err) => {
-      logger.warn("Umami event error", { event: eventName, err });
+  try {
+    const res = await fetch(`${umamiUrl}/api/send`, {
+      method: "POST",
+      headers: fetchHeaders,
+      body: JSON.stringify({
+        type: "event",
+        payload: {
+          website: websiteId,
+          url,
+          name: eventName,
+          hostname: process.env.NEXT_PUBLIC_APP_URL
+            ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
+            : "",
+          language: clientInfo?.language ?? "",
+          referrer: clientInfo?.referrer ?? "",
+        },
+      }),
     });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({ status: res.status }));
+      logger.warn("Umami event failed", { event: eventName, status: res.status, data });
+    } else {
+      logger.info("Umami event sent", { event: eventName, url });
+    }
+  } catch (err) {
+    logger.warn("Umami event error", { event: eventName, err });
+  }
 }

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -96,11 +96,27 @@ export async function trackEvent(
 // Fire-and-forget tracking for server components/pages: captures request client
 // info during render, then schedules the event to run after the response is sent
 // so analytics never blocks the render. De-duplicates the capture+after+track
-// pattern repeated across pages.
+// pattern repeated across pages. Never rejects — a headers() failure is logged,
+// not propagated to the render.
 export async function trackEventAfterResponse(
   eventName: string,
   url: string,
 ): Promise<void> {
-  const clientInfo = await getClientInfoFromHeaders();
-  after(() => trackEvent(eventName, url, clientInfo));
+  try {
+    const clientInfo = await getClientInfoFromHeaders();
+    after(() => trackEvent(eventName, url, clientInfo));
+  } catch (err) {
+    logger.warn("trackEventAfterResponse error", { event: eventName, err });
+  }
+}
+
+// Fire-and-forget tracking for route handlers: schedules the event after the
+// response is sent using client info derived from the request. De-duplicates the
+// after(() => trackEvent(..., getClientInfo(req))) pattern across API routes.
+export function trackEventAfterRequest(
+  eventName: string,
+  url: string,
+  request: NextRequest,
+): void {
+  after(() => trackEvent(eventName, url, getClientInfo(request)));
 }

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,5 +1,5 @@
 import { headers } from "next/headers";
-import { NextRequest } from "next/server";
+import { NextRequest, after } from "next/server";
 import { logger } from "@/lib/logger";
 
 export type ClientInfo = {
@@ -41,10 +41,10 @@ export async function getClientInfoFromHeaders(): Promise<ClientInfo> {
   };
 }
 
-// Awaited so callers (server components via `after()`, API routes, background
-// jobs) can ensure the request completes before the response/render finishes —
-// a detached fetch would be reaped by the runtime and the event silently lost.
-// Never rejects: failures are logged so tracking can never break a user flow.
+// Best-effort, bounded by a 5s timeout, and never rejects: failures are logged
+// so tracking can never break a user flow. Await it only where the response can
+// wait; for user-facing routes/pages prefer `trackEventAfterResponse` (or wrap
+// in `after()`) so analytics never delays the response.
 export async function trackEvent(
   eventName: string,
   url: string,
@@ -66,6 +66,7 @@ export async function trackEvent(
     const res = await fetch(`${umamiUrl}/api/send`, {
       method: "POST",
       headers: fetchHeaders,
+      signal: AbortSignal.timeout(5000),
       body: JSON.stringify({
         type: "event",
         payload: {
@@ -90,4 +91,16 @@ export async function trackEvent(
   } catch (err) {
     logger.warn("Umami event error", { event: eventName, err });
   }
+}
+
+// Fire-and-forget tracking for server components/pages: captures request client
+// info during render, then schedules the event to run after the response is sent
+// so analytics never blocks the render. De-duplicates the capture+after+track
+// pattern repeated across pages.
+export async function trackEventAfterResponse(
+  eventName: string,
+  url: string,
+): Promise<void> {
+  const clientInfo = await getClientInfoFromHeaders();
+  after(() => trackEvent(eventName, url, clientInfo));
 }

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -59,7 +59,7 @@ export async function trackEvent(
     "Content-Type": "application/json",
   };
 
-  if (clientInfo?.ip) fetchHeaders["x-forwarded-for"] = clientInfo.ip;
+  if (clientInfo?.ip) fetchHeaders["x-umami-client-ip"] = clientInfo.ip;
   if (clientInfo?.userAgent) fetchHeaders["user-agent"] = clientInfo.userAgent;
 
   try {

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -78,6 +78,13 @@ export async function trackEvent(
             : "",
           language: clientInfo?.language ?? "",
           referrer: clientInfo?.referrer ?? "",
+          // Pass the visitor IP/UA in the payload (not just headers): Umami runs a
+          // full MaxMind lookup on payload.ip and skips its provider-header
+          // shortcut, so server-side events resolve country + region + city
+          // (headers alone yielded country only). This is Umami's documented
+          // server-side tracking pattern.
+          ...(clientInfo?.ip ? { ip: clientInfo.ip } : {}),
+          ...(clientInfo?.userAgent ? { userAgent: clientInfo.userAgent } : {}),
         },
       }),
     });

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -93,6 +93,7 @@ export const DatasetSchema = z.object({
   canDelete: z.boolean().optional(),
   isFeatured: z.boolean().optional(),
   canFeature: z.boolean().optional(),
+  canRefresh: z.boolean().optional(),
 });
 
 export type Dataset = z.infer<typeof DatasetSchema>;


### PR DESCRIPTION
## 1.13.0

### Added
- Admin-only manual dataset refresh with last-fetched timestamp caption [#346]
- Analytics: track sign-in, sign-out, downloads, page views, and featured-toggle events [#335], [#336], [#344], [#345]

### Changed
- Send visitor IP via `x-umami-client-ip` so server-side events resolve the right city [#344]
- Bound Umami fetch timeout and make event tracking non-blocking in routes [#335], [#336]
- Batch cron refresh tracking and gate manual dataset refresh to admins [#346]

### Fixed
- Featured dataset toggle now reflects the dataset's real featured state on the detail page [#335]
- Admin status now refreshes from the database on every session check [#335]
- Token refresh now fails closed on deleted users and uses edge-runtime-safe logging [#335]

### Security
- Bump js-yaml to 4.2.0 (DoS fix in the merge operator) [#337]

After merge: tag v1.13.0 on main, push tag, create GitHub release. CI auto-deploys main to production.

[#335]: https://github.com/osmforcities/osmforcities/pull/335
[#336]: https://github.com/osmforcities/osmforcities/pull/336
[#337]: https://github.com/osmforcities/osmforcities/pull/337
[#344]: https://github.com/osmforcities/osmforcities/pull/344
[#345]: https://github.com/osmforcities/osmforcities/pull/345
[#346]: https://github.com/osmforcities/osmforcities/pull/346