### PR TITLE
fix(home): consistent zoom-to-area for featured hero card

### DIFF
--- a/docs/features/map-rendering.md
+++ b/docs/features/map-rendering.md
@@ -1,46 +1,29 @@
 # Map Rendering
 
-Decisions and direction for all dataset maps (dataset page + home featured card), plus the canonical dataset list for testing map changes.
+Shared decisions for all dataset maps (dataset page + home featured card).
 
 ## View state (zoom-to-area)
 
-`computeInitialViewState(area, dataBounds)` in `src/lib/utils.ts` is the single entry point for the initial view of every dataset map. Do not hand-roll `fitBounds` logic in map components.
+`computeInitialViewState(area, dataBounds)` in `src/lib/utils.ts` is the single entry point — no hand-rolled `fitBounds` in map components.
 
-Decision tree:
+1. Small area bbox (span <= 0.25 deg): fit area bounds.
+2. Else center on the admin centre at zoom 12 — large bboxes are untrustworthy. If the centre is far from the data bbox, fit data bounds instead.
+3. Fallback: area bounds -> data bounds -> world.
 
-1. Area bbox small (span <= 0.25 deg, `isSmallAreaBounds`): fit area bounds, padding 20.
-2. Area has admin centre (`centerLat`/`centerLon`, from OSM `admin_centre` or Nominatim): center on it at zoom 12 (`DATASET_MAP_DEFAULT_ZOOM`) — large bboxes are untrustworthy (scattered boundaries, huge municipalities).
-   - Far-center guard: if the centre is >~5.5 km outside the data bbox, fit data bounds instead (bad Nominatim centroid).
-3. Fallback chain: area bounds -> data bounds -> world view.
+New map surfaces must select `bounds`, `centerLat`, `centerLon` on the area and go through this function.
 
-Consumers:
+## Style
 
-- Dataset page: `use-map-data.ts` (has data bounds server-side, guard active on first paint).
-- Featured home card: `featured-dataset-map-client.tsx` (geojson loads client-side; first paint uses area only, refits when data arrival changes the outcome — including on client-side nav, which swaps props without remounting the map).
-
-Any new dataset map surface must select `bounds`, `centerLat`, `centerLon` on the area and go through `computeInitialViewState`.
-
-## Style direction (2026-07)
-
-Single source of truth: `src/components/dataset/map/layers/map-layers.tsx` (`DEFAULT_STYLE_KNOBS`, builders, `AGE_PALETTES`). Legend and AOI boundary import from it — no color drift.
-
-- Age coloring: sequential single-hue BluGrn ramp, dark = recent. At 1-3px dot sizes luminance is the only channel that carries; color-blind safe. The very-old majority stays pale and recedes (figure/ground, ciclomapa-style).
-- Recent edits (<1% of features): drawn on top via sort-key, +1 radius boost, white halo.
-- Basemap: muted by a white wash layer at 0.4 opacity (`src/lib/map-tiles.ts`).
-- AOI boundary: design-token olive-500 `#57814c` — reads as chrome, not data.
-- Live tuning: dev-only Tune panel on dataset pages; bake values back into `DEFAULT_STYLE_KNOBS` (see osmforcities-map-style-tuning skill for the workflow).
+Single source of truth: `src/components/dataset/map/layers/map-style.ts` (`DEFAULT_STYLE_KNOBS`). Rationale for each choice is commented inline there. Highlights: Viridis age ramp (dark = recent), white-washed basemap, olive AOI boundary, size reinforces recency. Live-tune via the dev-only Tune panel (osmforcities-map-style-tuning skill).
 
 ## Test datasets
 
-Canonical matrix for verifying zoom or style changes. Check each on BOTH the dataset page and the home featured card (feature them via the dataset page admin button).
+Verify zoom/style changes on BOTH the dataset page and the home featured card. Populate via `POST /api/datasets {templateId, osmRelationId}` (never SQL), feature via the dataset page admin button.
 
-| Dataset | Area (OSM relation) | Exercises |
+| Dataset | Relation | Exercises |
 | --- | --- | --- |
-| Bus Stops in Luanda | 1802546 (province, ~1.9 deg span) | Large bbox -> admin-centre path; sparse points |
-| Banks in Altamira | 185554 (huge municipality, ~4 deg span) | Admin centre with tight data cluster; far-center tolerance |
-| Cycleways in Recife | 303585 (~0.2 deg span) | Small-bounds control — must fit area bounds |
-| Cycleways in Amsterdam | 271110 (0.35 deg lon span) | Just-over-threshold city; dense line rendering |
-
-Expected: Luanda/Altamira/Amsterdam center on the city at zoom 12; Recife fits its bounds; featured card matches the dataset page for all four.
-
-Populate via the app, not SQL: `POST /api/datasets` with `{ templateId, osmRelationId }` (signed in, Overpass tunnel up), then feature each via the dataset page.
+| Bus Stops in Luanda | 1802546 | Large bbox -> admin-centre path, sparse points |
+| Banks in Altamira | 185554 | Huge municipality, tight data cluster |
+| Cycleways in Recife | 303585 | Small-bounds control — must fit area bounds |
+| Cycleways in Amsterdam | 271110 | Just-over-threshold city, dense lines |
+| Bus Stops in Sao Paulo | 298285 | Large bbox, 18k points (density/perf) |

--- a/docs/features/map-rendering.md
+++ b/docs/features/map-rendering.md
@@ -1,0 +1,46 @@
+# Map Rendering
+
+Decisions and direction for all dataset maps (dataset page + home featured card), plus the canonical dataset list for testing map changes.
+
+## View state (zoom-to-area)
+
+`computeInitialViewState(area, dataBounds)` in `src/lib/utils.ts` is the single entry point for the initial view of every dataset map. Do not hand-roll `fitBounds` logic in map components.
+
+Decision tree:
+
+1. Area bbox small (span <= 0.25 deg, `isSmallAreaBounds`): fit area bounds, padding 20.
+2. Area has admin centre (`centerLat`/`centerLon`, from OSM `admin_centre` or Nominatim): center on it at zoom 12 (`DATASET_MAP_DEFAULT_ZOOM`) — large bboxes are untrustworthy (scattered boundaries, huge municipalities).
+   - Far-center guard: if the centre is >~5.5 km outside the data bbox, fit data bounds instead (bad Nominatim centroid).
+3. Fallback chain: area bounds -> data bounds -> world view.
+
+Consumers:
+
+- Dataset page: `use-map-data.ts` (has data bounds server-side, guard active on first paint).
+- Featured home card: `featured-dataset-map-client.tsx` (geojson loads client-side; first paint uses area only, refits when data arrival changes the outcome — including on client-side nav, which swaps props without remounting the map).
+
+Any new dataset map surface must select `bounds`, `centerLat`, `centerLon` on the area and go through `computeInitialViewState`.
+
+## Style direction (2026-07)
+
+Single source of truth: `src/components/dataset/map/layers/map-layers.tsx` (`DEFAULT_STYLE_KNOBS`, builders, `AGE_PALETTES`). Legend and AOI boundary import from it — no color drift.
+
+- Age coloring: sequential single-hue BluGrn ramp, dark = recent. At 1-3px dot sizes luminance is the only channel that carries; color-blind safe. The very-old majority stays pale and recedes (figure/ground, ciclomapa-style).
+- Recent edits (<1% of features): drawn on top via sort-key, +1 radius boost, white halo.
+- Basemap: muted by a white wash layer at 0.4 opacity (`src/lib/map-tiles.ts`).
+- AOI boundary: design-token olive-500 `#57814c` — reads as chrome, not data.
+- Live tuning: dev-only Tune panel on dataset pages; bake values back into `DEFAULT_STYLE_KNOBS` (see osmforcities-map-style-tuning skill for the workflow).
+
+## Test datasets
+
+Canonical matrix for verifying zoom or style changes. Check each on BOTH the dataset page and the home featured card (feature them via the dataset page admin button).
+
+| Dataset | Area (OSM relation) | Exercises |
+| --- | --- | --- |
+| Bus Stops in Luanda | 1802546 (province, ~1.9 deg span) | Large bbox -> admin-centre path; sparse points |
+| Banks in Altamira | 185554 (huge municipality, ~4 deg span) | Admin centre with tight data cluster; far-center tolerance |
+| Cycleways in Recife | 303585 (~0.2 deg span) | Small-bounds control — must fit area bounds |
+| Cycleways in Amsterdam | 271110 (0.35 deg lon span) | Just-over-threshold city; dense line rendering |
+
+Expected: Luanda/Altamira/Amsterdam center on the city at zoom 12; Recife fits its bounds; featured card matches the dataset page for all four.
+
+Populate via the app, not SQL: `POST /api/datasets` with `{ templateId, osmRelationId }` (signed in, Overpass tunnel up), then feature each via the dataset page.

--- a/src/components/home/shared/featured-dataset-map-client.tsx
+++ b/src/components/home/shared/featured-dataset-map-client.tsx
@@ -10,18 +10,39 @@ import { useTranslations } from "next-intl";
 import type { FeatureCollection } from "geojson";
 import { mapStyle } from "@/lib/map-tiles";
 import { getTemplateIcon } from "@/lib/category-icons";
-import { calculateBbox } from "@/lib/utils";
-import type { Bbox } from "@/types/geojson";
+import { calculateBbox, computeInitialViewState } from "@/lib/utils";
+import type { InitialViewState } from "@/lib/utils";
 import type { ProcessedDatasetStats } from "@/lib/dataset-stats";
 import { DatasetStatsRow } from "@/components/ui/dataset-stats-row";
 import { MapLayers } from "@/components/dataset/map/layers";
 import { AoiBoundaryLayer } from "@/components/dataset/map/aoi-boundary-layer";
 import { processOSMFeaturesForVisualization } from "@/lib/osm-data-processor";
 
+function applyViewState(map: MapRef | null, viewState: InitialViewState) {
+  if (!map) return;
+  if ("bounds" in viewState) {
+    map.fitBounds(viewState.bounds, {
+      ...viewState.fitBoundsOptions,
+      duration: 0,
+    });
+  } else {
+    map.jumpTo({
+      center: [viewState.longitude, viewState.latitude],
+      zoom: viewState.zoom,
+    });
+  }
+}
+
+type FeaturedArea = {
+  bounds: string | null;
+  centerLat: number | null;
+  centerLon: number | null;
+};
+
 type FeaturedDatasetMapClientProps = {
   datasetId: string;
   areaId: number;
-  bounds: Bbox | null;
+  area: FeaturedArea;
   title: string;
   /** Category slug (icon fallback when the template has no icon) */
   category: string;
@@ -34,7 +55,7 @@ type FeaturedDatasetMapClientProps = {
 export function FeaturedDatasetMapClient({
   datasetId,
   areaId,
-  bounds,
+  area,
   title,
   category,
   templateId,
@@ -76,30 +97,30 @@ export function FeaturedDatasetMapClient({
   );
 
   // Client-side navigation swaps props without remounting the Map, so
-  // initialViewState alone would keep the old view. bounds is read via
+  // initialViewState alone would keep the old view. area is read via
   // ref because its identity changes every server render. The sync effect
   // must stay declared before the refit effect that reads it.
-  const boundsRef = useRef(bounds);
+  const areaRef = useRef(area);
   useEffect(() => {
-    boundsRef.current = bounds;
-  }, [bounds]);
+    areaRef.current = area;
+  }, [area]);
   useEffect(() => {
-    if (boundsRef.current) {
-      mapRef.current?.fitBounds(boundsRef.current, {
-        padding: 40,
-        duration: 0,
-      });
-    }
+    applyViewState(mapRef.current, computeInitialViewState(areaRef.current, null));
   }, [datasetId]);
 
-  // Server bounds cover most datasets; fit to the data when the area has none
+  // The far-center guard and the no-bounds fallback both need the data bbox,
+  // which only exists once the geojson arrives. Refit only when it changes
+  // the outcome, so the common case never jumps.
   useEffect(() => {
-    if (bounds || !geojson) return;
+    if (!geojson) return;
     const dataBounds = calculateBbox(geojson);
-    if (dataBounds) {
-      mapRef.current?.fitBounds(dataBounds, { padding: 40, duration: 0 });
+    if (!dataBounds) return;
+    const withData = computeInitialViewState(areaRef.current, dataBounds);
+    const withoutData = computeInitialViewState(areaRef.current, null);
+    if (JSON.stringify(withData) !== JSON.stringify(withoutData)) {
+      applyViewState(mapRef.current, withData);
     }
-  }, [bounds, geojson]);
+  }, [geojson]);
 
   const statItems = [
     { type: "features" as const, label: t("stats.features"), value: stats.features },
@@ -112,11 +133,7 @@ export function FeaturedDatasetMapClient({
       <Map
         ref={mapRef}
         mapStyle={mapStyle}
-        initialViewState={
-          bounds
-            ? { bounds, fitBoundsOptions: { padding: 40 } }
-            : { longitude: 0, latitude: 0, zoom: 1 }
-        }
+        initialViewState={computeInitialViewState(area, null)}
         dragPan
         scrollZoom={false}
         dragRotate={false}

--- a/src/components/home/shared/featured-dataset-map.tsx
+++ b/src/components/home/shared/featured-dataset-map.tsx
@@ -3,7 +3,6 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/db";
 import { processDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
-import { parseAreaBounds } from "@/lib/utils";
 import { getDatasetPath } from "@/lib/urls";
 import { HeroMap } from "./hero-map";
 import { FeaturedDatasetMapClient } from "./featured-dataset-map-client";
@@ -20,6 +19,8 @@ const FEATURED_DATASET_SELECT = {
       id: true,
       countryCode: true,
       bounds: true,
+      centerLat: true,
+      centerLon: true,
     },
   },
   template: {
@@ -82,7 +83,7 @@ export async function FeaturedDatasetMap() {
     <FeaturedDatasetMapClient
       datasetId={dataset.id}
       areaId={dataset.areaId}
-      bounds={parseAreaBounds(dataset.area)}
+      area={dataset.area}
       title={t("title", {
         template: resolvedTemplate.name,
         city: dataset.cityName,


### PR DESCRIPTION
## Featured hero card: consistent zoom-to-area with dataset page

**Related:** follow-up perf ticket #375; view-state logic introduced in #369/#371.

**Problem:** #369/#371 fixed zoom-to-area on the dataset page (large/untrustworthy area bboxes center on the OSM admin centre at zoom 12 instead of fitting the whole bbox). The home hero card, built earlier in #356, never got the fix: it always fits the raw area bounds, so large areas (observed with Luanda on staging) render zoomed out to the whole province and never correct.

**Acceptance Criteria:**
- [ ] Featured card uses the same shared `computeInitialViewState` as the dataset page
- [ ] Large-bbox areas (Luanda, Altamira, Sao Paulo, Amsterdam) center on the admin centre at zoom 12
- [ ] Small areas (Recife) still fit their bounds
- [ ] Client-side nav between featured datasets still refits without remount
- [ ] Dataset page behavior unchanged

**Changes:**
- `featured-dataset-map.tsx`: select `centerLat`/`centerLon` on the area; pass the area object to the client instead of pre-parsed bounds.
- `featured-dataset-map-client.tsx`: replace the three hand-rolled `fitBounds(padding: 40)` paths with `computeInitialViewState(area, dataBounds)`. First paint uses area info only; when the client-fetched geojson arrives, refit only if the data bbox changes the outcome (far-center guard / no-bounds fallback). Same recompute runs on `datasetId` change to preserve the nav refit.
- New `docs/features/map-rendering.md`: view-state decision tree, style direction, canonical test datasets.

Verified in a worktree against Luanda bus stops, Altamira banks, Sao Paulo bus stops (18k), Amsterdam cycleways, Recife cycleways: hero now matches the dataset page for all five; dataset page screenshots identical to baseline. type-check, lint (0 errors), i18n:check, and 241 unit tests pass (3 pre-existing env-dependent DB test files unrelated to this diff fail locally without a seeded test DB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved featured dataset maps with more accurate initial positioning based on area boundaries, geographic centers, or available data.
  * Map views now update more smoothly when navigating between datasets and refit when displayed data changes.
  * Standardized map styling and rendering guidance across dataset pages and featured map cards.

* **Documentation**
  * Added guidance for map positioning, styling, supported datasets, and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->