### PR TITLE
fix: broken dataset links in report emails

### DIFF
--- a/src/app/[locale]/explore/featured/page.tsx
+++ b/src/app/[locale]/explore/featured/page.tsx
@@ -5,6 +5,7 @@ import { processDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
+import { getDatasetPath } from "@/lib/urls";
 
 export const revalidate = 300;
 
@@ -101,7 +102,7 @@ export default async function FeaturedPage({
                 city={dataset.cityName}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.name ?? "other"}
-                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                href={getDatasetPath({ locale, areaId: dataset.areaId, templateId: dataset.templateId })}
                 stats={stats}
               />
             );

--- a/src/app/[locale]/explore/largest/page.tsx
+++ b/src/app/[locale]/explore/largest/page.tsx
@@ -5,6 +5,7 @@ import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/ex
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
+import { getDatasetPath } from "@/lib/urls";
 
 export const revalidate = 300;
 
@@ -97,7 +98,7 @@ export default async function LargestPage({
                 city={dataset.cityName}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.name ?? "other"}
-                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                href={getDatasetPath({ locale, areaId: dataset.areaId, templateId: dataset.templateId })}
                 stats={stats}
               />
             );

--- a/src/app/[locale]/explore/most-contributors/page.tsx
+++ b/src/app/[locale]/explore/most-contributors/page.tsx
@@ -5,6 +5,7 @@ import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/ex
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
+import { getDatasetPath } from "@/lib/urls";
 
 export const revalidate = 300;
 
@@ -98,7 +99,7 @@ export default async function MostContributorsPage({
                 city={dataset.cityName}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.name ?? "other"}
-                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                href={getDatasetPath({ locale, areaId: dataset.areaId, templateId: dataset.templateId })}
                 stats={stats}
               />
             );

--- a/src/app/[locale]/explore/most-saved/page.tsx
+++ b/src/app/[locale]/explore/most-saved/page.tsx
@@ -4,6 +4,7 @@ import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/ex
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
+import { getDatasetPath } from "@/lib/urls";
 
 export const revalidate = 300;
 
@@ -96,7 +97,7 @@ export default async function MostSavedPage({
                 city={dataset.cityName}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.name ?? "other"}
-                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                href={getDatasetPath({ locale, areaId: dataset.areaId, templateId: dataset.templateId })}
                 stats={stats}
               />
             );

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -6,6 +6,7 @@ import { formatRelativeTime } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
+import { getDatasetPath } from "@/lib/urls";
 
 export const revalidate = 300;
 
@@ -100,7 +101,7 @@ export default async function RecentlyEditedPage({
                 city={dataset.cityName}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.name ?? "other"}
-                href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+                href={getDatasetPath({ locale, areaId: dataset.areaId, templateId: dataset.templateId })}
                 stats={stats}
               />
             );

--- a/src/components/dataset/dataset-sections.tsx
+++ b/src/components/dataset/dataset-sections.tsx
@@ -4,6 +4,7 @@ import { Link } from "@/i18n/navigation";
 import { DatasetCard, type StatType } from "@/components/ui/dataset-card";
 import { processDatasetStats, formatRelativeTime } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { getDatasetPath } from "@/lib/urls";
 
 type SectionTemplate = {
   id: string;
@@ -64,7 +65,7 @@ export async function DatasetSections({
         city={dataset.cityName}
         country={dataset.area.countryCode ?? ""}
         category={resolved.category?.name ?? "other"}
-        href={`/${locale}/area/${dataset.areaId}/dataset/${dataset.templateId}`}
+        href={getDatasetPath({ locale, areaId: dataset.areaId, templateId: dataset.templateId })}
         stats={stats}
       />
     );

--- a/src/lib/__tests__/urls.test.ts
+++ b/src/lib/__tests__/urls.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { getDatasetPath, getDatasetUrl } from "../urls";
+
+describe("getDatasetPath", () => {
+  it("builds the area/template dataset path", () => {
+    expect(getDatasetPath({ locale: "en", areaId: 12345, templateId: "schools" })).toBe(
+      "/en/area/12345/dataset/schools"
+    );
+  });
+});
+
+describe("getDatasetUrl", () => {
+  it("prefixes the path with the base URL", () => {
+    expect(
+      getDatasetUrl("https://osmforcities.com", {
+        locale: "en",
+        areaId: 12345,
+        templateId: "schools",
+      })
+    ).toBe("https://osmforcities.com/en/area/12345/dataset/schools");
+  });
+});

--- a/src/lib/__tests__/urls.test.ts
+++ b/src/lib/__tests__/urls.test.ts
@@ -19,4 +19,14 @@ describe("getDatasetUrl", () => {
       })
     ).toBe("https://osmforcities.com/en/area/12345/dataset/schools");
   });
+
+  it("strips a trailing slash from the base URL", () => {
+    expect(
+      getDatasetUrl("https://osmforcities.com/", {
+        locale: "en",
+        areaId: 12345,
+        templateId: "schools",
+      })
+    ).toBe("https://osmforcities.com/en/area/12345/dataset/schools");
+  });
 });

--- a/src/lib/tasks/__tests__/user-report.test.ts
+++ b/src/lib/tasks/__tests__/user-report.test.ts
@@ -105,6 +105,8 @@ describe("user-report email generation", () => {
 
   const mockDataset = {
     id: "ds-1",
+    areaId: 12345,
+    templateId: "template-schools",
     cityName: "Sao Paulo",
     stats: {
       mostRecentElement: new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString(),
@@ -283,6 +285,20 @@ describe("user-report email generation", () => {
     const result = await generateNextUserReport();
     expect(result).toBeNull();
   });
+
+  it("links to the area/template dataset route, not the bare dataset id", async () => {
+    vi.mocked(getEmailT).mockResolvedValue(createMockT(enMessages));
+    vi.mocked(resolveTemplateForLocale).mockReturnValue({ name: "Schools", description: "Schools" });
+    mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+    mockPrisma.dataset.findMany.mockResolvedValue([mockDataset]);
+
+    const result = await generateNextUserReport();
+
+    expect(result?.emailContent.html).toContain(
+      `https://osmforcities.com/en/area/${mockDataset.areaId}/dataset/${mockDataset.templateId}`
+    );
+    expect(result?.emailContent.html).not.toContain(`/dataset/${mockDataset.id}`);
+  });
 });
 
 describe("deadlock scenario", () => {
@@ -302,6 +318,8 @@ describe("deadlock scenario", () => {
 
   const mockDatasetWithChanges = {
     id: "ds-1",
+    areaId: 12345,
+    templateId: "template-schools",
     cityName: "Sao Paulo",
     stats: {
       mostRecentElement: new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString(),
@@ -456,6 +474,8 @@ describe("report status tracking helpers", () => {
     mockPrisma.dataset.findMany.mockResolvedValue([
       {
         id: "ds-1",
+        areaId: 12345,
+        templateId: "template-schools",
         cityName: "Sao Paulo",
         stats: { mostRecentElement: new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString() },
         template: {

--- a/src/lib/tasks/user-report.ts
+++ b/src/lib/tasks/user-report.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db";
 import { htmlToText } from "html-to-text";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { getDatasetUrl } from "@/lib/urls";
 import {
   createEmailLink,
   getEmailT,
@@ -106,7 +107,11 @@ function generateEmailBodyWithChanges(
         .map(
           (ds) =>
             `${createEmailLink(
-              `${getBaseUrl()}/${userLocale}/area/${ds.areaId}/dataset/${ds.templateId}`,
+              getDatasetUrl(getBaseUrl(), {
+                locale: userLocale,
+                areaId: ds.areaId,
+                templateId: ds.templateId,
+              }),
               `${ds.templateName} - ${ds.name}`
             )}`
         )

--- a/src/lib/tasks/user-report.ts
+++ b/src/lib/tasks/user-report.ts
@@ -29,6 +29,8 @@ interface DatasetStats {
   };
   recentDatasets: Array<{
     id: string;
+    areaId: number;
+    templateId: string;
     name: string;
     templateName: string;
     lastChanged: Date | null;
@@ -55,6 +57,8 @@ function getLatestChangeDate(datasets: Array<{ stats?: DatasetStatsData }>): str
 function generateEmailBodyWithChanges(
   recentDatasets: Array<{
     id: string;
+    areaId: number;
+    templateId: string;
     name: string;
     templateName: string;
     lastChanged: Date | null;
@@ -62,12 +66,15 @@ function generateEmailBodyWithChanges(
   }>,
   frequency: "DAILY" | "WEEKLY",
   changedText: string,
-  deprecationText?: string
+  deprecationText: string | undefined,
+  userLocale: Locale
 ): string {
   const datasetsByDay = new Map<
     string,
     Array<{
       id: string;
+      areaId: number;
+      templateId: string;
       name: string;
       templateName: string;
     }>
@@ -82,6 +89,8 @@ function generateEmailBodyWithChanges(
     }
     datasetsByDay.get(dayKey)!.push({
       id: ds.id,
+      areaId: ds.areaId,
+      templateId: ds.templateId,
       name: ds.name,
       templateName: ds.templateName,
     });
@@ -97,7 +106,7 @@ function generateEmailBodyWithChanges(
         .map(
           (ds) =>
             `${createEmailLink(
-              `${getBaseUrl()}/dataset/${ds.id}`,
+              `${getBaseUrl()}/${userLocale}/area/${ds.areaId}/dataset/${ds.templateId}`,
               `${ds.templateName} - ${ds.name}`
             )}`
         )
@@ -162,7 +171,8 @@ async function generateEmailContent(
           recentDatasets,
           frequency,
           reportChangedText,
-          deprecationNotice
+          deprecationNotice,
+          userLocale
         )
       : await formatEmail(userLocale, "reportNoChanges", {
           savedDatasetsLink,
@@ -269,6 +279,8 @@ export async function generateNextUserReport(): Promise<{
     },
     select: {
       id: true,
+      areaId: true,
+      templateId: true,
       cityName: true,
       stats: true,
       template: {
@@ -340,6 +352,8 @@ export async function generateNextUserReport(): Promise<{
 
       return {
         id: dataset.id,
+        areaId: dataset.areaId,
+        templateId: dataset.templateId,
         name: dataset.cityName,
         templateName: resolvedTemplate.name,
         lastChanged: mostRecentElement ? new Date(mostRecentElement) : null,

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,17 @@
+import type { Locale } from "next-intl";
+
+interface DatasetLocation {
+  locale: Locale | string;
+  areaId: number;
+  templateId: string;
+}
+
+/** Path to a dataset page. Datasets are keyed by (areaId, templateId), not by id. */
+export function getDatasetPath({ locale, areaId, templateId }: DatasetLocation): string {
+  return `/${locale}/area/${areaId}/dataset/${templateId}`;
+}
+
+/** Absolute dataset URL for contexts without a router (emails, external links). */
+export function getDatasetUrl(baseUrl: string, location: DatasetLocation): string {
+  return `${baseUrl}${getDatasetPath(location)}`;
+}

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -13,5 +13,5 @@ export function getDatasetPath({ locale, areaId, templateId }: DatasetLocation):
 
 /** Absolute dataset URL for contexts without a router (emails, external links). */
 export function getDatasetUrl(baseUrl: string, location: DatasetLocation): string {
-  return `${baseUrl}${getDatasetPath(location)}`;
+  return `${baseUrl.replace(/\/+$/, "")}${getDatasetPath(location)}`;
 }


### PR DESCRIPTION
**Problem:** Dataset links in user report emails 404. They linked to `/dataset/{id}`, a route that never existed — dataset pages are keyed by `(areaId, templateId)`, not `id`. Broken since per-dataset links were added to reports (2025-07-25).

**Changes:**
- Fix the link to use the real `/{locale}/area/{areaId}/dataset/{templateId}` route
- Add `getDatasetPath`/`getDatasetUrl` in `src/lib/urls.ts` and use them everywhere this path was previously hand-built (5 explore pages, `dataset-sections.tsx`, `user-report.ts`) to prevent future drift
- Regression test asserting the report link format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset card links across explore pages and dataset sections for consistent, correct navigation to the localized area/template dataset routes.
  * Updated user report email links to point to the correct localized dataset pages (area/template), instead of legacy dataset ID routes.
* **New Features**
  * Centralized dataset URL generation via shared locale-aware URL helpers.
* **Tests**
  * Added URL helper tests to verify both dataset path formatting and absolute URL building.
  * Extended report email tests to validate the updated area/template link structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->