### PR TITLE
feat(map): center dataset map on admin centre for large areas

### DIFF
--- a/prisma/migrations/20260718111325_fix_dataset_saves_constraint_names/migration.sql
+++ b/prisma/migrations/20260718111325_fix_dataset_saves_constraint_names/migration.sql
@@ -1,0 +1,14 @@
+-- Rename constraints/indexes left behind by the dataset_watches -> dataset_saves
+-- table rename (20260618075936), which renamed the table only.
+
+-- AlterTable
+ALTER TABLE "dataset_saves" RENAME CONSTRAINT "dataset_watches_pkey" TO "dataset_saves_pkey";
+
+-- RenameForeignKey
+ALTER TABLE "dataset_saves" RENAME CONSTRAINT "dataset_watches_datasetId_fkey" TO "dataset_saves_datasetId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "dataset_saves" RENAME CONSTRAINT "dataset_watches_userId_fkey" TO "dataset_saves_userId_fkey";
+
+-- RenameIndex
+ALTER INDEX "dataset_watches_userId_datasetId_key" RENAME TO "dataset_saves_userId_datasetId_key";

--- a/prisma/migrations/20260718111326_add_area_center/migration.sql
+++ b/prisma/migrations/20260718111326_add_area_center/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "areas" ADD COLUMN     "centerLat" DOUBLE PRECISION,
+ADD COLUMN     "centerLon" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,8 @@ model Area {
   name        String
   countryCode String?
   bounds      String?
+  centerLat   Float?
+  centerLon   Float?
   geojson     Json?
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt

--- a/src/app/api/datasets/[id]/route.ts
+++ b/src/app/api/datasets/[id]/route.ts
@@ -33,6 +33,8 @@ export async function GET(
             name: true,
             countryCode: true,
             bounds: true,
+            centerLat: true,
+            centerLon: true,
             geojson: true,
           },
         },

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -40,11 +40,9 @@ export async function POST(req: NextRequest) {
 
   if (!area) {
     try {
-      const [fetched, countryCode] = await Promise.all([
+      const [fetched, areaDetails] = await Promise.all([
         fetchOsmRelationData(osmRelationId),
-        getAreaDetailsById(osmRelationId)
-          .then((details) => details?.countryCode ?? null)
-          .catch(() => null),
+        getAreaDetailsById(osmRelationId).catch(() => null),
       ]);
 
       if (!fetched)
@@ -58,7 +56,9 @@ export async function POST(req: NextRequest) {
           id: osmRelationId,
           name: fetched.name,
           bounds: fetched.bounds,
-          countryCode,
+          countryCode: areaDetails?.countryCode ?? null,
+          centerLat: areaDetails?.centerLat ?? null,
+          centerLon: areaDetails?.centerLon ?? null,
           geojson: JSON.parse(JSON.stringify(fetched.convertedGeojson)),
         },
       });

--- a/src/components/dataset/map/hooks/use-map-data.ts
+++ b/src/components/dataset/map/hooks/use-map-data.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { FeatureCollection } from "geojson";
 import { GeoJSONFeatureCollectionSchema } from "@/types/geojson";
 import { processOSMFeaturesForVisualization } from "../../../../lib/osm-data-processor";
-import { calculateBbox, parseAreaBounds } from "../../../../lib/utils";
+import { calculateBbox, computeInitialViewState } from "../../../../lib/utils";
 import type { DateFilter } from "@/types/geojson";
 import type { Dataset } from "@/schemas/dataset";
 
@@ -32,29 +32,10 @@ export function useMapData({ dataset, dateFilter }: UseMapDataProps) {
     return calculateBbox(processedData);
   }, [processedData]);
 
-  const initialViewState = useMemo(() => {
-    const areaBounds = parseAreaBounds(dataset.area);
-
-    if (areaBounds) {
-      return {
-        bounds: areaBounds,
-        fitBoundsOptions: { padding: 20 },
-      };
-    }
-
-    if (dataBounds) {
-      return {
-        bounds: dataBounds,
-        fitBoundsOptions: { padding: 20 },
-      };
-    }
-
-    return {
-      longitude: 0,
-      latitude: 0,
-      zoom: 2,
-    };
-  }, [dataset.area, dataBounds]);
+  const initialViewState = useMemo(
+    () => computeInitialViewState(dataset.area, dataBounds),
+    [dataset.area, dataBounds]
+  );
 
   const hasFilteredData = Boolean(processedData?.features?.length);
 

--- a/src/lib/__tests__/area-conversion.test.ts
+++ b/src/lib/__tests__/area-conversion.test.ts
@@ -54,6 +54,29 @@ describe("fromNominatim", () => {
     expect(area.country).toBe("Portugal");
   });
 
+  it("keeps center coordinates from lat/lon", () => {
+    const area = fromNominatim(mockNominatimCity);
+
+    expect(area.centerLat).toBe(38.7);
+    expect(area.centerLon).toBe(-9.1);
+  });
+
+  it("omits center when lat/lon are not numeric", () => {
+    const invalidCenter = { ...mockNominatimCity, lat: "abc", lon: "-9.1" };
+    const area = fromNominatim(invalidCenter);
+
+    expect(area.centerLat).toBeUndefined();
+    expect(area.centerLon).toBeUndefined();
+  });
+
+  it("omits center when lat/lon are out of range", () => {
+    const outOfRange = { ...mockNominatimCity, lat: "91", lon: "-9.1" };
+    const area = fromNominatim(outOfRange);
+
+    expect(area.centerLat).toBeUndefined();
+    expect(area.centerLon).toBeUndefined();
+  });
+
   it("reorders bbox from [minLat, maxLat, minLon, maxLon] to [minLat, minLon, maxLat, maxLon]", () => {
     const area = fromNominatim(mockNominatimCity);
 

--- a/src/lib/__tests__/dataset-operations.test.ts
+++ b/src/lib/__tests__/dataset-operations.test.ts
@@ -13,8 +13,11 @@ vi.mock("@/lib/db", () => ({
         name: "Test Area",
         countryCode: "US",
         bounds: null,
+        centerLat: 38.7,
+        centerLon: -9.1,
         geojson: null,
       }),
+      update: vi.fn(),
     },
   },
 }));
@@ -55,10 +58,13 @@ vi.mock("@/lib/nominatim", () => ({
 
 import { getOrCreateDataset } from "@/lib/dataset-operations";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
+import { getAreaDetailsById } from "@/lib/nominatim";
 import { prisma } from "@/lib/db";
 
 const mockFetchDatasetSnapshot = vi.mocked(fetchDatasetSnapshot);
 const mockDatasetFindFirst = vi.mocked(prisma.dataset.findFirst);
+const mockGetAreaDetailsById = vi.mocked(getAreaDetailsById);
+const mockAreaUpdate = vi.mocked(prisma.area.update);
 
 const existingDatasetRow = {
   id: "ds-1",
@@ -75,7 +81,15 @@ const existingDatasetRow = {
   isActive: true,
   isFeatured: true,
   template: { id: "tmpl-1", name: "Test", description: null, translations: [] },
-  area: { id: 1, name: "Test City", countryCode: "US", bounds: null, geojson: null },
+  area: {
+    id: 1,
+    name: "Test City",
+    countryCode: "US",
+    bounds: null,
+    centerLat: 38.7,
+    centerLon: -9.1,
+    geojson: null,
+  },
   user: null,
   savedBy: [],
 };
@@ -95,6 +109,43 @@ describe("getOrCreateDataset — isFeatured passthrough", () => {
     const selectArg = mockDatasetFindFirst.mock.calls[0]?.[0]?.select;
     expect(selectArg?.isFeatured).toBe(true);
     expect(dataset.isFeatured).toBe(true);
+  });
+});
+
+describe("getOrCreateDataset — area details backfill", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("backfills center coordinates when the area is missing them", async () => {
+    mockDatasetFindFirst.mockResolvedValueOnce({
+      ...existingDatasetRow,
+      area: { ...existingDatasetRow.area, centerLat: null, centerLon: null },
+    } as never);
+    mockGetAreaDetailsById.mockResolvedValueOnce({
+      countryCode: "pt",
+      centerLat: 38.7,
+      centerLon: -9.1,
+    } as never);
+
+    await getOrCreateDataset(1, "test-template", "en");
+    // Backfill is fire-and-forget; flush pending promises
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockAreaUpdate).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { countryCode: "pt", centerLat: 38.7, centerLon: -9.1 },
+    });
+  });
+
+  it("does not backfill when countryCode and center are present", async () => {
+    mockDatasetFindFirst.mockResolvedValueOnce(existingDatasetRow as never);
+
+    await getOrCreateDataset(1, "test-template", "en");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockGetAreaDetailsById).not.toHaveBeenCalled();
+    expect(mockAreaUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/__tests__/dataset-operations.test.ts
+++ b/src/lib/__tests__/dataset-operations.test.ts
@@ -138,6 +138,22 @@ describe("getOrCreateDataset — area details backfill", () => {
     });
   });
 
+  it("skips the update when Nominatim has nothing new", async () => {
+    mockDatasetFindFirst.mockResolvedValueOnce({
+      ...existingDatasetRow,
+      area: { ...existingDatasetRow.area, centerLat: null, centerLon: null },
+    } as never);
+    mockGetAreaDetailsById.mockResolvedValueOnce({
+      countryCode: "us",
+    } as never);
+
+    await getOrCreateDataset(1, "test-template", "en");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // countryCode already set and no center returned: no write
+    expect(mockAreaUpdate).not.toHaveBeenCalled();
+  });
+
   it("does not backfill when countryCode and center are present", async () => {
     mockDatasetFindFirst.mockResolvedValueOnce(existingDatasetRow as never);
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { isSmallAreaBounds, computeInitialViewState } from "@/lib/utils";
+import type { Bbox } from "@/types/geojson";
+
+// GeoJSON bbox order: [minLon, minLat, maxLon, maxLat]
+const smallTownBbox: Bbox = [-9.2, 38.69, -9.1, 38.79]; // ~0.1 deg span
+const tokyoBbox: Bbox = [135.0, 20.2, 154.2, 35.9]; // includes Ogasawara islands
+
+// DB bounds string order: "minLat,minLon,maxLat,maxLon"
+const smallTownBounds = "38.69,-9.2,38.79,-9.1";
+const tokyoBounds = "20.2,135.0,35.9,154.2";
+
+describe("isSmallAreaBounds", () => {
+  it("accepts a small town bbox", () => {
+    expect(isSmallAreaBounds(smallTownBbox)).toBe(true);
+  });
+
+  it("rejects a Tokyo-scale scattered bbox", () => {
+    expect(isSmallAreaBounds(tokyoBbox)).toBe(false);
+  });
+
+  it("accepts a bbox exactly at the threshold", () => {
+    expect(isSmallAreaBounds([10.0, 0.0, 10.25, 0.25])).toBe(true);
+  });
+
+  it("rejects a bbox just over the threshold", () => {
+    expect(isSmallAreaBounds([10.0, 0.0, 10.3, 0.3])).toBe(false);
+  });
+
+  it("corrects longitude span at high latitude", () => {
+    // 0.4 deg of longitude at 70N is ~15 km — small despite the raw span
+    expect(isSmallAreaBounds([20.0, 69.9, 20.4, 70.1])).toBe(true);
+  });
+});
+
+describe("computeInitialViewState", () => {
+  it("fits bounds for a small area even when a center exists", () => {
+    const view = computeInitialViewState(
+      { bounds: smallTownBounds, centerLat: 38.74, centerLon: -9.15 },
+      null
+    );
+
+    expect(view).toEqual({
+      bounds: [-9.2, 38.69, -9.1, 38.79],
+      fitBoundsOptions: { padding: 20 },
+    });
+  });
+
+  it("centers at fixed zoom for a large area with a center", () => {
+    const view = computeInitialViewState(
+      { bounds: tokyoBounds, centerLat: 35.6768601, centerLon: 139.7638947 },
+      null
+    );
+
+    expect(view).toEqual({
+      longitude: 139.7638947,
+      latitude: 35.6768601,
+      zoom: 12,
+    });
+  });
+
+  it("falls back to bounds fit for a large area without a center", () => {
+    const view = computeInitialViewState(
+      { bounds: tokyoBounds, centerLat: null, centerLon: null },
+      null
+    );
+
+    expect(view).toEqual({
+      bounds: [135.0, 20.2, 154.2, 35.9],
+      fitBoundsOptions: { padding: 20 },
+    });
+  });
+
+  it("uses the center when bounds are missing", () => {
+    const view = computeInitialViewState(
+      { bounds: null, centerLat: 35.68, centerLon: 139.76 },
+      null
+    );
+
+    expect(view).toEqual({ longitude: 139.76, latitude: 35.68, zoom: 12 });
+  });
+
+  it("falls back to data bounds when area has neither bounds nor center", () => {
+    const dataBounds: Bbox = [139.7, 35.6, 139.8, 35.7];
+    const view = computeInitialViewState(
+      { bounds: null, centerLat: null, centerLon: null },
+      dataBounds
+    );
+
+    expect(view).toEqual({
+      bounds: dataBounds,
+      fitBoundsOptions: { padding: 20 },
+    });
+  });
+
+  it("falls back to world view when nothing is available", () => {
+    const view = computeInitialViewState(
+      { bounds: null, centerLat: null, centerLon: null },
+      null
+    );
+
+    expect(view).toEqual({ longitude: 0, latitude: 0, zoom: 2 });
+  });
+});

--- a/src/lib/area-conversion.ts
+++ b/src/lib/area-conversion.ts
@@ -60,6 +60,24 @@ function normalizeBoundsToBbox(bounds: { minlat: number; minlon: number; maxlat:
   return [bounds.minlat, bounds.minlon, bounds.maxlat, bounds.maxlon];
 }
 
+function parseCenter(lat: string, lon: string): { centerLat?: number; centerLon?: number } {
+  const centerLat = parseFloat(lat);
+  const centerLon = parseFloat(lon);
+
+  if (
+    isNaN(centerLat) ||
+    isNaN(centerLon) ||
+    centerLat < -90 ||
+    centerLat > 90 ||
+    centerLon < -180 ||
+    centerLon > 180
+  ) {
+    return {};
+  }
+
+  return { centerLat, centerLon };
+}
+
 export function fromNominatim(result: NominatimResult): Area {
   validateId(result.osm_id);
 
@@ -67,6 +85,7 @@ export function fromNominatim(result: NominatimResult): Area {
   validateBBox(bbox);
 
   return {
+    ...parseCenter(result.lat, result.lon),
     id: result.osm_id,
     name: result.name?.trim() || result.display_name?.split(",")[0].trim() || "",
     displayName: result.display_name?.trim() || "",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,6 +11,12 @@ export const DEPRECATION_DAYS = 30;
 /** Simplification tolerance for area boundaries (reduces coordinate count while preserving detail) */
 export const BOUNDARY_SIMPLIFICATION_TOLERANCE = 0.00001;
 
+/** Initial zoom for the dataset map when centering on the area's admin centre */
+export const DATASET_MAP_DEFAULT_ZOOM = 12;
+
+/** Max lat-corrected bbox span (degrees, ~25 km) below which a bounds fit still gives a good initial view */
+export const AREA_BOUNDS_MAX_SPAN_DEG = 0.25;
+
 /** Supported locales for translations */
 export const SUPPORTED_LOCALES = ["en", "pt-BR", "es"] as const;
 

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -41,13 +41,17 @@ export async function getOrCreateDataset(
       void (async () => {
         try {
           const areaDetails = await getAreaDetailsById(areaId);
-          if (areaDetails) {
+          const hasNewCountryCode =
+            !dataset.area.countryCode && areaDetails?.countryCode;
+          const hasNewCenter =
+            dataset.area.centerLat == null && areaDetails?.centerLat != null;
+          if (hasNewCountryCode || hasNewCenter) {
             await prisma.area.update({
               where: { id: areaId },
               data: {
-                countryCode: areaDetails.countryCode ?? undefined,
-                centerLat: areaDetails.centerLat ?? undefined,
-                centerLon: areaDetails.centerLon ?? undefined,
+                countryCode: areaDetails?.countryCode ?? undefined,
+                centerLat: areaDetails?.centerLat ?? undefined,
+                centerLon: areaDetails?.centerLon ?? undefined,
               },
             });
           }
@@ -159,13 +163,16 @@ async function createDatasetOnDemand(
   if (area && (!area.countryCode || area.centerLat == null)) {
     try {
       const areaDetails = await getAreaDetailsById(areaId);
-      if (areaDetails) {
+      const hasNewCountryCode = !area.countryCode && areaDetails?.countryCode;
+      const hasNewCenter =
+        area.centerLat == null && areaDetails?.centerLat != null;
+      if (hasNewCountryCode || hasNewCenter) {
         area = await prisma.area.update({
           where: { id: areaId },
           data: {
-            countryCode: areaDetails.countryCode ?? undefined,
-            centerLat: areaDetails.centerLat ?? undefined,
-            centerLon: areaDetails.centerLon ?? undefined,
+            countryCode: areaDetails?.countryCode ?? undefined,
+            centerLat: areaDetails?.centerLat ?? undefined,
+            centerLon: areaDetails?.centerLon ?? undefined,
           },
         });
       }

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -37,18 +37,22 @@ export async function getOrCreateDataset(
   let dataset = await getDatasetWithDetails(areaId, template.id, locale);
 
   if (dataset) {
-    if (!dataset.area.countryCode) {
+    if (!dataset.area.countryCode || dataset.area.centerLat == null) {
       void (async () => {
         try {
           const areaDetails = await getAreaDetailsById(areaId);
-          if (areaDetails?.countryCode) {
+          if (areaDetails) {
             await prisma.area.update({
               where: { id: areaId },
-              data: { countryCode: areaDetails.countryCode },
+              data: {
+                countryCode: areaDetails.countryCode ?? undefined,
+                centerLat: areaDetails.centerLat ?? undefined,
+                centerLon: areaDetails.centerLon ?? undefined,
+              },
             });
           }
         } catch (error) {
-          logger.error("Failed to backfill countryCode", { areaId, error });
+          logger.error("Failed to backfill area details", { areaId, error });
         }
       })();
     }
@@ -108,6 +112,8 @@ async function getDatasetWithDetails(areaId: number, templateId: string, locale:
           name: true,
           countryCode: true,
           bounds: true,
+          centerLat: true,
+          centerLon: true,
           geojson: true,
         },
       },
@@ -150,17 +156,21 @@ async function createDatasetOnDemand(
     where: { id: areaId },
   });
 
-  if (area && !area.countryCode) {
+  if (area && (!area.countryCode || area.centerLat == null)) {
     try {
       const areaDetails = await getAreaDetailsById(areaId);
-      if (areaDetails?.countryCode) {
+      if (areaDetails) {
         area = await prisma.area.update({
           where: { id: areaId },
-          data: { countryCode: areaDetails.countryCode },
+          data: {
+            countryCode: areaDetails.countryCode ?? undefined,
+            centerLat: areaDetails.centerLat ?? undefined,
+            centerLon: areaDetails.centerLon ?? undefined,
+          },
         });
       }
     } catch (error) {
-      logger.error("Failed to backfill countryCode", { areaId, error });
+      logger.error("Failed to backfill area details", { areaId, error });
     }
   }
 
@@ -176,8 +186,10 @@ async function createDatasetOnDemand(
       }
 
       // City OSM relations don't carry ISO3166 tags — Nominatim is the
-      // only reliable source for country code.
+      // only reliable source for country code and admin centre coordinates.
       const countryCode = areaDetails?.countryCode ?? null;
+      const centerLat = areaDetails?.centerLat ?? null;
+      const centerLon = areaDetails?.centerLon ?? null;
 
       if (osmData) {
         area = await prisma.area.upsert({
@@ -185,6 +197,8 @@ async function createDatasetOnDemand(
           update: {
             name: osmData.name,
             countryCode,
+            centerLat,
+            centerLon,
             bounds: osmData.bounds,
             geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
           },
@@ -192,6 +206,8 @@ async function createDatasetOnDemand(
             id: areaId,
             name: osmData.name,
             countryCode,
+            centerLat,
+            centerLon,
             bounds: osmData.bounds,
             geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
           },
@@ -202,6 +218,8 @@ async function createDatasetOnDemand(
           update: {
             name: areaDetails!.name,
             countryCode,
+            centerLat,
+            centerLon,
             bounds: areaDetails!.boundingBox
               ? JSON.stringify(areaDetails!.boundingBox)
               : null,
@@ -211,6 +229,8 @@ async function createDatasetOnDemand(
             id: areaId,
             name: areaDetails!.name,
             countryCode,
+            centerLat,
+            centerLon,
             bounds: areaDetails!.boundingBox
               ? JSON.stringify(areaDetails!.boundingBox)
               : null,
@@ -283,6 +303,8 @@ async function createDatasetOnDemand(
             name: true,
             countryCode: true,
             bounds: true,
+            centerLat: true,
+            centerLon: true,
             geojson: true,
           },
         },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,11 @@ import { BboxSchema, type Bbox } from "@/types/geojson";
 import type { DateFilter } from "../types/geojson";
 import type { Area } from "@/types/area";
 import type { useTranslations } from "next-intl";
-import { SUPPORTED_LOCALES } from "./constants";
+import {
+  SUPPORTED_LOCALES,
+  AREA_BOUNDS_MAX_SPAN_DEG,
+  DATASET_MAP_DEFAULT_ZOOM,
+} from "./constants";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -51,7 +55,7 @@ export function calculateBbox(geojson: FeatureCollection): Bbox | null {
  * @param area - Area object with bounds property
  * @returns Bbox if valid, null otherwise
  */
-export function parseAreaBounds(area: Pick<Area, "bounds"> | { bounds: string | null }): Bbox | null {
+export function parseAreaBounds(area: Pick<Area, "bounds"> | { bounds?: string | null }): Bbox | null {
   if (!area?.bounds) return null;
 
   try {
@@ -71,6 +75,62 @@ export function parseAreaBounds(area: Pick<Area, "bounds"> | { bounds: string | 
   } catch {
     return null;
   }
+}
+
+/**
+ * Whether an area bbox is small enough that fitting it gives a good initial
+ * map view. Large bboxes are untrustworthy (scattered boundaries like Tokyo's
+ * outlying islands) and the map should center on the admin centre instead.
+ * @param bbox - GeoJSON bbox [minLon, minLat, maxLon, maxLat]
+ */
+export function isSmallAreaBounds(bbox: Bbox): boolean {
+  const [minLon, minLat, maxLon, maxLat] = bbox;
+  const latSpan = maxLat - minLat;
+  const midLat = (minLat + maxLat) / 2;
+  const lonSpan = (maxLon - minLon) * Math.cos((midLat * Math.PI) / 180);
+  return Math.max(latSpan, lonSpan) <= AREA_BOUNDS_MAX_SPAN_DEG;
+}
+
+export type InitialViewState =
+  | { bounds: Bbox; fitBoundsOptions: { padding: number } }
+  | { longitude: number; latitude: number; zoom: number };
+
+/**
+ * Initial view for the dataset map. Small area bboxes fit well; large ones
+ * are untrustworthy (scattered boundaries) so the admin centre at a fixed
+ * zoom wins. Falls back to area bounds, then data bounds, then world view.
+ */
+export function computeInitialViewState(
+  area: {
+    bounds?: string | null;
+    centerLat?: number | null;
+    centerLon?: number | null;
+  },
+  dataBounds: Bbox | null
+): InitialViewState {
+  const areaBounds = parseAreaBounds(area);
+
+  if (areaBounds && isSmallAreaBounds(areaBounds)) {
+    return { bounds: areaBounds, fitBoundsOptions: { padding: 20 } };
+  }
+
+  if (area.centerLat != null && area.centerLon != null) {
+    return {
+      longitude: area.centerLon,
+      latitude: area.centerLat,
+      zoom: DATASET_MAP_DEFAULT_ZOOM,
+    };
+  }
+
+  if (areaBounds) {
+    return { bounds: areaBounds, fitBoundsOptions: { padding: 20 } };
+  }
+
+  if (dataBounds) {
+    return { bounds: dataBounds, fitBoundsOptions: { padding: 20 } };
+  }
+
+  return { longitude: 0, latitude: 0, zoom: 2 };
 }
 
 export const getAvailableTimeframes = (features: Feature[]): DateFilter[] => {

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -77,6 +77,8 @@ export const DatasetSchema = z.object({
     name: z.string(),
     countryCode: z.string().nullable(),
     bounds: z.string().nullable(),
+    centerLat: z.number().nullish(),
+    centerLon: z.number().nullish(),
     geojson: GeoJSONFeatureCollectionSchema.nullable(),
   }),
   savedBy: z

--- a/src/types/area.ts
+++ b/src/types/area.ts
@@ -8,6 +8,8 @@ export type Area = {
   addresstype?: string;
   boundingBox: [number, number, number, number];
   bounds?: string;
+  centerLat?: number;
+  centerLon?: number;
   countryCode?: string;
   country?: string;
   state?: string;


### PR DESCRIPTION
## Issue #366: Center dataset map on admin centre instead of fitting area bounds

**Problem:** Dataset map initial view fits the area relation bbox. For cities with scattered boundaries this looks bad at first sight, e.g. Tokyo (relation 1543125): bbox spans lat 20.2-35.9 because the metropolis includes the Ogasawara islands, so the initial view is mostly ocean. Nominatim lookup (already called in getAreaDetailsById) returns lat/lon resolved to the admin_centre/label node with point-on-surface fallback, but these were dropped in fromNominatim and Area had no center column.

**Acceptance Criteria:**
- [x] Tokyo dataset opens centered on the city, not the island chain
- [x] Cities without admin_centre still get a sensible initial view (Nominatim lat/lon always present via point-on-surface fallback)
- [x] Existing areas work without manual backfill (lazy backfill on dataset page view)

**Changes:**
- Add nullable Area.centerLat/centerLon; fromNominatim keeps Nominatim lat/lon (range-validated); threaded through Area type, dataset schema (nullish), and all area selects
- Center written on area create (createDatasetOnDemand branches, POST /api/datasets); existing countryCode backfill in getOrCreateDataset generalized to also backfill center (fire-and-forget, same pattern)
- Initial view: small area bbox (lat-corrected span <= 0.25 deg) keeps current viewport-aware bounds fit; larger bbox centers on admin centre at fixed z12 for a constant, replicable view; areas without center fall back to previous behavior (bounds fit -> data bounds -> world)
- Extracted pure computeInitialViewState/isSmallAreaBounds into lib/utils with unit tests; backfill and center-parsing tests added
- Separate migration renames dataset_saves constraints left behind by the earlier dataset_watches table rename (schema drift surfaced by prisma migrate dev; safe on prod, which has the old names)

Verified: type-check, lint, i18n:check, build, unit tests pass. Browser-verified Tokyo railway-stations opens centered on central Tokyo at z12 and Paris keeps its tight bounds fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added geographic center coordinates to area and dataset information.
  * Improved map initialization using area centers, bounds, and data coverage for more accurate views.
  * Automatically fills in missing area location metadata when available.

* **Bug Fixes**
  * Corrected dataset save database constraint and index naming.

* **Tests**
  * Added coverage for coordinate validation, metadata backfilling, and map view selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->