### PR TITLE
fix(map): prefer OSM admin_centre for area center; lazy TTL on area info

### DIFF
--- a/prisma/migrations/20260718132356_add_area_refreshed_at/migration.sql
+++ b/prisma/migrations/20260718132356_add_area_refreshed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "areas" ADD COLUMN     "refreshedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,7 @@ model Area {
   bounds      String?
   centerLat   Float?
   centerLon   Float?
+  refreshedAt DateTime?
   geojson     Json?
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -4,11 +4,7 @@ import { prisma } from "@/lib/db";
 import { CreateDatasetSchema } from "@/schemas/dataset";
 import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
-import {
-  isAreaInfoStale,
-  refreshAreaInfo,
-  resolveAreaCenter,
-} from "@/lib/area-refresh";
+import { refreshAreaInfoIfStale, resolveAreaCenter } from "@/lib/area-refresh";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { trackEvent, getClientInfo } from "@/lib/umami";
@@ -43,12 +39,8 @@ export async function POST(req: NextRequest) {
     where: { id: osmRelationId },
   });
 
-  if (area && isAreaInfoStale(area.refreshedAt)) {
-    try {
-      area = (await refreshAreaInfo(osmRelationId, area.bounds)) ?? area;
-    } catch (err) {
-      console.error("Failed to refresh area info", err);
-    }
+  if (area) {
+    area = await refreshAreaInfoIfStale(area);
   }
 
   if (!area) {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/db";
 import { CreateDatasetSchema } from "@/schemas/dataset";
 import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
+import { resolveAreaCenter } from "@/lib/area-refresh";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { trackEvent, getClientInfo } from "@/lib/umami";
@@ -51,14 +52,17 @@ export async function POST(req: NextRequest) {
           { status: 400 }
         );
 
+      const center = resolveAreaCenter(fetched, areaDetails);
+
       area = await prisma.area.create({
         data: {
           id: osmRelationId,
           name: fetched.name,
           bounds: fetched.bounds,
           countryCode: areaDetails?.countryCode ?? null,
-          centerLat: areaDetails?.centerLat ?? null,
-          centerLon: areaDetails?.centerLon ?? null,
+          centerLat: center?.centerLat ?? null,
+          centerLon: center?.centerLon ?? null,
+          refreshedAt: new Date(),
           geojson: JSON.parse(JSON.stringify(fetched.convertedGeojson)),
         },
       });

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -4,7 +4,11 @@ import { prisma } from "@/lib/db";
 import { CreateDatasetSchema } from "@/schemas/dataset";
 import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
-import { resolveAreaCenter } from "@/lib/area-refresh";
+import {
+  isAreaInfoStale,
+  refreshAreaInfo,
+  resolveAreaCenter,
+} from "@/lib/area-refresh";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { trackEvent, getClientInfo } from "@/lib/umami";
@@ -38,6 +42,14 @@ export async function POST(req: NextRequest) {
   let area = await prisma.area.findUnique({
     where: { id: osmRelationId },
   });
+
+  if (area && isAreaInfoStale(area.refreshedAt)) {
+    try {
+      area = (await refreshAreaInfo(osmRelationId, area.bounds)) ?? area;
+    } catch (err) {
+      console.error("Failed to refresh area info", err);
+    }
+  }
 
   if (!area) {
     try {

--- a/src/lib/__tests__/area-boundary.test.ts
+++ b/src/lib/__tests__/area-boundary.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    area: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/overpass/transport", () => ({
+  executeOverpassQuery: vi.fn(),
+  convertOverpassToGeoJSON: vi.fn().mockReturnValue({
+    type: "FeatureCollection",
+    features: [],
+  }),
+}));
+
+import { fetchOsmRelationData } from "@/lib/area-boundary";
+import {
+  executeOverpassQuery,
+  convertOverpassToGeoJSON,
+} from "@/lib/overpass/transport";
+
+const mockExecuteOverpassQuery = vi.mocked(executeOverpassQuery);
+const mockConvert = vi.mocked(convertOverpassToGeoJSON);
+
+const luandaRelation = {
+  type: "relation",
+  id: 1802546,
+  tags: { name: "Luanda", boundary: "administrative" },
+  bounds: {
+    minlat: -10.4562358,
+    minlon: 12.7897792,
+    maxlat: -8.5800243,
+    maxlon: 14.6216669,
+  },
+};
+
+const adminCentreNode = {
+  type: "node",
+  id: 27564941,
+  lat: -8.8272699,
+  lon: 13.2439512,
+  tags: { name: "Luanda", place: "city" },
+};
+
+describe("fetchOsmRelationData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConvert.mockReturnValue({ type: "FeatureCollection", features: [] });
+  });
+
+  it("returns admin_centre coordinates when the member node is present", async () => {
+    mockExecuteOverpassQuery.mockResolvedValueOnce({
+      elements: [luandaRelation, adminCentreNode],
+    } as never);
+
+    const result = await fetchOsmRelationData(1802546);
+
+    expect(result?.adminCentre).toEqual({ lat: -8.8272699, lon: 13.2439512 });
+    expect(result?.name).toBe("Luanda");
+    expect(result?.bounds).toBe("-10.4562358,12.7897792,-8.5800243,14.6216669");
+  });
+
+  it("returns null adminCentre when the relation has no admin_centre member", async () => {
+    mockExecuteOverpassQuery.mockResolvedValueOnce({
+      elements: [luandaRelation],
+    } as never);
+
+    const result = await fetchOsmRelationData(1802546);
+
+    expect(result?.adminCentre).toBeNull();
+  });
+
+  it("finds the relation even when the node element comes first", async () => {
+    mockExecuteOverpassQuery.mockResolvedValueOnce({
+      elements: [adminCentreNode, luandaRelation],
+    } as never);
+
+    const result = await fetchOsmRelationData(1802546);
+
+    expect(result?.name).toBe("Luanda");
+    expect(result?.adminCentre).toEqual({ lat: -8.8272699, lon: 13.2439512 });
+  });
+
+  it("converts only the relation element to geojson (no stray point feature)", async () => {
+    mockExecuteOverpassQuery.mockResolvedValueOnce({
+      elements: [luandaRelation, adminCentreNode],
+    } as never);
+
+    await fetchOsmRelationData(1802546);
+
+    const convertArg = mockConvert.mock.calls[0][0] as { elements: unknown[] };
+    expect(convertArg.elements).toHaveLength(1);
+    expect((convertArg.elements[0] as { type: string }).type).toBe("relation");
+  });
+
+  it("returns null on transport error", async () => {
+    mockExecuteOverpassQuery.mockRejectedValueOnce(new Error("timeout"));
+
+    expect(await fetchOsmRelationData(1802546)).toBeNull();
+  });
+
+  it("returns null when no relation element is present", async () => {
+    mockExecuteOverpassQuery.mockResolvedValueOnce({
+      elements: [adminCentreNode],
+    } as never);
+
+    expect(await fetchOsmRelationData(1802546)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/area-refresh.test.ts
+++ b/src/lib/__tests__/area-refresh.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/lib/nominatim", () => ({
 import {
   isAreaInfoStale,
   refreshAreaInfo,
+  refreshAreaInfoIfStale,
   resolveAreaCenter,
 } from "@/lib/area-refresh";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
@@ -84,6 +85,48 @@ describe("resolveAreaCenter", () => {
         { ...luandaNominatim, centerLat: undefined, centerLon: undefined } as never
       )
     ).toBeNull();
+  });
+});
+
+describe("refreshAreaInfoIfStale", () => {
+  const staleArea = {
+    id: 1802546,
+    bounds: luandaOsmData.bounds,
+    refreshedAt: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes and returns the updated area when stale", async () => {
+    mockFetchOsmRelationData.mockResolvedValueOnce(luandaOsmData as never);
+    mockGetAreaDetailsById.mockResolvedValueOnce(luandaNominatim as never);
+    mockAreaUpdate.mockResolvedValueOnce({ id: 1802546, name: "Luanda" } as never);
+
+    const result = await refreshAreaInfoIfStale(staleArea);
+
+    expect(mockAreaUpdate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ id: 1802546, name: "Luanda" });
+  });
+
+  it("returns the area untouched when fresh", async () => {
+    const freshArea = { ...staleArea, refreshedAt: new Date() };
+
+    const result = await refreshAreaInfoIfStale(freshArea);
+
+    expect(result).toBe(freshArea);
+    expect(mockFetchOsmRelationData).not.toHaveBeenCalled();
+    expect(mockAreaUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns the original area when the refresh fails", async () => {
+    mockFetchOsmRelationData.mockRejectedValueOnce(new Error("boom"));
+    mockGetAreaDetailsById.mockResolvedValueOnce(luandaNominatim as never);
+
+    const result = await refreshAreaInfoIfStale(staleArea);
+
+    expect(result).toBe(staleArea);
   });
 });
 

--- a/src/lib/__tests__/area-refresh.test.ts
+++ b/src/lib/__tests__/area-refresh.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    area: {
+      update: vi.fn().mockResolvedValue({ id: 1802546 }),
+    },
+  },
+}));
+
+vi.mock("@/lib/area-boundary", () => ({
+  fetchOsmRelationData: vi.fn(),
+}));
+
+vi.mock("@/lib/nominatim", () => ({
+  getAreaDetailsById: vi.fn(),
+}));
+
+import {
+  isAreaInfoStale,
+  refreshAreaInfo,
+  resolveAreaCenter,
+} from "@/lib/area-refresh";
+import { fetchOsmRelationData } from "@/lib/area-boundary";
+import { getAreaDetailsById } from "@/lib/nominatim";
+import { prisma } from "@/lib/db";
+import { Prisma } from "@prisma/client";
+
+const mockFetchOsmRelationData = vi.mocked(fetchOsmRelationData);
+const mockGetAreaDetailsById = vi.mocked(getAreaDetailsById);
+const mockAreaUpdate = vi.mocked(prisma.area.update);
+
+const luandaOsmData = {
+  name: "Luanda",
+  bounds: "-10.456,12.789,-8.580,14.621",
+  adminCentre: { lat: -8.8272699, lon: 13.2439512 },
+  geojson: {},
+  convertedGeojson: { type: "FeatureCollection", features: [] },
+};
+
+const luandaNominatim = {
+  name: "Luanda",
+  countryCode: "ao",
+  centerLat: -9.5180344,
+  centerLon: 13.535676,
+};
+
+describe("isAreaInfoStale", () => {
+  it("is stale when refreshedAt is null", () => {
+    expect(isAreaInfoStale(null)).toBe(true);
+  });
+
+  it("is stale when older than 30 days", () => {
+    const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+    expect(isAreaInfoStale(fortyDaysAgo)).toBe(true);
+  });
+
+  it("is fresh within 30 days", () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    expect(isAreaInfoStale(yesterday)).toBe(false);
+  });
+});
+
+describe("resolveAreaCenter", () => {
+  it("prefers the OSM admin_centre over the Nominatim center", () => {
+    expect(
+      resolveAreaCenter(luandaOsmData as never, luandaNominatim as never)
+    ).toEqual({ centerLat: -8.8272699, centerLon: 13.2439512 });
+  });
+
+  it("falls back to the Nominatim center without admin_centre", () => {
+    expect(
+      resolveAreaCenter(
+        { ...luandaOsmData, adminCentre: null } as never,
+        luandaNominatim as never
+      )
+    ).toEqual({ centerLat: -9.5180344, centerLon: 13.535676 });
+  });
+
+  it("returns null when neither source has a center", () => {
+    expect(
+      resolveAreaCenter(
+        { ...luandaOsmData, adminCentre: null } as never,
+        { ...luandaNominatim, centerLat: undefined, centerLon: undefined } as never
+      )
+    ).toBeNull();
+  });
+});
+
+describe("refreshAreaInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes refreshed fields with the admin_centre center and stamps refreshedAt", async () => {
+    mockFetchOsmRelationData.mockResolvedValueOnce(luandaOsmData as never);
+    mockGetAreaDetailsById.mockResolvedValueOnce(luandaNominatim as never);
+
+    await refreshAreaInfo(1802546, luandaOsmData.bounds);
+
+    expect(mockAreaUpdate).toHaveBeenCalledTimes(1);
+    const arg = mockAreaUpdate.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: 1802546 });
+    expect(arg.data).toMatchObject({
+      name: "Luanda",
+      bounds: luandaOsmData.bounds,
+      countryCode: "ao",
+      centerLat: -8.8272699,
+      centerLon: 13.2439512,
+    });
+    expect(arg.data.refreshedAt).toBeInstanceOf(Date);
+    expect("geojson" in arg.data).toBe(false);
+  });
+
+  it("invalidates the cached boundary when bounds changed", async () => {
+    mockFetchOsmRelationData.mockResolvedValueOnce(luandaOsmData as never);
+    mockGetAreaDetailsById.mockResolvedValueOnce(luandaNominatim as never);
+
+    await refreshAreaInfo(1802546, "-10.0,12.0,-8.0,14.0");
+
+    const arg = mockAreaUpdate.mock.calls[0][0];
+    expect(arg.data.geojson).toBe(Prisma.JsonNull);
+  });
+
+  it("does not write when both sources fail", async () => {
+    mockFetchOsmRelationData.mockResolvedValueOnce(null);
+    mockGetAreaDetailsById.mockRejectedValueOnce(new Error("Nominatim down"));
+
+    const result = await refreshAreaInfo(1802546, null);
+
+    expect(result).toBeNull();
+    expect(mockAreaUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes from Nominatim when Overpass fails", async () => {
+    mockFetchOsmRelationData.mockResolvedValueOnce(null);
+    mockGetAreaDetailsById.mockResolvedValueOnce(luandaNominatim as never);
+
+    await refreshAreaInfo(1802546, null);
+
+    const arg = mockAreaUpdate.mock.calls[0][0];
+    expect(arg.data).toMatchObject({
+      name: "Luanda",
+      countryCode: "ao",
+      centerLat: -9.5180344,
+      centerLon: 13.535676,
+    });
+    // No bounds from Overpass: leave stored bounds untouched
+    expect(arg.data.bounds).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/area-refresh.test.ts
+++ b/src/lib/__tests__/area-refresh.test.ts
@@ -132,7 +132,7 @@ describe("refreshAreaInfo", () => {
     expect(mockAreaUpdate).not.toHaveBeenCalled();
   });
 
-  it("still refreshes from Nominatim when Overpass fails", async () => {
+  it("writes Nominatim fields without stamping refreshedAt when Overpass fails", async () => {
     mockFetchOsmRelationData.mockResolvedValueOnce(null);
     mockGetAreaDetailsById.mockResolvedValueOnce(luandaNominatim as never);
 
@@ -145,7 +145,7 @@ describe("refreshAreaInfo", () => {
       centerLat: -9.5180344,
       centerLon: 13.535676,
     });
-    // No bounds from Overpass: leave stored bounds untouched
     expect(arg.data.bounds).toBeUndefined();
+    expect("refreshedAt" in arg.data).toBe(false);
   });
 });

--- a/src/lib/__tests__/dataset-operations.test.ts
+++ b/src/lib/__tests__/dataset-operations.test.ts
@@ -59,17 +59,20 @@ vi.mock("@/lib/nominatim", () => ({
 
 vi.mock("@/lib/area-refresh", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/area-refresh")>();
-  return { ...actual, refreshAreaInfo: vi.fn() };
+  return {
+    ...actual,
+    refreshAreaInfoIfStale: vi.fn((area: unknown) => Promise.resolve(area)),
+  };
 });
 
 import { getOrCreateDataset } from "@/lib/dataset-operations";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
-import { refreshAreaInfo } from "@/lib/area-refresh";
+import { refreshAreaInfoIfStale } from "@/lib/area-refresh";
 import { prisma } from "@/lib/db";
 
 const mockFetchDatasetSnapshot = vi.mocked(fetchDatasetSnapshot);
 const mockDatasetFindFirst = vi.mocked(prisma.dataset.findFirst);
-const mockRefreshAreaInfo = vi.mocked(refreshAreaInfo);
+const mockRefreshAreaInfoIfStale = vi.mocked(refreshAreaInfoIfStale);
 
 const existingDatasetRow = {
   id: "ds-1",
@@ -118,50 +121,21 @@ describe("getOrCreateDataset — isFeatured passthrough", () => {
   });
 });
 
-describe("getOrCreateDataset — area info refresh trigger", () => {
+describe("getOrCreateDataset — area info refresh", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("refreshes area info when refreshedAt is null", async () => {
-    mockDatasetFindFirst.mockResolvedValueOnce({
-      ...existingDatasetRow,
-      area: { ...existingDatasetRow.area, refreshedAt: null },
-    } as never);
+  it("hands the area to refreshAreaInfoIfStale without blocking the response", async () => {
+    mockDatasetFindFirst.mockResolvedValueOnce(existingDatasetRow as never);
 
     await getOrCreateDataset(1, "test-template", "en");
     // Refresh is fire-and-forget; flush pending promises
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(mockRefreshAreaInfo).toHaveBeenCalledWith(
-      1,
-      existingDatasetRow.area.bounds
+    expect(mockRefreshAreaInfoIfStale).toHaveBeenCalledWith(
+      existingDatasetRow.area
     );
-  });
-
-  it("refreshes area info when refreshedAt is older than the TTL", async () => {
-    const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
-    mockDatasetFindFirst.mockResolvedValueOnce({
-      ...existingDatasetRow,
-      area: { ...existingDatasetRow.area, refreshedAt: fortyDaysAgo },
-    } as never);
-
-    await getOrCreateDataset(1, "test-template", "en");
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(mockRefreshAreaInfo).toHaveBeenCalledWith(
-      1,
-      existingDatasetRow.area.bounds
-    );
-  });
-
-  it("does not refresh when area info is fresh", async () => {
-    mockDatasetFindFirst.mockResolvedValueOnce(existingDatasetRow as never);
-
-    await getOrCreateDataset(1, "test-template", "en");
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(mockRefreshAreaInfo).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/__tests__/dataset-operations.test.ts
+++ b/src/lib/__tests__/dataset-operations.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/lib/db", () => ({
         bounds: null,
         centerLat: 38.7,
         centerLon: -9.1,
+        refreshedAt: new Date(),
         geojson: null,
       }),
       update: vi.fn(),
@@ -56,15 +57,19 @@ vi.mock("@/lib/nominatim", () => ({
   getAreaDetailsById: vi.fn(),
 }));
 
+vi.mock("@/lib/area-refresh", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/area-refresh")>();
+  return { ...actual, refreshAreaInfo: vi.fn() };
+});
+
 import { getOrCreateDataset } from "@/lib/dataset-operations";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
-import { getAreaDetailsById } from "@/lib/nominatim";
+import { refreshAreaInfo } from "@/lib/area-refresh";
 import { prisma } from "@/lib/db";
 
 const mockFetchDatasetSnapshot = vi.mocked(fetchDatasetSnapshot);
 const mockDatasetFindFirst = vi.mocked(prisma.dataset.findFirst);
-const mockGetAreaDetailsById = vi.mocked(getAreaDetailsById);
-const mockAreaUpdate = vi.mocked(prisma.area.update);
+const mockRefreshAreaInfo = vi.mocked(refreshAreaInfo);
 
 const existingDatasetRow = {
   id: "ds-1",
@@ -85,9 +90,10 @@ const existingDatasetRow = {
     id: 1,
     name: "Test City",
     countryCode: "US",
-    bounds: null,
+    bounds: "38.69,-9.2,38.79,-9.1",
     centerLat: 38.7,
     centerLon: -9.1,
+    refreshedAt: new Date(),
     geojson: null,
   },
   user: null,
@@ -112,56 +118,50 @@ describe("getOrCreateDataset — isFeatured passthrough", () => {
   });
 });
 
-describe("getOrCreateDataset — area details backfill", () => {
+describe("getOrCreateDataset — area info refresh trigger", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("backfills center coordinates when the area is missing them", async () => {
+  it("refreshes area info when refreshedAt is null", async () => {
     mockDatasetFindFirst.mockResolvedValueOnce({
       ...existingDatasetRow,
-      area: { ...existingDatasetRow.area, centerLat: null, centerLon: null },
-    } as never);
-    mockGetAreaDetailsById.mockResolvedValueOnce({
-      countryCode: "pt",
-      centerLat: 38.7,
-      centerLon: -9.1,
+      area: { ...existingDatasetRow.area, refreshedAt: null },
     } as never);
 
     await getOrCreateDataset(1, "test-template", "en");
-    // Backfill is fire-and-forget; flush pending promises
+    // Refresh is fire-and-forget; flush pending promises
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(mockAreaUpdate).toHaveBeenCalledWith({
-      where: { id: 1 },
-      data: { countryCode: "pt", centerLat: 38.7, centerLon: -9.1 },
-    });
+    expect(mockRefreshAreaInfo).toHaveBeenCalledWith(
+      1,
+      existingDatasetRow.area.bounds
+    );
   });
 
-  it("skips the update when Nominatim has nothing new", async () => {
+  it("refreshes area info when refreshedAt is older than the TTL", async () => {
+    const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
     mockDatasetFindFirst.mockResolvedValueOnce({
       ...existingDatasetRow,
-      area: { ...existingDatasetRow.area, centerLat: null, centerLon: null },
-    } as never);
-    mockGetAreaDetailsById.mockResolvedValueOnce({
-      countryCode: "us",
+      area: { ...existingDatasetRow.area, refreshedAt: fortyDaysAgo },
     } as never);
 
     await getOrCreateDataset(1, "test-template", "en");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    // countryCode already set and no center returned: no write
-    expect(mockAreaUpdate).not.toHaveBeenCalled();
+    expect(mockRefreshAreaInfo).toHaveBeenCalledWith(
+      1,
+      existingDatasetRow.area.bounds
+    );
   });
 
-  it("does not backfill when countryCode and center are present", async () => {
+  it("does not refresh when area info is fresh", async () => {
     mockDatasetFindFirst.mockResolvedValueOnce(existingDatasetRow as never);
 
     await getOrCreateDataset(1, "test-template", "en");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(mockGetAreaDetailsById).not.toHaveBeenCalled();
-    expect(mockAreaUpdate).not.toHaveBeenCalled();
+    expect(mockRefreshAreaInfo).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -59,6 +59,35 @@ describe("computeInitialViewState", () => {
     });
   });
 
+  it("centers when the center lies inside the data bounds", () => {
+    const dataBounds: Bbox = [139.5, 35.4, 140.0, 35.9];
+    const view = computeInitialViewState(
+      { bounds: tokyoBounds, centerLat: 35.6768601, centerLon: 139.7638947 },
+      dataBounds
+    );
+
+    expect(view).toEqual({
+      longitude: 139.7638947,
+      latitude: 35.6768601,
+      zoom: 12,
+    });
+  });
+
+  it("fits data bounds when the center falls outside them (bad centroid)", () => {
+    // Luanda: stored center is the empty province interior, data is in the city
+    const luandaBounds = "-10.4562358,12.7897792,-8.5800243,14.6216669";
+    const dataBounds: Bbox = [13.15, -8.95, 13.35, -8.75];
+    const view = computeInitialViewState(
+      { bounds: luandaBounds, centerLat: -9.5180344, centerLon: 13.535676 },
+      dataBounds
+    );
+
+    expect(view).toEqual({
+      bounds: dataBounds,
+      fitBoundsOptions: { padding: 20 },
+    });
+  });
+
   it("falls back to bounds fit for a large area without a center", () => {
     const view = computeInitialViewState(
       { bounds: tokyoBounds, centerLat: null, centerLon: null },

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -73,6 +73,22 @@ describe("computeInitialViewState", () => {
     });
   });
 
+  it("centers when the center is just outside the data bounds (Altamira)", () => {
+    // Admin centre ~40 m north of the banks bbox edge — within tolerance
+    const altamiraBounds = "-9.645,-55.623871,-2.9887169,-51.6475378";
+    const dataBounds: Bbox = [-52.4477987, -3.6977382, -52.2098271, -3.204434];
+    const view = computeInitialViewState(
+      { bounds: altamiraBounds, centerLat: -3.204065, centerLon: -52.209961 },
+      dataBounds
+    );
+
+    expect(view).toEqual({
+      longitude: -52.209961,
+      latitude: -3.204065,
+      zoom: 12,
+    });
+  });
+
   it("fits data bounds when the center falls outside them (bad centroid)", () => {
     // Luanda: stored center is the empty province interior, data is in the city
     const luandaBounds = "-10.4562358,12.7897792,-8.5800243,14.6216669";

--- a/src/lib/area-boundary.ts
+++ b/src/lib/area-boundary.ts
@@ -81,8 +81,10 @@ export async function getAreaBoundary(areaId: number): Promise<FeatureCollection
 export async function fetchOsmRelationData(relationId: number) {
   const query = `
     [out:json][timeout:25];
-    rel(${relationId});
-    out bb tags;
+    rel(${relationId})->.a;
+    .a out bb tags;
+    node(r.a:"admin_centre");
+    out;
   `;
 
   let overpassData;
@@ -98,16 +100,31 @@ export async function fetchOsmRelationData(relationId: number) {
     return null;
   }
 
-  const rel = validationResult.data.elements?.[0] as OSMRelation;
-  if (!rel || rel.type !== "relation") return null;
+  const elements = validationResult.data.elements ?? [];
+  const rel = elements.find((e) => e.type === "relation") as
+    | OSMRelation
+    | undefined;
+  if (!rel) return null;
 
-  const geojson = convertOverpassToGeoJSON(validationResult.data);
+  const adminCentreNode = elements.find((e) => e.type === "node");
+  const adminCentre =
+    adminCentreNode && adminCentreNode.type === "node"
+      ? { lat: adminCentreNode.lat, lon: adminCentreNode.lon }
+      : null;
+
+  // Convert only the relation so the admin_centre node doesn't leak a stray
+  // point feature into the stored area geojson.
+  const geojson = convertOverpassToGeoJSON({
+    ...validationResult.data,
+    elements: [rel],
+  });
 
   return {
     name: rel.tags?.name || `Relation ${relationId}`,
     bounds: rel.bounds
       ? `${rel.bounds.minlat},${rel.bounds.minlon},${rel.bounds.maxlat},${rel.bounds.maxlon}`
       : null,
+    adminCentre,
     geojson: rel,
     convertedGeojson: geojson,
   };

--- a/src/lib/area-boundary.ts
+++ b/src/lib/area-boundary.ts
@@ -112,8 +112,7 @@ export async function fetchOsmRelationData(relationId: number) {
       ? { lat: adminCentreNode.lat, lon: adminCentreNode.lon }
       : null;
 
-  // Convert only the relation so the admin_centre node doesn't leak a stray
-  // point feature into the stored area geojson.
+  // Exclude the admin_centre node from the stored area geojson
   const geojson = convertOverpassToGeoJSON({
     ...validationResult.data,
     elements: [rel],

--- a/src/lib/area-boundary.ts
+++ b/src/lib/area-boundary.ts
@@ -5,7 +5,7 @@ import {
   convertOverpassToGeoJSON,
 } from "@/lib/overpass/transport";
 import { OverpassResponseSchema } from "@/types/overpass";
-import type { OSMRelation } from "@/types/osm";
+import type { OSMNode, OSMRelation } from "@/types/osm";
 import { BOUNDARY_SIMPLIFICATION_TOLERANCE } from "@/lib/constants";
 import { createLogger } from "@/lib/logger";
 import type { FeatureCollection } from "geojson";
@@ -101,16 +101,15 @@ export async function fetchOsmRelationData(relationId: number) {
   }
 
   const elements = validationResult.data.elements ?? [];
-  const rel = elements.find((e) => e.type === "relation") as
-    | OSMRelation
-    | undefined;
+  const rel = elements.find((e): e is OSMRelation => e.type === "relation");
   if (!rel) return null;
 
-  const adminCentreNode = elements.find((e) => e.type === "node");
-  const adminCentre =
-    adminCentreNode && adminCentreNode.type === "node"
-      ? { lat: adminCentreNode.lat, lon: adminCentreNode.lon }
-      : null;
+  const adminCentreNode = elements.find(
+    (e): e is OSMNode => e.type === "node"
+  );
+  const adminCentre = adminCentreNode
+    ? { lat: adminCentreNode.lat, lon: adminCentreNode.lon }
+    : null;
 
   // Exclude the admin_centre node from the stored area geojson
   const geojson = convertOverpassToGeoJSON({

--- a/src/lib/area-refresh.ts
+++ b/src/lib/area-refresh.ts
@@ -1,0 +1,73 @@
+import { prisma } from "@/lib/db";
+import { Prisma } from "@prisma/client";
+import { fetchOsmRelationData } from "@/lib/area-boundary";
+import { getAreaDetailsById } from "@/lib/nominatim";
+import { AREA_INFO_TTL_DAYS } from "@/lib/constants";
+
+export function isAreaInfoStale(refreshedAt: Date | null): boolean {
+  if (!refreshedAt) return true;
+  const ttlMs = AREA_INFO_TTL_DAYS * 24 * 60 * 60 * 1000;
+  return Date.now() - refreshedAt.getTime() > ttlMs;
+}
+
+/**
+ * Resolve the map center for an area: the OSM relation's admin_centre member
+ * is authoritative; Nominatim's lat/lon is a fallback that can be a bad
+ * centroid (e.g. Luanda province resolves to an empty interior point).
+ */
+export function resolveAreaCenter(
+  osmData: Awaited<ReturnType<typeof fetchOsmRelationData>>,
+  areaDetails: Awaited<ReturnType<typeof getAreaDetailsById>>
+): { centerLat: number; centerLon: number } | null {
+  if (osmData?.adminCentre) {
+    return {
+      centerLat: osmData.adminCentre.lat,
+      centerLon: osmData.adminCentre.lon,
+    };
+  }
+  if (areaDetails?.centerLat != null && areaDetails?.centerLon != null) {
+    return {
+      centerLat: areaDetails.centerLat,
+      centerLon: areaDetails.centerLon,
+    };
+  }
+  return null;
+}
+
+/**
+ * Refresh stored area info (name, bounds, center, countryCode) from OSM and
+ * Nominatim, stamping refreshedAt. When the relation's bbox changed, the
+ * cached boundary polygon is invalidated so getAreaBoundary refetches it.
+ * Returns the updated area, or null when nothing could be fetched (leaving
+ * refreshedAt stale so the next view retries).
+ */
+export async function refreshAreaInfo(
+  areaId: number,
+  currentBounds: string | null
+) {
+  const [osmData, areaDetails] = await Promise.all([
+    fetchOsmRelationData(areaId),
+    getAreaDetailsById(areaId).catch(() => null),
+  ]);
+
+  if (!osmData && !areaDetails) return null;
+
+  const center = resolveAreaCenter(osmData, areaDetails);
+  const boundsChanged =
+    osmData?.bounds != null &&
+    currentBounds != null &&
+    osmData.bounds !== currentBounds;
+
+  return prisma.area.update({
+    where: { id: areaId },
+    data: {
+      name: osmData?.name ?? areaDetails?.name ?? undefined,
+      bounds: osmData?.bounds ?? undefined,
+      countryCode: areaDetails?.countryCode ?? undefined,
+      centerLat: center?.centerLat,
+      centerLon: center?.centerLon,
+      refreshedAt: new Date(),
+      ...(boundsChanged ? { geojson: Prisma.JsonNull } : {}),
+    },
+  });
+}

--- a/src/lib/area-refresh.ts
+++ b/src/lib/area-refresh.ts
@@ -10,11 +10,8 @@ export function isAreaInfoStale(refreshedAt: Date | null): boolean {
   return Date.now() - refreshedAt.getTime() > ttlMs;
 }
 
-/**
- * Resolve the map center for an area: the OSM relation's admin_centre member
- * is authoritative; Nominatim's lat/lon is a fallback that can be a bad
- * centroid (e.g. Luanda province resolves to an empty interior point).
- */
+// Nominatim's lat/lon can be a bad centroid (e.g. Luanda province resolves
+// to an empty interior point), so the OSM admin_centre member wins.
 export function resolveAreaCenter(
   osmData: Awaited<ReturnType<typeof fetchOsmRelationData>>,
   areaDetails: Awaited<ReturnType<typeof getAreaDetailsById>>
@@ -34,13 +31,6 @@ export function resolveAreaCenter(
   return null;
 }
 
-/**
- * Refresh stored area info (name, bounds, center, countryCode) from OSM and
- * Nominatim, stamping refreshedAt. When the relation's bbox changed, the
- * cached boundary polygon is invalidated so getAreaBoundary refetches it.
- * Returns the updated area, or null when nothing could be fetched (leaving
- * refreshedAt stale so the next view retries).
- */
 export async function refreshAreaInfo(
   areaId: number,
   currentBounds: string | null
@@ -66,7 +56,8 @@ export async function refreshAreaInfo(
       countryCode: areaDetails?.countryCode ?? undefined,
       centerLat: center?.centerLat,
       centerLon: center?.centerLon,
-      refreshedAt: new Date(),
+      // Nominatim-only refresh stays stale so the next view retries the bounds
+      ...(osmData ? { refreshedAt: new Date() } : {}),
       ...(boundsChanged ? { geojson: Prisma.JsonNull } : {}),
     },
   });

--- a/src/lib/area-refresh.ts
+++ b/src/lib/area-refresh.ts
@@ -3,6 +3,9 @@ import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
 import { getAreaDetailsById } from "@/lib/nominatim";
 import { AREA_INFO_TTL_DAYS } from "@/lib/constants";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("area-refresh");
 
 export function isAreaInfoStale(refreshedAt: Date | null): boolean {
   if (!refreshedAt) return true;
@@ -61,4 +64,22 @@ export async function refreshAreaInfo(
       ...(boundsChanged ? { geojson: Prisma.JsonNull } : {}),
     },
   });
+}
+
+type RefreshableArea = {
+  id: number;
+  bounds: string | null;
+  refreshedAt: Date | null;
+};
+
+export async function refreshAreaInfoIfStale<T extends RefreshableArea>(
+  area: T
+) {
+  if (!isAreaInfoStale(area.refreshedAt)) return area;
+  try {
+    return (await refreshAreaInfo(area.id, area.bounds)) ?? area;
+  } catch (error) {
+    logger.error("Failed to refresh area info", { areaId: area.id, error });
+    return area;
+  }
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,6 +17,9 @@ export const DATASET_MAP_DEFAULT_ZOOM = 12;
 /** Max lat-corrected bbox span (degrees, ~25 km) below which a bounds fit still gives a good initial view */
 export const AREA_BOUNDS_MAX_SPAN_DEG = 0.25;
 
+/** Days before stored area info (name, bounds, center, countryCode) is refreshed on view */
+export const AREA_INFO_TTL_DAYS = 30;
+
 /** Supported locales for translations */
 export const SUPPORTED_LOCALES = ["en", "pt-BR", "es"] as const;
 

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -3,6 +3,11 @@ import { getAreaDetailsById } from "@/lib/nominatim";
 import { resolveTemplate } from "@/lib/template-resolver";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
+import {
+  isAreaInfoStale,
+  refreshAreaInfo,
+  resolveAreaCenter,
+} from "@/lib/area-refresh";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { Prisma } from "@prisma/client";
 import { trackEvent } from "@/lib/umami";
@@ -37,26 +42,12 @@ export async function getOrCreateDataset(
   let dataset = await getDatasetWithDetails(areaId, template.id, locale);
 
   if (dataset) {
-    if (!dataset.area.countryCode || dataset.area.centerLat == null) {
+    if (isAreaInfoStale(dataset.area.refreshedAt)) {
       void (async () => {
         try {
-          const areaDetails = await getAreaDetailsById(areaId);
-          const hasNewCountryCode =
-            !dataset.area.countryCode && areaDetails?.countryCode;
-          const hasNewCenter =
-            dataset.area.centerLat == null && areaDetails?.centerLat != null;
-          if (hasNewCountryCode || hasNewCenter) {
-            await prisma.area.update({
-              where: { id: areaId },
-              data: {
-                countryCode: areaDetails?.countryCode ?? undefined,
-                centerLat: areaDetails?.centerLat ?? undefined,
-                centerLon: areaDetails?.centerLon ?? undefined,
-              },
-            });
-          }
+          await refreshAreaInfo(areaId, dataset.area.bounds);
         } catch (error) {
-          logger.error("Failed to backfill area details", { areaId, error });
+          logger.error("Failed to refresh area info", { areaId, error });
         }
       })();
     }
@@ -118,6 +109,7 @@ async function getDatasetWithDetails(areaId: number, templateId: string, locale:
           bounds: true,
           centerLat: true,
           centerLon: true,
+          refreshedAt: true,
           geojson: true,
         },
       },
@@ -160,24 +152,11 @@ async function createDatasetOnDemand(
     where: { id: areaId },
   });
 
-  if (area && (!area.countryCode || area.centerLat == null)) {
+  if (area && isAreaInfoStale(area.refreshedAt)) {
     try {
-      const areaDetails = await getAreaDetailsById(areaId);
-      const hasNewCountryCode = !area.countryCode && areaDetails?.countryCode;
-      const hasNewCenter =
-        area.centerLat == null && areaDetails?.centerLat != null;
-      if (hasNewCountryCode || hasNewCenter) {
-        area = await prisma.area.update({
-          where: { id: areaId },
-          data: {
-            countryCode: areaDetails?.countryCode ?? undefined,
-            centerLat: areaDetails?.centerLat ?? undefined,
-            centerLon: areaDetails?.centerLon ?? undefined,
-          },
-        });
-      }
+      area = (await refreshAreaInfo(areaId, area.bounds)) ?? area;
     } catch (error) {
-      logger.error("Failed to backfill area details", { areaId, error });
+      logger.error("Failed to refresh area info", { areaId, error });
     }
   }
 
@@ -193,10 +172,14 @@ async function createDatasetOnDemand(
       }
 
       // City OSM relations don't carry ISO3166 tags — Nominatim is the
-      // only reliable source for country code and admin centre coordinates.
+      // only reliable source for country code. The admin_centre member from
+      // Overpass is the authoritative map center; Nominatim's lat/lon can be
+      // a bad centroid (e.g. Luanda province).
       const countryCode = areaDetails?.countryCode ?? null;
-      const centerLat = areaDetails?.centerLat ?? null;
-      const centerLon = areaDetails?.centerLon ?? null;
+      const center = resolveAreaCenter(osmData, areaDetails);
+      const centerLat = center?.centerLat ?? null;
+      const centerLon = center?.centerLon ?? null;
+      const refreshedAt = new Date();
 
       if (osmData) {
         area = await prisma.area.upsert({
@@ -206,6 +189,7 @@ async function createDatasetOnDemand(
             countryCode,
             centerLat,
             centerLon,
+            refreshedAt,
             bounds: osmData.bounds,
             geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
           },
@@ -215,6 +199,7 @@ async function createDatasetOnDemand(
             countryCode,
             centerLat,
             centerLon,
+            refreshedAt,
             bounds: osmData.bounds,
             geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
           },
@@ -227,6 +212,7 @@ async function createDatasetOnDemand(
             countryCode,
             centerLat,
             centerLon,
+            refreshedAt,
             bounds: areaDetails!.boundingBox
               ? JSON.stringify(areaDetails!.boundingBox)
               : null,
@@ -238,6 +224,7 @@ async function createDatasetOnDemand(
             countryCode,
             centerLat,
             centerLon,
+            refreshedAt,
             bounds: areaDetails!.boundingBox
               ? JSON.stringify(areaDetails!.boundingBox)
               : null,
@@ -312,6 +299,7 @@ async function createDatasetOnDemand(
             bounds: true,
             centerLat: true,
             centerLon: true,
+            refreshedAt: true,
             geojson: true,
           },
         },

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -3,11 +3,7 @@ import { getAreaDetailsById } from "@/lib/nominatim";
 import { resolveTemplate } from "@/lib/template-resolver";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
-import {
-  isAreaInfoStale,
-  refreshAreaInfo,
-  resolveAreaCenter,
-} from "@/lib/area-refresh";
+import { refreshAreaInfoIfStale, resolveAreaCenter } from "@/lib/area-refresh";
 import { fetchDatasetSnapshot } from "@/lib/dataset-snapshot";
 import { Prisma } from "@prisma/client";
 import { trackEvent } from "@/lib/umami";
@@ -42,15 +38,7 @@ export async function getOrCreateDataset(
   let dataset = await getDatasetWithDetails(areaId, template.id, locale);
 
   if (dataset) {
-    if (isAreaInfoStale(dataset.area.refreshedAt)) {
-      void (async () => {
-        try {
-          await refreshAreaInfo(areaId, dataset.area.bounds);
-        } catch (error) {
-          logger.error("Failed to refresh area info", { areaId, error });
-        }
-      })();
-    }
+    void refreshAreaInfoIfStale(dataset.area);
     return { dataset, wasCreated: false };
   }
 
@@ -152,12 +140,8 @@ async function createDatasetOnDemand(
     where: { id: areaId },
   });
 
-  if (area && isAreaInfoStale(area.refreshedAt)) {
-    try {
-      area = (await refreshAreaInfo(areaId, area.bounds)) ?? area;
-    } catch (error) {
-      logger.error("Failed to refresh area info", { areaId, error });
-    }
+  if (area) {
+    area = await refreshAreaInfoIfStale(area);
   }
 
   if (!area) {
@@ -173,63 +157,35 @@ async function createDatasetOnDemand(
 
       // City OSM relations don't carry ISO3166 tags — Nominatim is the
       // only reliable source for country code.
-      const countryCode = areaDetails?.countryCode ?? null;
       const center = resolveAreaCenter(osmData, areaDetails);
-      const centerLat = center?.centerLat ?? null;
-      const centerLon = center?.centerLon ?? null;
-      const refreshedAt = new Date();
+      const shared = {
+        countryCode: areaDetails?.countryCode ?? null,
+        centerLat: center?.centerLat ?? null,
+        centerLon: center?.centerLon ?? null,
+        refreshedAt: new Date(),
+      };
 
-      if (osmData) {
-        area = await prisma.area.upsert({
-          where: { id: areaId },
-          update: {
+      const data = osmData
+        ? {
+            ...shared,
             name: osmData.name,
-            countryCode,
-            centerLat,
-            centerLon,
-            refreshedAt,
             bounds: osmData.bounds,
             geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
-          },
-          create: {
-            id: areaId,
-            name: osmData.name,
-            countryCode,
-            centerLat,
-            centerLon,
-            refreshedAt,
-            bounds: osmData.bounds,
-            geojson: JSON.parse(JSON.stringify(osmData.convertedGeojson)),
-          },
-        });
-      } else {
-        area = await prisma.area.upsert({
-          where: { id: areaId },
-          update: {
+          }
+        : {
+            ...shared,
             name: areaDetails!.name,
-            countryCode,
-            centerLat,
-            centerLon,
-            refreshedAt,
             bounds: areaDetails!.boundingBox
               ? JSON.stringify(areaDetails!.boundingBox)
               : null,
             geojson: Prisma.JsonNull,
-          },
-          create: {
-            id: areaId,
-            name: areaDetails!.name,
-            countryCode,
-            centerLat,
-            centerLon,
-            refreshedAt,
-            bounds: areaDetails!.boundingBox
-              ? JSON.stringify(areaDetails!.boundingBox)
-              : null,
-            geojson: Prisma.JsonNull,
-          },
-        });
-      }
+          };
+
+      area = await prisma.area.upsert({
+        where: { id: areaId },
+        update: data,
+        create: { id: areaId, ...data },
+      });
     } catch (error) {
       logger.error("Failed to fetch area data", { areaId, error });
       throw new Error(`Failed to fetch area data: ${areaId}`);

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -164,7 +164,7 @@ async function createDatasetOnDemand(
     try {
       const [osmData, areaDetails] = await Promise.all([
         fetchOsmRelationData(areaId),
-        getAreaDetailsById(areaId),
+        getAreaDetailsById(areaId).catch(() => null),
       ]);
 
       if (!osmData && !areaDetails) {
@@ -172,9 +172,7 @@ async function createDatasetOnDemand(
       }
 
       // City OSM relations don't carry ISO3166 tags — Nominatim is the
-      // only reliable source for country code. The admin_centre member from
-      // Overpass is the authoritative map center; Nominatim's lat/lon can be
-      // a bad centroid (e.g. Luanda province).
+      // only reliable source for country code.
       const countryCode = areaDetails?.countryCode ?? null;
       const center = resolveAreaCenter(osmData, areaDetails);
       const centerLat = center?.centerLat ?? null;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -95,10 +95,17 @@ export type InitialViewState =
   | { bounds: Bbox; fitBoundsOptions: { padding: number } }
   | { longitude: number; latitude: number; zoom: number };
 
+function isPointInBounds(lat: number, lon: number, bbox: Bbox): boolean {
+  const [minLon, minLat, maxLon, maxLat] = bbox;
+  return lat >= minLat && lat <= maxLat && lon >= minLon && lon <= maxLon;
+}
+
 /**
  * Initial view for the dataset map. Small area bboxes fit well; large ones
  * are untrustworthy (scattered boundaries) so the admin centre at a fixed
- * zoom wins. Falls back to area bounds, then data bounds, then world view.
+ * zoom wins — unless the stored center falls outside the actual data, which
+ * signals a bad center. Falls back to area bounds, then data bounds, then
+ * world view.
  */
 export function computeInitialViewState(
   area: {
@@ -115,11 +122,16 @@ export function computeInitialViewState(
   }
 
   if (area.centerLat != null && area.centerLon != null) {
-    return {
-      longitude: area.centerLon,
-      latitude: area.centerLat,
-      zoom: DATASET_MAP_DEFAULT_ZOOM,
-    };
+    if (!dataBounds || isPointInBounds(area.centerLat, area.centerLon, dataBounds)) {
+      return {
+        longitude: area.centerLon,
+        latitude: area.centerLat,
+        zoom: DATASET_MAP_DEFAULT_ZOOM,
+      };
+    }
+    // Center outside the actual data signals a bad center (e.g. a Nominatim
+    // centroid); the data extent is the trustworthy view.
+    return { bounds: dataBounds, fitBoundsOptions: { padding: 20 } };
   }
 
   if (areaBounds) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -95,15 +95,9 @@ export type InitialViewState =
   | { bounds: Bbox; fitBoundsOptions: { padding: number } }
   | { longitude: number; latitude: number; zoom: number };
 
-/** Tolerance (degrees, ~5.5 km) when testing whether a center is near the data. */
+/** ~5.5 km: the admin centre can sit just outside a tight data bbox */
 const CENTER_NEAR_BOUNDS_TOLERANCE_DEG = 0.05;
 
-/**
- * Whether the point is inside the bbox expanded by a tolerance margin. The
- * admin centre can sit just outside a tight data bbox (e.g. a bank across
- * the street from the bbox edge) — only a center far from the data signals
- * a bad center.
- */
 function isPointNearBounds(lat: number, lon: number, bbox: Bbox): boolean {
   const [minLon, minLat, maxLon, maxLat] = bbox;
   const t = CENTER_NEAR_BOUNDS_TOLERANCE_DEG;
@@ -112,13 +106,6 @@ function isPointNearBounds(lat: number, lon: number, bbox: Bbox): boolean {
   );
 }
 
-/**
- * Initial view for the dataset map. Small area bboxes fit well; large ones
- * are untrustworthy (scattered boundaries) so the admin centre at a fixed
- * zoom wins — unless the stored center falls outside the actual data, which
- * signals a bad center. Falls back to area bounds, then data bounds, then
- * world view.
- */
 export function computeInitialViewState(
   area: {
     bounds?: string | null;
@@ -141,8 +128,7 @@ export function computeInitialViewState(
         zoom: DATASET_MAP_DEFAULT_ZOOM,
       };
     }
-    // Center outside the actual data signals a bad center (e.g. a Nominatim
-    // centroid); the data extent is the trustworthy view.
+    // A center far from the data is a bad center (e.g. a Nominatim centroid)
     return { bounds: dataBounds, fitBoundsOptions: { padding: 20 } };
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -95,9 +95,21 @@ export type InitialViewState =
   | { bounds: Bbox; fitBoundsOptions: { padding: number } }
   | { longitude: number; latitude: number; zoom: number };
 
-function isPointInBounds(lat: number, lon: number, bbox: Bbox): boolean {
+/** Tolerance (degrees, ~5.5 km) when testing whether a center is near the data. */
+const CENTER_NEAR_BOUNDS_TOLERANCE_DEG = 0.05;
+
+/**
+ * Whether the point is inside the bbox expanded by a tolerance margin. The
+ * admin centre can sit just outside a tight data bbox (e.g. a bank across
+ * the street from the bbox edge) — only a center far from the data signals
+ * a bad center.
+ */
+function isPointNearBounds(lat: number, lon: number, bbox: Bbox): boolean {
   const [minLon, minLat, maxLon, maxLat] = bbox;
-  return lat >= minLat && lat <= maxLat && lon >= minLon && lon <= maxLon;
+  const t = CENTER_NEAR_BOUNDS_TOLERANCE_DEG;
+  return (
+    lat >= minLat - t && lat <= maxLat + t && lon >= minLon - t && lon <= maxLon + t
+  );
 }
 
 /**
@@ -122,7 +134,7 @@ export function computeInitialViewState(
   }
 
   if (area.centerLat != null && area.centerLon != null) {
-    if (!dataBounds || isPointInBounds(area.centerLat, area.centerLon, dataBounds)) {
+    if (!dataBounds || isPointNearBounds(area.centerLat, area.centerLon, dataBounds)) {
       return {
         longitude: area.centerLon,
         latitude: area.centerLat,


### PR DESCRIPTION
## Issue #370: Wrong center for areas whose Nominatim point is a centroid (Luanda); lazy TTL on area info

**Problem:** #369 centers the dataset map on Nominatim's lat/lon. For Luanda (relation 1802546) Nominatim resolves the boundary as addresstype=state and cannot link the place=city admin_centre node, so lat/lon falls back to the province point-on-surface - an empty interior ~80 km from the city; the map opened on nothing. OSM itself carries the correct admin_centre member (node 27564941). Stored area info also never refreshed, so bad values persisted indefinitely.

**Acceptance Criteria:**
- [x] Luanda bus-stops opens centered on Luanda city, not the empty province interior
- [x] Tokyo/Paris behavior from #369 unchanged
- [x] Area info self-corrects within 30 days of an OSM change once viewed

**Changes:**
- fetchOsmRelationData fetches the relation's admin_centre member node in the same Overpass round-trip (rel -> .a; out bb tags; node(r.a:"admin_centre"); out) and exposes it as adminCentre; only the relation element feeds the stored geojson so no stray point leaks in
- New src/lib/area-refresh.ts: resolveAreaCenter (admin_centre preferred, Nominatim fallback), isAreaInfoStale (30-day TTL), refreshAreaInfo (rewrites name, bounds, center, countryCode and stamps refreshedAt; nulls the cached boundary geojson when the relation bbox changed so the existing lazy boundary path refetches it; no write when both sources fail so the next view retries)
- New nullable Area.refreshedAt (migration add_area_refreshed_at). Existing rows start null, so every area - including ones with bad stored centers - self-repairs on first view after deploy; the fire-and-forget hook in getOrCreateDataset now triggers on staleness instead of missing fields
- Creation paths (createDatasetOnDemand, POST /api/datasets) use the same center priority and stamp refreshedAt
- Safety net in computeInitialViewState: a center falling outside the dataset's data bounds signals a bad center and falls back to data-bounds fit

Verified: type-check, lint, 216 unit tests pass (incl. new area-refresh, area-boundary parsing, safety-net suites). Browser-verified in worktree against live Overpass: Luanda opens on the city center (DB center -8.827/13.244 from admin_centre), Tokyo unchanged, corrupted-then-viewed area self-repaired (name + center rewritten, refreshedAt re-stamped), bounds-change nulled and refetched the boundary polygon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Area information now refreshes automatically when older than 30 days.
  - Map centers prioritize authoritative geographic center data, with fallback location details when needed.
  - Area metadata, boundaries, and refresh timestamps are kept up to date.
- **Bug Fixes**
  - Improved handling of geographic relation data and missing boundary information.
  - Maps now fit the available data when a stored center falls outside the dataset bounds.
- **Tests**
  - Added coverage for area refreshes, geographic boundaries, center selection, and map view behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->