### PR TITLE
fix(analytics): fire view events client-side to stop counting scrapers

### DIFF
--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -20,7 +20,7 @@ import {
 import { DatasetUpsellPage } from "@/components/dataset/dataset-upsell-page";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/db";
-import { trackEventAfterResponse } from "@/lib/umami";
+import { TrackView } from "@/components/analytics/track-view";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { getAreaBoundary } from "@/lib/area-boundary";
 import { MAX_SAVES_PER_USER } from "@/lib/constants";
@@ -60,17 +60,18 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
       return <AreaNotFoundError areaId={areaId} />;
     }
 
-    await trackEventAfterResponse(
-      ANALYTICS_EVENTS.DATASET_UPSELL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`,
-    );
-
     return (
-      <DatasetUpsellPage
-        datasetName={template.name}
-        areaName={areaInfo.name}
-        areaId={areaId}
-      />
+      <>
+        <TrackView
+          event={ANALYTICS_EVENTS.DATASET_UPSELL_VIEW}
+          url={`/area/${areaId}/dataset/${encodeURIComponent(templateId)}/upsell`}
+        />
+        <DatasetUpsellPage
+          datasetName={template.name}
+          areaName={areaInfo.name}
+          areaId={areaId}
+        />
+      </>
     );
   }
 
@@ -123,9 +124,11 @@ async function AreaTemplateDatasetView({
 
     const dataset = transformDataset(result.dataset, session?.user || null, locale, { isSaved, skipTemplateResolution: true });
 
-    await trackEventAfterResponse(
-      ANALYTICS_EVENTS.DATASET_DETAIL_VIEW,
-      `/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`,
+    const trackDetailView = (
+      <TrackView
+        event={ANALYTICS_EVENTS.DATASET_DETAIL_VIEW}
+        url={`/area/${areaId}/dataset/${encodeURIComponent(templateId)}/view`}
+      />
     );
 
     const areaName = areaInfo?.name || dataset.area.name;
@@ -135,6 +138,7 @@ async function AreaTemplateDatasetView({
       const datasetT = await getTranslations("DatasetPage");
       return (
         <div className="bg-gray-50">
+          {trackDetailView}
           <div
             className="max-w-7xl mx-auto px-4 py-8 flex flex-col"
             style={{ minHeight: "calc(100vh - var(--nav-height))" }}
@@ -165,6 +169,7 @@ async function AreaTemplateDatasetView({
 
     return (
       <div className="bg-gray-50 lg:h-[calc(100dvh_-_var(--nav-height))] lg:flex lg:overflow-hidden">
+        {trackDetailView}
         <DatasetInteractiveSection dataset={dataset} boundary={boundary} savedCount={savedCount} saveLimit={MAX_SAVES_PER_USER} />
       </div>
     );

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -4,7 +4,7 @@ import { getAreaDetailsById } from "@/lib/nominatim";
 import { getAreaDataTypes } from "@/lib/area-templates";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
 import { DatasetGrid } from "@/components/ui/template-grid";
-import { trackEventAfterResponse } from "@/lib/umami";
+import { TrackView } from "@/components/analytics/track-view";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { auth } from "@/auth";
 
@@ -36,13 +36,6 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
     notFound();
   }
 
-  await trackEventAfterResponse(
-    session?.user
-      ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
-      : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT,
-    `/area/${areaId}/view`,
-  );
-
   const breadcrumbItems = [
     { label: navT("home"), href: "/" },
     { label: areaInfo.country || "Area" },
@@ -51,6 +44,14 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
 
   return (
     <div className="min-h-screen bg-gray-50 lg:min-h-0 lg:h-[calc(100dvh_-_var(--nav-height))] lg:flex lg:flex-col lg:overflow-hidden">
+      <TrackView
+        event={
+          session?.user
+            ? ANALYTICS_EVENTS.AREA_VIEW_LOGGED_IN
+            : ANALYTICS_EVENTS.AREA_VIEW_LOGGED_OUT
+        }
+        url={`/area/${areaId}/view`}
+      />
       {/* Header (fixed on desktop) */}
       <div className="max-w-7xl w-full mx-auto px-6 pt-8 pb-10 lg:flex-shrink-0">
         <div className="mb-6">

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -10,7 +10,7 @@ import { getTranslations, getLocale } from "next-intl/server";
 import { prisma } from "@/lib/db";
 import { DashboardGrid } from "@/components/dashboard/dashboard-grid";
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
-import { trackEventAfterResponse } from "@/lib/umami";
+import { TrackView } from "@/components/analytics/track-view";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { MAX_SAVES_PER_USER } from "@/lib/constants";
 
@@ -55,10 +55,9 @@ export default async function Dashboard() {
   const tabT = await getTranslations("TabLayout");
   const savedDatasets = await getSavedDatasets(user.id);
 
-  await trackEventAfterResponse(ANALYTICS_EVENTS.SAVED_DATASETS_VIEW, "/datasets/saved/view");
-
   return (
     <div className="min-h-screen bg-white dark:bg-black">
+      <TrackView event={ANALYTICS_EVENTS.SAVED_DATASETS_VIEW} url="/datasets/saved/view" />
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-6xl mx-auto space-y-8">
           <div>

--- a/src/components/analytics/__tests__/track-view.test.ts
+++ b/src/components/analytics/__tests__/track-view.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  startTrackViewEvent,
+  RETRY_INTERVAL_MS,
+  MAX_WAIT_MS,
+} from "../track-view";
+
+type TrackArg =
+  | string
+  | ((props: Record<string, unknown>) => Record<string, unknown>);
+
+function stubWindow(umami?: { track: (arg: TrackArg) => void }) {
+  vi.stubGlobal("window", umami ? { umami } : {});
+}
+
+describe("startTrackViewEvent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("fires immediately when umami is loaded", () => {
+    const track = vi.fn();
+    stubWindow({ track });
+    const onFired = vi.fn();
+
+    startTrackViewEvent("my_event", undefined, onFired);
+
+    expect(track).toHaveBeenCalledWith("my_event");
+    expect(onFired).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the function form to set a virtual url", () => {
+    const track = vi.fn();
+    stubWindow({ track });
+
+    startTrackViewEvent("my_event", "/virtual/url", vi.fn());
+
+    const arg = track.mock.calls[0][0];
+    expect(typeof arg).toBe("function");
+    const payload = (arg as Exclude<TrackArg, string>)({ hostname: "h" });
+    expect(payload).toEqual({
+      hostname: "h",
+      name: "my_event",
+      url: "/virtual/url",
+    });
+  });
+
+  it("retries until umami appears", () => {
+    stubWindow();
+    const onFired = vi.fn();
+
+    startTrackViewEvent("my_event", undefined, onFired);
+    vi.advanceTimersByTime(RETRY_INTERVAL_MS * 2);
+    expect(onFired).not.toHaveBeenCalled();
+
+    const track = vi.fn();
+    stubWindow({ track });
+    vi.advanceTimersByTime(RETRY_INTERVAL_MS);
+
+    expect(track).toHaveBeenCalledWith("my_event");
+    expect(onFired).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires only once after umami appears", () => {
+    stubWindow();
+    const onFired = vi.fn();
+
+    startTrackViewEvent("my_event", undefined, onFired);
+    const track = vi.fn();
+    stubWindow({ track });
+    vi.advanceTimersByTime(RETRY_INTERVAL_MS * 5);
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(onFired).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after MAX_WAIT_MS with a warning and without firing", () => {
+    stubWindow();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onFired = vi.fn();
+
+    startTrackViewEvent("my_event", undefined, onFired);
+    vi.advanceTimersByTime(MAX_WAIT_MS + RETRY_INTERVAL_MS * 2);
+
+    expect(onFired).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cleanup stops polling", () => {
+    stubWindow();
+    const onFired = vi.fn();
+
+    const cleanup = startTrackViewEvent("my_event", undefined, onFired);
+    cleanup();
+
+    const track = vi.fn();
+    stubWindow({ track });
+    vi.advanceTimersByTime(MAX_WAIT_MS);
+
+    expect(track).not.toHaveBeenCalled();
+    expect(onFired).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/analytics/track-view.tsx
+++ b/src/components/analytics/track-view.tsx
@@ -18,8 +18,47 @@ declare global {
   }
 }
 
-const RETRY_INTERVAL_MS = 500;
-const MAX_WAIT_MS = 10_000;
+export const RETRY_INTERVAL_MS = 500;
+export const MAX_WAIT_MS = 10_000;
+
+// Exported for unit tests (unit project is node-env, so the React wrapper
+// itself is exercised in the browser, not vitest). Returns a cleanup that
+// stops polling; calls onFired only when the event was actually sent.
+export function startTrackViewEvent(
+  event: string,
+  url: string | undefined,
+  onFired: () => void,
+): () => void {
+  const fire = () => {
+    if (!window.umami) return false;
+    if (url) {
+      window.umami.track((props) => ({ ...props, name: event, url }));
+    } else {
+      window.umami.track(event);
+    }
+    return true;
+  };
+
+  if (fire()) {
+    onFired();
+    return () => {};
+  }
+
+  const deadline = Date.now() + MAX_WAIT_MS;
+  const timer = setInterval(() => {
+    if (fire()) {
+      onFired();
+      clearInterval(timer);
+      return;
+    }
+    if (Date.now() > deadline) {
+      console.warn(`TrackView: gave up waiting for umami to load ("${event}")`);
+      clearInterval(timer);
+    }
+  }, RETRY_INTERVAL_MS);
+
+  return () => clearInterval(timer);
+}
 
 type TrackViewProps = {
   event: AnalyticsEvent;
@@ -37,32 +76,12 @@ export function TrackView({ event, url }: TrackViewProps) {
   const fired = useRef(false);
 
   useEffect(() => {
+    // Guard only against re-sending an event that was actually fired; a
+    // timed-out attempt leaves fired false so a prop change can retry.
     if (fired.current) return;
-
-    const fire = () => {
-      if (!window.umami) return false;
-      if (url) {
-        window.umami.track((props) => ({ ...props, name: event, url }));
-      } else {
-        window.umami.track(event);
-      }
-      return true;
-    };
-
-    if (fire()) {
+    return startTrackViewEvent(event, url, () => {
       fired.current = true;
-      return;
-    }
-
-    const deadline = Date.now() + MAX_WAIT_MS;
-    const timer = setInterval(() => {
-      if (fire() || Date.now() > deadline) {
-        fired.current = true;
-        clearInterval(timer);
-      }
-    }, RETRY_INTERVAL_MS);
-
-    return () => clearInterval(timer);
+    });
   }, [event, url]);
 
   return null;

--- a/src/components/analytics/track-view.tsx
+++ b/src/components/analytics/track-view.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { AnalyticsEvent } from "@/lib/analytics/events";
+
+type UmamiTracker = {
+  track: (
+    eventOrFn:
+      | string
+      | ((props: Record<string, unknown>) => Record<string, unknown>),
+    data?: Record<string, unknown>,
+  ) => void;
+};
+
+declare global {
+  interface Window {
+    umami?: UmamiTracker;
+  }
+}
+
+const RETRY_INTERVAL_MS = 500;
+const MAX_WAIT_MS = 10_000;
+
+type TrackViewProps = {
+  event: AnalyticsEvent;
+  /** Virtual URL recorded with the event (defaults to the current page URL). */
+  url?: string;
+};
+
+/**
+ * Fires a view event through the Umami browser script. Client-side on purpose:
+ * scrapers fetch HTML without running JS, so view events share page-view
+ * semantics instead of counting every bot hit (see dataset_upsell_view skew).
+ * The script loads afterInteractive, so poll briefly until window.umami exists.
+ */
+export function TrackView({ event, url }: TrackViewProps) {
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current) return;
+
+    const fire = () => {
+      if (!window.umami) return false;
+      if (url) {
+        window.umami.track((props) => ({ ...props, name: event, url }));
+      } else {
+        window.umami.track(event);
+      }
+      return true;
+    };
+
+    if (fire()) {
+      fired.current = true;
+      return;
+    }
+
+    const deadline = Date.now() + MAX_WAIT_MS;
+    const timer = setInterval(() => {
+      if (fire() || Date.now() > deadline) {
+        fired.current = true;
+        clearInterval(timer);
+      }
+    }, RETRY_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [event, url]);
+
+  return null;
+}

--- a/src/components/analytics/track-view.tsx
+++ b/src/components/analytics/track-view.tsx
@@ -73,14 +73,16 @@ type TrackViewProps = {
  * The script loads afterInteractive, so poll briefly until window.umami exists.
  */
 export function TrackView({ event, url }: TrackViewProps) {
-  const fired = useRef(false);
+  const lastFiredKey = useRef<string | null>(null);
 
   useEffect(() => {
-    // Guard only against re-sending an event that was actually fired; a
-    // timed-out attempt leaves fired false so a prop change can retry.
-    if (fired.current) return;
+    // Key the guard by event+url: client-side navigation can reuse this
+    // instance with new props (new view to record), while StrictMode re-runs
+    // and timed-out attempts must not re-send the same event.
+    const key = `${event}:${url ?? ""}`;
+    if (lastFiredKey.current === key) return;
     return startTrackViewEvent(event, url, () => {
-      fired.current = true;
+      lastFiredKey.current = key;
     });
   }, [event, url]);
 

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,4 +1,3 @@
-import { headers } from "next/headers";
 import { NextRequest, after } from "next/server";
 import { logger } from "@/lib/logger";
 
@@ -26,25 +25,11 @@ export function getClientInfo(request: NextRequest): ClientInfo {
   };
 }
 
-export async function getClientInfoFromHeaders(): Promise<ClientInfo> {
-  const h = await headers();
-  return {
-    ip:
-      h.get("x-forwarded-for")?.split(",")[0].trim() ||
-      h.get("x-real-ip") ||
-      undefined,
-    userAgent: h.get("user-agent") || undefined,
-    language:
-      h.get("accept-language")?.split(",")[0].split(";")[0].trim() ||
-      undefined,
-    referrer: h.get("referer") || undefined,
-  };
-}
-
 // Best-effort, bounded by a 5s timeout, and never rejects: failures are logged
 // so tracking can never break a user flow. Await it only where the response can
-// wait; for user-facing routes/pages prefer `trackEventAfterResponse` (or wrap
-// in `after()`) so analytics never delays the response.
+// wait; for API routes prefer `trackEventAfterRequest` (or wrap in `after()`)
+// so analytics never delays the response. Page-view-type events belong in the
+// client (`TrackView` component) so scrapers that never run JS don't count.
 export async function trackEvent(
   eventName: string,
   url: string,
@@ -97,23 +82,6 @@ export async function trackEvent(
     }
   } catch (err) {
     logger.warn("Umami event error", { event: eventName, err });
-  }
-}
-
-// Fire-and-forget tracking for server components/pages: captures request client
-// info during render, then schedules the event to run after the response is sent
-// so analytics never blocks the render. De-duplicates the capture+after+track
-// pattern repeated across pages. Never rejects — a headers() failure is logged,
-// not propagated to the render.
-export async function trackEventAfterResponse(
-  eventName: string,
-  url: string,
-): Promise<void> {
-  try {
-    const clientInfo = await getClientInfoFromHeaders();
-    after(() => trackEvent(eventName, url, clientInfo));
-  } catch (err) {
-    logger.warn("trackEventAfterResponse error", { event: eventName, err });
   }
 }
 


### PR DESCRIPTION
## Analytics: view events counted scrapers, page views did not

**Problem:** Umami showed `dataset_upsell_view` at 657 events (91% of all custom events) with almost no matching page views. View-type events fired server-side during page render (`trackEventAfterResponse` -> POST to Umami `/api/send`), so every scraper HTML fetch counted. Page views come only from the Umami browser script, which requires JS — scrapers never run it. Umami's isbot filter does not help because these scrapers send browser-like user agents.

**Acceptance Criteria:**
- [x] View events fire only from JS-executing browsers (same semantics as page views)
- [x] curl fetch of a logged-out dataset page produces zero events
- [x] All five view events (`dataset_upsell_view`, `dataset_detail_view`, `area_view_logged_in`, `area_view_logged_out`, `saved_datasets_view`) reach `/api/send` from the browser with their virtual URLs preserved
- [x] Action events (save, download, sign_up, create, featured, cron) stay server-side
- [x] type-check, lint, unit tests green

**Changes:**
New `TrackView` client component (`src/components/analytics/track-view.tsx`) fires `window.umami.track()` once per mount, polling briefly until the afterInteractive script loads. The three pages (dataset detail/upsell, area, dashboard) render `<TrackView>` instead of calling `trackEventAfterResponse`; logged-in/out branching stays in the server component. Removed now-unused `trackEventAfterResponse` and `getClientInfoFromHeaders` from `src/lib/umami.ts`; `trackEvent`/`trackEventAfterRequest` remain for API routes.

Verified in a worktree against a local Umami capture server: curl (no JS) fires nothing; a real browser (Playwright) delivers all five events plus page views. No privacy change — the browser script already sends page views with IP/UA from the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic view analytics tracking across area, dataset (including empty state and upsell), and dashboard pages.

* **Bug Fixes**
  * Improved reliability of view tracking when the analytics script loads late by using bounded retry logic.
  * Prevented duplicate view events from being recorded.
  * Ensured pages render immediately without waiting for analytics to finish.

* **Tests**
  * Added automated coverage for the view-tracking retry, timeout, and de-duplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->