### PR TITLE
feat: filter-dimension computation helper (#338)

### DIFF
--- a/src/lib/__tests__/filter-dimensions.test.ts
+++ b/src/lib/__tests__/filter-dimensions.test.ts
@@ -1,0 +1,188 @@
+// src/lib/__tests__/filter-dimensions.test.ts
+
+import { describe, it, expect } from "vitest";
+import type { Feature } from "geojson";
+import {
+  computeFilterDimensions,
+  FILTERABLE_TAGS,
+  AGE_CATEGORY_ORDER,
+  type FilterDimension,
+} from "../filter-dimensions";
+
+const feature = (properties: Record<string, unknown> | null): Feature =>
+  ({ type: "Feature", geometry: null, properties } as unknown as Feature);
+
+const byKey = (dims: FilterDimension[], key: string) =>
+  dims.find((d) => d.key === key);
+
+describe("computeFilterDimensions — tag dimensions", () => {
+  it("counts allow-listed tag values and sorts desc by count", () => {
+    const features = [
+      feature({ surface: "asphalt" }),
+      feature({ surface: "asphalt" }),
+      feature({ surface: "asphalt" }),
+      feature({ surface: "gravel" }),
+      feature({ surface: "paving_stones" }),
+      feature({ surface: "gravel" }),
+    ];
+
+    const surface = byKey(computeFilterDimensions(features), "surface");
+
+    expect(surface).toBeDefined();
+    expect(surface!.kind).toBe("tag");
+    expect(surface!.values).toEqual([
+      { value: "asphalt", count: 3 },
+      { value: "gravel", count: 2 },
+      { value: "paving_stones", count: 1 },
+    ]);
+  });
+
+  it("counts features missing the tag (null/undefined)", () => {
+    const features = [
+      feature({ surface: "asphalt" }),
+      feature({ surface: null }),
+      feature({}), // undefined
+      feature({ amenity: "bench" }), // has a different tag, still missing surface
+    ];
+
+    const surface = byKey(computeFilterDimensions(features), "surface");
+
+    expect(surface!.missing).toBe(3);
+    expect(surface!.values).toEqual([{ value: "asphalt", count: 1 }]);
+  });
+
+  it("merges values case-insensitively, preserving the dominant casing", () => {
+    const features = [
+      feature({ material: "Wood" }),
+      feature({ material: "wood" }),
+      feature({ material: "wood" }),
+      feature({ material: "WOOD" }),
+      feature({ material: "Metal" }),
+    ];
+
+    const material = byKey(computeFilterDimensions(features), "material");
+
+    expect(material!.values).toEqual([
+      // count is the case-folded total (Wood+wood+wood+WOOD); display uses the
+      // dominant casing "wood" (3 of 4 occurrences)
+      { value: "wood", count: 4 },
+      { value: "Metal", count: 1 },
+    ]);
+  });
+
+  it("coerces non-string tag values to strings", () => {
+    // `amenity` is allow-listed; use it with a numeric-ish value to exercise coercion
+    const features = [
+      feature({ amenity: 2 }),
+      feature({ amenity: 2 }),
+      feature({ amenity: "bench" }),
+    ];
+
+    const amenity = byKey(computeFilterDimensions(features), "amenity");
+
+    expect(amenity!.values).toEqual([
+      { value: "2", count: 2 },
+      { value: "bench", count: 1 },
+    ]);
+  });
+
+  it("omits allow-listed tags absent from all features", () => {
+    const features = [feature({ amenity: "bench" })];
+
+    const dims = computeFilterDimensions(features);
+
+    expect(byKey(dims, "surface")).toBeUndefined();
+    expect(byKey(dims, "material")).toBeUndefined();
+    expect(byKey(dims, "amenity")).toBeDefined();
+  });
+
+  it("ignores present tags that are not allow-listed", () => {
+    const features = [
+      feature({ colour: "red" }),
+      feature({ colour: "blue" }),
+    ];
+
+    const dims = computeFilterDimensions(features);
+
+    expect(byKey(dims, "colour")).toBeUndefined();
+    // only the always-present age dimension remains
+    expect(dims.map((d) => d.key)).toEqual(["age"]);
+  });
+
+  it("honors a custom filterableTags argument over the default seed", () => {
+    const features = [
+      feature({ colour: "red" }),
+      feature({ surface: "asphalt" }),
+    ];
+
+    const dims = computeFilterDimensions(features, ["colour"]);
+
+    expect(byKey(dims, "colour")).toBeDefined();
+    expect(byKey(dims, "surface")).toBeUndefined();
+  });
+});
+
+describe("computeFilterDimensions — age dimension", () => {
+  it("is always present with buckets in ordinal order, omitting zero-count buckets", () => {
+    const features = [
+      feature({ ageCategory: "older" }),
+      feature({ ageCategory: "recent" }),
+      feature({ ageCategory: "recent" }),
+      feature({ ageCategory: "very-old" }),
+    ];
+
+    const age = byKey(computeFilterDimensions(features), "age");
+
+    expect(age!.kind).toBe("age");
+    // ordinal order (recent, medium, older, very-old); `medium` omitted (zero)
+    expect(age!.values).toEqual([
+      { value: "recent", count: 2 },
+      { value: "older", count: 1 },
+      { value: "very-old", count: 1 },
+    ]);
+  });
+
+  it("counts features without a valid ageCategory as missing", () => {
+    const features = [
+      feature({ ageCategory: "recent" }),
+      feature({ ageCategory: "bogus" }),
+      feature({}),
+      feature(null),
+    ];
+
+    const age = byKey(computeFilterDimensions(features), "age");
+
+    expect(age!.missing).toBe(3);
+    expect(age!.values).toEqual([{ value: "recent", count: 1 }]);
+  });
+
+  it("keeps age buckets in the declared ordinal order", () => {
+    const features = AGE_CATEGORY_ORDER.map((c) => feature({ ageCategory: c }));
+
+    const age = byKey(computeFilterDimensions(features), "age");
+
+    expect(age!.values.map((v) => v.value)).toEqual([...AGE_CATEGORY_ORDER]);
+  });
+});
+
+describe("computeFilterDimensions — edge cases", () => {
+  it("handles an empty feature array without throwing", () => {
+    const dims = computeFilterDimensions([]);
+
+    expect(dims).toEqual([{ key: "age", kind: "age", values: [], missing: 0 }]);
+  });
+
+  it("handles features with null properties", () => {
+    const features = [feature(null), feature(null)];
+
+    const dims = computeFilterDimensions(features);
+
+    // no tag dimensions; age present with everything missing
+    expect(dims).toHaveLength(1);
+    expect(byKey(dims, "age")!.missing).toBe(2);
+  });
+
+  it("exposes a non-empty default allow-list", () => {
+    expect(FILTERABLE_TAGS.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/filter-dimensions.ts
+++ b/src/lib/filter-dimensions.ts
@@ -1,0 +1,145 @@
+// src/lib/filter-dimensions.ts
+
+import type { Feature } from "geojson";
+
+/**
+ * A single filterable value within a dimension, with how many features carry it.
+ */
+export type FilterDimensionValue = { value: string; count: number };
+
+/**
+ * A filter dimension the FilterPanel (#339) renders and the map swap (#340)
+ * drives highlight/mute from.
+ *
+ * - `tag`  — an allow-listed OSM tag; `values` sorted desc by count.
+ * - `age`  — feature edit-age buckets; `values` in fixed ordinal order.
+ *
+ * `missing` = features lacking this dimension (data-quality signal).
+ */
+export type FilterDimension = {
+  key: string;
+  kind: "tag" | "age";
+  values: FilterDimensionValue[];
+  missing: number;
+};
+
+/**
+ * Allow-list of tag keys that become filter dimensions. Introduced progressively:
+ * grow this list as more tags prove useful to filter on.
+ *
+ * TODO(#184): move allow-list to per-template config (templates.yml) so datasets
+ * expose the tags meaningful to them (e.g. trees -> genus/leaf_type).
+ */
+export const FILTERABLE_TAGS: string[] = [
+  "surface",
+  "amenity",
+  "material",
+  "leaf_type",
+];
+
+/**
+ * Fixed ordinal order for the age dimension, mirroring the buckets assigned by
+ * `categorizeFeatureByAge` in osm-data-processor.ts.
+ */
+export const AGE_CATEGORY_ORDER = [
+  "recent",
+  "medium",
+  "older",
+  "very-old",
+] as const;
+
+type AgeCategory = (typeof AGE_CATEGORY_ORDER)[number];
+
+const isAgeCategory = (v: unknown): v is AgeCategory =>
+  typeof v === "string" && (AGE_CATEGORY_ORDER as readonly string[]).includes(v);
+
+/**
+ * Count an allow-listed tag across features, case-folded, preserving the dominant
+ * original casing for display. Returns values sorted desc by count plus a `missing`
+ * count. Salvaged from `detectCategoricalTheme` (map-themes/detection.ts) minus the
+ * color/scoring/category-count gating — here we surface every value.
+ */
+function computeTagDimension(features: Feature[], key: string): FilterDimension {
+  const countByLower = new Map<string, number>();
+  // lower -> (original casing -> count), to pick the dominant casing for display
+  const casingByLower = new Map<string, Map<string, number>>();
+  let missing = 0;
+
+  for (const feature of features) {
+    const raw = feature.properties?.[key];
+    if (raw === null || raw === undefined) {
+      missing++;
+      continue;
+    }
+
+    const value = String(raw);
+    const lower = value.toLowerCase();
+    countByLower.set(lower, (countByLower.get(lower) ?? 0) + 1);
+
+    if (!casingByLower.has(lower)) casingByLower.set(lower, new Map());
+    const casing = casingByLower.get(lower)!;
+    casing.set(value, (casing.get(value) ?? 0) + 1);
+  }
+
+  const values: FilterDimensionValue[] = Array.from(countByLower.entries())
+    .map(([lower, count]) => ({ value: dominantCasing(casingByLower.get(lower)!), count }))
+    .sort((a, b) => b.count - a.count);
+
+  return { key, kind: "tag", values, missing };
+}
+
+/** Pick the most frequent original casing variant for a lowercased value. */
+function dominantCasing(casing: Map<string, number>): string {
+  let best = "";
+  let bestCount = -1;
+  for (const [variant, count] of casing.entries()) {
+    if (count > bestCount) {
+      bestCount = count;
+      best = variant;
+    }
+  }
+  return best;
+}
+
+/**
+ * Count the internal `ageCategory` property into ordinal buckets. Zero-count buckets
+ * are omitted; features without a valid category count toward `missing`.
+ */
+function computeAgeDimension(features: Feature[]): FilterDimension {
+  const counts = new Map<AgeCategory, number>();
+  let missing = 0;
+
+  for (const feature of features) {
+    const category = feature.properties?.ageCategory;
+    if (isAgeCategory(category)) {
+      counts.set(category, (counts.get(category) ?? 0) + 1);
+    } else {
+      missing++;
+    }
+  }
+
+  const values: FilterDimensionValue[] = AGE_CATEGORY_ORDER.filter((c) =>
+    counts.has(c)
+  ).map((c) => ({ value: c, count: counts.get(c)! }));
+
+  return { key: "age", kind: "age", values, missing };
+}
+
+/**
+ * Turn a dataset's geojson features into filter dimensions for the FilterPanel.
+ *
+ * Emits one dimension per allow-listed tag that is present in at least one feature
+ * (sorted desc by count, with a `missing` count), plus an always-present `age`
+ * dimension. Pure — pass a custom `filterableTags` to override the default seed list.
+ */
+export function computeFilterDimensions(
+  features: Feature[],
+  filterableTags: string[] = FILTERABLE_TAGS
+): FilterDimension[] {
+  const tagDimensions = filterableTags
+    .map((key) => computeTagDimension(features, key))
+    // Only surface tags actually present in the data.
+    .filter((dim) => dim.values.length > 0);
+
+  return [...tagDimensions, computeAgeDimension(features)];
+}

--- a/src/lib/filter-dimensions.ts
+++ b/src/lib/filter-dimensions.ts
@@ -30,7 +30,7 @@ export type FilterDimension = {
  * TODO(#184): move allow-list to per-template config (templates.yml) so datasets
  * expose the tags meaningful to them (e.g. trees -> genus/leaf_type).
  */
-export const FILTERABLE_TAGS: string[] = [
+export const FILTERABLE_TAGS: readonly string[] = [
   "surface",
   "amenity",
   "material",
@@ -134,7 +134,7 @@ function computeAgeDimension(features: Feature[]): FilterDimension {
  */
 export function computeFilterDimensions(
   features: Feature[],
-  filterableTags: string[] = FILTERABLE_TAGS
+  filterableTags: readonly string[] = FILTERABLE_TAGS
 ): FilterDimension[] {
   const tagDimensions = filterableTags
     .map((key) => computeTagDimension(features, key))


### PR DESCRIPTION
## Issue #338: filter-dimension computation helper (tag value counts + age buckets)

**Problem:** Epic #184 reshapes the dataset map from color-by-value themes to a neutral map driven by a left-panel FilterPanel. Step 1 needs a pure function that turns a dataset's geojson features into the "filter dimensions" FilterPanel (#339) renders and the map swap (#340) consumes. No UI in this ticket.

**Acceptance Criteria:**
- [x] Pure function, unit tested (counts, missing, case-folding)
- [x] Handles empty/edge datasets
- [x] `pnpm type-check` passes

**Design note (deviation from issue text):** The issue described a deny-list (exclude `@*` + internal fields, show all other tags). Per maintainer decision, this uses an **allow-list** instead — only explicitly-approved tag keys become filter dimensions, introduced progressively. The helper stays pure by taking the allow-list as a parameter (`FILTERABLE_TAGS` seed default: surface, amenity, material, leaf_type). Per-template allow-lists (templates.yml) are a deliberate follow-up.

**Changes:**
- New `src/lib/filter-dimensions.ts` — `computeFilterDimensions(features, filterableTags?)`.
  - Tag dims: case-folded value counts with dominant casing preserved, sorted desc, plus a `missing` count; only emitted for allow-listed tags present in the data; non-string values coerced.
  - Age dim: always emitted, ordinal buckets (recent/medium/older/very-old) from the internal `ageCategory`; zero-count buckets omitted; invalid/absent counts toward `missing`.
  - Salvaged counting/case-folding from `detectCategoricalTheme` (map-themes/detection.ts); dropped color/scoring/category-count gating so all values surface.
- New `src/lib/__tests__/filter-dimensions.test.ts` — 13 vitest cases (counts, missing, case-folding, coercion, allow-list, custom arg, age ordering, empty/null edges).
- No changes to `map-themes/` — that cleanup is #341.

Closes #338.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filter-dimension computation for the map/feature filtering experience.
  * Tag values are counted case-insensitively, merged for display with dominant casing, sorted by popularity, and report missing values for null/undefined.
  * Only configured/filterable tags with observed values appear; non-filterable tags are ignored.
  * Added an age-category filter with consistent bucket ordering and explicit missing/invalid handling.
* **Tests**
  * Added a comprehensive test suite covering tags, age buckets, empty inputs, and missing properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->