### PR TITLE
feat(map): per-template filterable-tag allow-list with localized legend

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -666,5 +666,50 @@
       "title": "{area} - Datasets - OSM for Cities",
       "description": "Explore OpenStreetMap datasets for {area}"
     }
+  },
+  "TagLabel": {
+    "shelter": "Shelter",
+    "bench": "Bench",
+    "covered": "Covered",
+    "lit": "Lit",
+    "tactile_paving": "Tactile paving",
+    "bicycle_parking": "Type",
+    "capacity": "Capacity",
+    "access": "Access",
+    "fee": "Fee"
+  },
+  "TagValue": {
+    "__common__": {
+      "yes": "Yes",
+      "no": "No",
+      "limited": "Limited"
+    },
+    "access": {
+      "private": "Private",
+      "customers": "Customers",
+      "permissive": "Permissive",
+      "designated": "Designated",
+      "permit": "By permit"
+    },
+    "bicycle_parking": {
+      "stands": "Stands",
+      "wide_stands": "Wide stands",
+      "low_stands": "Low stands",
+      "large_stands": "Large stands",
+      "wall_loops": "Wall loops",
+      "safe_loops": "Safe loops",
+      "ground_slots": "Ground slots",
+      "rack": "Rack",
+      "two-tier": "Two-tier",
+      "shed": "Shed",
+      "floor": "Floor",
+      "lockers": "Lockers",
+      "building": "Building",
+      "bollard": "Bollard",
+      "anchors": "Anchors",
+      "handlebar_holder": "Handlebar holder",
+      "crossbar": "Crossbar",
+      "informal": "Informal"
+    }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -673,5 +673,50 @@
       "title": "{area} - Conjuntos de Datos - OSM for Cities",
       "description": "Explora conjuntos de datos de OpenStreetMap para {area}"
     }
+  },
+  "TagLabel": {
+    "shelter": "Marquesina",
+    "bench": "Banco",
+    "covered": "Cubierto",
+    "lit": "Iluminado",
+    "tactile_paving": "Pavimento táctil",
+    "bicycle_parking": "Tipo",
+    "capacity": "Capacidad",
+    "access": "Acceso",
+    "fee": "Tarifa"
+  },
+  "TagValue": {
+    "__common__": {
+      "yes": "Sí",
+      "no": "No",
+      "limited": "Limitado"
+    },
+    "access": {
+      "private": "Privado",
+      "customers": "Clientes",
+      "permissive": "Permisivo",
+      "designated": "Designado",
+      "permit": "Con permiso"
+    },
+    "bicycle_parking": {
+      "stands": "Soportes",
+      "wide_stands": "Soportes anchos",
+      "low_stands": "Soportes bajos",
+      "large_stands": "Soportes grandes",
+      "wall_loops": "Anclajes de pared",
+      "safe_loops": "Anclajes seguros",
+      "ground_slots": "Ranuras en el suelo",
+      "rack": "Rack",
+      "two-tier": "Dos niveles",
+      "shed": "Cobertizo",
+      "floor": "Suelo",
+      "lockers": "Casilleros",
+      "building": "Edificio",
+      "bollard": "Bolardo",
+      "anchors": "Anclajes",
+      "handlebar_holder": "Soporte de manillar",
+      "crossbar": "Barra",
+      "informal": "Informal"
+    }
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -673,5 +673,50 @@
       "title": "{area} - Conjuntos de Dados - OSM for Cities",
       "description": "Explore conjuntos de dados do OpenStreetMap para {area}"
     }
+  },
+  "TagLabel": {
+    "shelter": "Abrigo",
+    "bench": "Banco",
+    "covered": "Coberto",
+    "lit": "Iluminado",
+    "tactile_paving": "Piso tátil",
+    "bicycle_parking": "Tipo",
+    "capacity": "Capacidade",
+    "access": "Acesso",
+    "fee": "Tarifa"
+  },
+  "TagValue": {
+    "__common__": {
+      "yes": "Sim",
+      "no": "Não",
+      "limited": "Limitado"
+    },
+    "access": {
+      "private": "Privado",
+      "customers": "Clientes",
+      "permissive": "Permissivo",
+      "designated": "Designado",
+      "permit": "Com permissão"
+    },
+    "bicycle_parking": {
+      "stands": "Suportes",
+      "wide_stands": "Suportes largos",
+      "low_stands": "Suportes baixos",
+      "large_stands": "Suportes grandes",
+      "wall_loops": "Fixação na parede",
+      "safe_loops": "Fixação segura",
+      "ground_slots": "Ranhuras no chão",
+      "rack": "Rack",
+      "two-tier": "Dois níveis",
+      "shed": "Galpão",
+      "floor": "Piso",
+      "lockers": "Armários",
+      "building": "Edifício",
+      "bollard": "Pilarete",
+      "anchors": "Âncoras",
+      "handlebar_holder": "Suporte de guidão",
+      "crossbar": "Barra",
+      "informal": "Informal"
+    }
   }
 }

--- a/prisma/lib/__tests__/template-parser.test.ts
+++ b/prisma/lib/__tests__/template-parser.test.ts
@@ -285,14 +285,38 @@ describe("template-parser", () => {
     it("loads templates.yml array format and returns entries + categories", () => {
       const { entries, categories } = loadTemplatesLogic("./prisma");
       expect(entries.length).toBeGreaterThan(0);
-      expect(entries[0]).toEqual({
+      const byId = new Map(entries.map((e) => [e.id, e]));
+      expect(byId.get("bicycle-parking")).toEqual({
         id: "bicycle-parking",
         query: "amenity=bicycle_parking",
         category: "transportation",
         icon: "Bike",
+        parent: "bicycle-infrastructure",
+        filterableTags: [
+          "bicycle_parking",
+          "covered",
+          "capacity",
+          "access",
+          "fee",
+        ],
       });
       expect(categories.transportation).toBe("Car");
       expect(categories.agriculture).toBe("Wheat");
+    });
+
+    it("attaches per-template filterableTags from the map (curated only)", () => {
+      const { entries } = loadTemplatesLogic("./prisma");
+      const byId = new Map(entries.map((e) => [e.id, e]));
+      // Curated templates carry their list
+      expect(byId.get("bus-stops")?.filterableTags).toEqual([
+        "shelter",
+        "bench",
+        "covered",
+        "lit",
+        "tactile_paving",
+      ]);
+      // Uncurated templates have no list (age-only in the legend)
+      expect(byId.get("hospitals")?.filterableTags).toBeUndefined();
     });
   });
 

--- a/prisma/lib/template-parser.ts
+++ b/prisma/lib/template-parser.ts
@@ -18,6 +18,7 @@ export interface LogicEntry {
   category: string;
   icon?: string;
   parent?: string;
+  filterableTags?: string[];
 }
 
 /**
@@ -28,6 +29,7 @@ export interface TemplateLogic {
   category: string;
   icon?: string;
   parent?: string;
+  filterableTags?: string[];
 }
 
 /**
@@ -61,6 +63,7 @@ export interface TemplateConfig {
   parent?: string;
   name?: string;
   description?: string;
+  filterableTags?: string[];
 }
 
 /**
@@ -73,6 +76,7 @@ export interface ParsedTemplate {
   overpassQuery: string;
   category: string;
   tags: string[];
+  filterableTags: string[];
   parent?: string;
 }
 
@@ -220,6 +224,7 @@ export function buildTemplate(config: TemplateConfig): ParsedTemplate {
     parent,
     name: configName,
     description: configDesc,
+    filterableTags,
   } = config;
 
   if (!isValidId(id)) {
@@ -247,6 +252,7 @@ export function buildTemplate(config: TemplateConfig): ParsedTemplate {
     overpassQuery,
     category,
     tags,
+    filterableTags: filterableTags ?? [],
     parent,
   };
 }
@@ -264,13 +270,31 @@ export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
     const config = yaml.load(file) as {
       templates?: unknown[];
       categories?: Record<string, string>;
+      filterableTags?: Record<string, unknown>;
     };
 
     if (!config?.templates || !Array.isArray(config.templates)) {
       throw new Error("Invalid templates.yml: templates must be an array");
     }
 
+    // Sparse per-template allow-list of tag keys that become legend views.
+    // Templates absent from this map fall back to the age view only.
+    const filterableByIdRaw = config.filterableTags ?? {};
+    const filterableById = new Map<string, string[]>();
+    for (const [id, tags] of Object.entries(filterableByIdRaw)) {
+      // Guard hand-edited YAML: a scalar/object or non-string array element would
+      // otherwise disable the template silently or produce "[object Object]" keys.
+      if (!Array.isArray(tags) || tags.some((tag) => typeof tag !== "string")) {
+        console.warn(
+          `templates.yml: filterableTags for "${id}" must be a string array`,
+        );
+        continue;
+      }
+      filterableById.set(id, tags.map((tag) => tag.trim()).filter(Boolean));
+    }
+
     const entries: LogicEntry[] = [];
+    const seenIds = new Set<string>();
     for (const row of config.templates) {
       const arr = Array.isArray(row) ? row : [row];
       const id = String(arr[0] ?? "");
@@ -279,6 +303,7 @@ export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
       const iconRaw = arr[3];
       const parentRaw = arr[4];
       if (id && query && category) {
+        seenIds.add(id);
         entries.push({
           id,
           query,
@@ -291,8 +316,19 @@ export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
             parentRaw !== undefined && parentRaw !== null && String(parentRaw) !== ""
               ? String(parentRaw)
               : undefined,
+          filterableTags: filterableById.get(id),
         });
       }
+    }
+
+    // Surface typo'd/stale ids under `filterableTags:` — they attach to nothing
+    // and would silently leave a template age-only. Warn rather than throw so a
+    // bad key never blocks the seed.
+    const unmatched = [...filterableById.keys()].filter((id) => !seenIds.has(id));
+    if (unmatched.length > 0) {
+      console.warn(
+        `templates.yml: filterableTags references unknown template id(s): ${unmatched.join(", ")}`,
+      );
     }
 
     return {
@@ -351,6 +387,7 @@ export function loadTemplatesYaml(
       category: entry.category,
       icon: entry.icon,
       parent: entry.parent,
+      filterableTags: entry.filterableTags,
     };
   }
   return { templates, categories };
@@ -395,6 +432,7 @@ export function parseTemplates(config: LogicConfig): ParseResult {
         category: obj.category,
         icon: obj.icon,
         parent: obj.parent,
+        filterableTags: obj.filterableTags,
       };
       const template = buildTemplate(parsed);
       templates.push(template);

--- a/prisma/migrations/20260721152950_add_template_filterable_tags/migration.sql
+++ b/prisma/migrations/20260721152950_add_template_filterable_tags/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "templates" ADD COLUMN     "filterableTags" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/migrations/20260725101500_harden_template_tag_arrays/migration.sql
+++ b/prisma/migrations/20260725101500_harden_template_tag_arrays/migration.sql
@@ -3,7 +3,11 @@
 -- layer (Prisma scalar lists are always non-null), but the underlying columns
 -- were created nullable, so a non-Prisma write could insert NULL and violate the
 -- contract that dataset reads rely on. Backfill any stray NULLs, then constrain.
-UPDATE "templates" SET "tags" = ARRAY[]::TEXT[] WHERE "tags" IS NULL;
-UPDATE "templates" SET "filterableTags" = ARRAY[]::TEXT[] WHERE "filterableTags" IS NULL;
+UPDATE "templates"
+SET "tags" = ARRAY[]::TEXT[]
+WHERE "tags" IS NULL;
+UPDATE "templates"
+SET "filterableTags" = ARRAY[]::TEXT[]
+WHERE "filterableTags" IS NULL;
 ALTER TABLE "templates" ALTER COLUMN "tags" SET NOT NULL;
 ALTER TABLE "templates" ALTER COLUMN "filterableTags" SET NOT NULL;

--- a/prisma/migrations/20260725101500_harden_template_tag_arrays/migration.sql
+++ b/prisma/migrations/20260725101500_harden_template_tag_arrays/migration.sql
@@ -4,5 +4,6 @@
 -- were created nullable, so a non-Prisma write could insert NULL and violate the
 -- contract that dataset reads rely on. Backfill any stray NULLs, then constrain.
 UPDATE "templates" SET "tags" = ARRAY[]::TEXT[] WHERE "tags" IS NULL;
+UPDATE "templates" SET "filterableTags" = ARRAY[]::TEXT[] WHERE "filterableTags" IS NULL;
 ALTER TABLE "templates" ALTER COLUMN "tags" SET NOT NULL;
 ALTER TABLE "templates" ALTER COLUMN "filterableTags" SET NOT NULL;

--- a/prisma/migrations/20260725101500_harden_template_tag_arrays/migration.sql
+++ b/prisma/migrations/20260725101500_harden_template_tag_arrays/migration.sql
@@ -1,0 +1,8 @@
+-- Enforce the required-array invariant at the database level for the template
+-- tag arrays. Both `tags` and `filterableTags` are non-null at the Prisma/app
+-- layer (Prisma scalar lists are always non-null), but the underlying columns
+-- were created nullable, so a non-Prisma write could insert NULL and violate the
+-- contract that dataset reads rely on. Backfill any stray NULLs, then constrain.
+UPDATE "templates" SET "tags" = ARRAY[]::TEXT[] WHERE "tags" IS NULL;
+ALTER TABLE "templates" ALTER COLUMN "tags" SET NOT NULL;
+ALTER TABLE "templates" ALTER COLUMN "filterableTags" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Template {
   parent        Template?             @relation("TemplateHierarchy", fields: [parentId], references: [id])
   children      Template[]            @relation("TemplateHierarchy")
   tags          String[]
+  filterableTags String[]             @default([])
   isActive      Boolean               @default(true)
   deprecatesAt  DateTime?
   createdAt     DateTime              @default(now())

--- a/prisma/sync-templates.ts
+++ b/prisma/sync-templates.ts
@@ -154,6 +154,7 @@ async function main() {
         overpassQuery: template.overpassQuery,
         category: { connect: { id: categoryId } },
         tags: template.tags,
+        filterableTags: template.filterableTags,
         updatedAt: new Date(),
       },
       create: {
@@ -163,6 +164,7 @@ async function main() {
         overpassQuery: template.overpassQuery,
         category: { connect: { id: categoryId } },
         tags: template.tags,
+        filterableTags: template.filterableTags,
       },
     });
     upserted++;

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -276,6 +276,14 @@ templates:
   # =========================
   # Vegetation requiring attention during extreme weather events
   - ["vegetation-risk-context","natural=tree;natural=tree_row;natural=wood","emergency","TriangleAlert"]
+# Per-template filterable-tag allow-list.
+# Curated OSM tag keys that become interactive-legend views for a template.
+# Templates absent here show the age ("Recent edits") view only.
+# Add tag-key labels to messages/*.json (TagLabel) and controlled values (TagValue).
+filterableTags:
+  bus-stops:       [shelter, bench, covered, lit, tactile_paving]
+  bicycle-parking: [bicycle_parking, covered, capacity, access, fee]
+
 # Category to icon mapping (fallback for templates without icon)
 categories:
   transportation: Car

--- a/src/components/dataset/full-map.tsx
+++ b/src/components/dataset/full-map.tsx
@@ -27,13 +27,11 @@ import type { Feature, FeatureCollection } from "geojson";
 import { MapErrorState, MapNoDataState } from "./map/map-states";
 import { mapStyle } from "@/lib/map-tiles";
 import { AGE_COLORS } from "./map/layers/map-style";
-import { PALETTES } from "@/lib/map-palettes";
 import {
   buildCuratedThemesFromDimensions,
   buildAgeVisibilityFilter,
   buildTagVisibilityFilter,
-  OTHER_CATEGORY,
-  MISSING_CATEGORY,
+  buildLegendRows,
 } from "@/lib/curated-themes";
 import { computeFilterDimensions } from "@/lib/filter-dimensions";
 import { tagLabel, tagValue, type MessageResolver } from "@/lib/tag-i18n";
@@ -161,37 +159,12 @@ export const DatasetFullMap = forwardRef<
         count,
       }));
     }
-    const rows: LegendCategory[] = activeTheme.topValues.map(
-      ({ value, count }) => ({
-        id: value.toLowerCase(),
-        label: tagValue(tTagValue, activeTheme.field, value),
-        color: activeTheme.colorMap.get(value.toLowerCase())!,
-        count,
-      })
-    );
-    // Localized categorical rows read as unsorted in count order, so sort them by
-    // label. Presorted (numeric) rows are already ordered and left as-is.
-    if (!activeTheme.presorted) {
-      rows.sort((a, b) => a.label.localeCompare(b.label, locale));
-    }
-    if (activeTheme.otherCount > 0) {
-      rows.push({
-        id: OTHER_CATEGORY,
-        label: t("legendOther"),
-        color: PALETTES.categorical.other,
-        count: activeTheme.otherCount,
-      });
-    }
-    if (activeTheme.missingCount > 0) {
-      rows.push({
-        id: MISSING_CATEGORY,
-        label: t("legendMissing"),
-        color: PALETTES.categorical.missing,
-        count: activeTheme.missingCount,
-        muted: true,
-      });
-    }
-    return rows;
+    return buildLegendRows(activeTheme, {
+      localizeValue: (value) => tagValue(tTagValue, activeTheme.field, value),
+      locale,
+      otherLabel: t("legendOther"),
+      missingLabel: t("legendMissing"),
+    });
   }, [activeTheme, ageDimension, t, tTagValue, locale]);
 
   const visibilityFilter = useMemo(

--- a/src/components/dataset/full-map.tsx
+++ b/src/components/dataset/full-map.tsx
@@ -12,7 +12,7 @@ import React, {
 import Map, { Source, Layer } from "react-map-gl/maplibre";
 import type { MapRef } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import type { Dataset } from "@/schemas/dataset";
 import { MapLayers } from "./map/layers";
 import { AoiBoundaryLayer } from "./map/aoi-boundary-layer";
@@ -36,6 +36,7 @@ import {
   MISSING_CATEGORY,
 } from "@/lib/curated-themes";
 import { computeFilterDimensions } from "@/lib/filter-dimensions";
+import { tagLabel, tagValue, type MessageResolver } from "@/lib/tag-i18n";
 
 export interface DatasetFullMapHandle {
   deselectFeature: () => void;
@@ -64,6 +65,11 @@ export const DatasetFullMap = forwardRef<
   DatasetFullMapProps
 >(({ dataset, boundary, onFeatureSelect }, ref) => {
   const t = useTranslations("DatasetMap");
+  // next-intl types message keys as literals; tag keys/values are dynamic (OSM
+  // data), so widen the translator to the loose MessageResolver shape.
+  const tTagLabel = useTranslations("TagLabel") as unknown as MessageResolver;
+  const tTagValue = useTranslations("TagValue") as unknown as MessageResolver;
+  const locale = useLocale();
   const mapRef = useRef<MapRef | null>(null);
 
   const {
@@ -92,12 +98,21 @@ export const DatasetFullMap = forwardRef<
 
   // One pass over the features feeds both the curated tag themes and the
   // age bucket counts for the legend rows
+  // Schema types this optional (input/output asymmetry at the API boundary), so
+  // memoize the []-fallback to a stable reference the filterDimensions dep can use.
+  const filterableTags = useMemo(
+    () => dataset.template.filterableTags ?? [],
+    [dataset.template.filterableTags]
+  );
   const filterDimensions = useMemo(
-    () => (features?.length ? computeFilterDimensions(features) : []),
-    [features]
+    () =>
+      features?.length
+        ? computeFilterDimensions(features, filterableTags)
+        : [],
+    [features, filterableTags]
   );
 
-  // Curated tag themes from the allow-list (#184) — no auto-detection
+  // Curated tag themes from the allow-list — no auto-detection
   const curatedThemes = useMemo(
     () => buildCuratedThemesFromDimensions(filterDimensions),
     [filterDimensions]
@@ -129,9 +144,12 @@ export const DatasetFullMap = forwardRef<
   const views: LegendViewOption[] = useMemo(
     () => [
       { id: AGE_VIEW_ID, label: t("lastEditedLegend") },
-      ...curatedThemes.map((theme) => ({ id: theme.field, label: theme.field })),
+      ...curatedThemes.map((theme) => ({
+        id: theme.field,
+        label: tagLabel(tTagLabel, theme.field),
+      })),
     ],
-    [curatedThemes, t]
+    [curatedThemes, t, tTagLabel]
   );
 
   const categories: LegendCategory[] = useMemo(() => {
@@ -146,11 +164,16 @@ export const DatasetFullMap = forwardRef<
     const rows: LegendCategory[] = activeTheme.topValues.map(
       ({ value, count }) => ({
         id: value.toLowerCase(),
-        label: value,
+        label: tagValue(tTagValue, activeTheme.field, value),
         color: activeTheme.colorMap.get(value.toLowerCase())!,
         count,
       })
     );
+    // Localized categorical rows read as unsorted in count order, so sort them by
+    // label. Presorted (numeric) rows are already ordered and left as-is.
+    if (!activeTheme.presorted) {
+      rows.sort((a, b) => a.label.localeCompare(b.label, locale));
+    }
     if (activeTheme.otherCount > 0) {
       rows.push({
         id: OTHER_CATEGORY,
@@ -169,7 +192,7 @@ export const DatasetFullMap = forwardRef<
       });
     }
     return rows;
-  }, [activeTheme, ageDimension, t]);
+  }, [activeTheme, ageDimension, t, tTagValue, locale]);
 
   const visibilityFilter = useMemo(
     () =>
@@ -208,7 +231,7 @@ export const DatasetFullMap = forwardRef<
       {/* Map */}
       <div className="flex-1 relative">
         {hasFilteredData && (
-          /* Legend: the map's single control (#184) */
+          /* Legend: the map's single control */
           <div className="absolute z-10 top-4 end-4">
             <InteractiveLegend
               views={views}

--- a/src/components/dataset/map/interactive-legend.tsx
+++ b/src/components/dataset/map/interactive-legend.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { Button, Checkbox } from "react-aria-components";
 import { Check, ChevronUp, Layers } from "lucide-react";
 
@@ -39,7 +39,7 @@ type InteractiveLegendProps = {
  * color swatch doubles as the checkbox (checkmark = visible, hollow =
  * hidden) so toggling reads as an affordance, not decoration. Collapsible;
  * starts collapsed on small screens where the card would blanket the map.
- * Fully controlled; filter state lives in the map container. Epic #184.
+ * Fully controlled; filter state lives in the map container.
  */
 export function InteractiveLegend({
   views,
@@ -50,6 +50,7 @@ export function InteractiveLegend({
   onToggle,
 }: InteractiveLegendProps) {
   const t = useTranslations("DatasetMap");
+  const locale = useLocale();
   const activeView = views.find((v) => v.id === activeViewId);
 
   // SSR markup must match the first client render, so the small-screen
@@ -150,7 +151,7 @@ export function InteractiveLegend({
                 {category.label}
               </span>
               <span className="text-gray-400 tabular-nums">
-                {category.count.toLocaleString()}
+                {category.count.toLocaleString(locale)}
               </span>
             </Checkbox>
           );

--- a/src/components/dataset/map/interactive-legend.tsx
+++ b/src/components/dataset/map/interactive-legend.tsx
@@ -4,16 +4,9 @@ import { useEffect, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { Button, Checkbox } from "react-aria-components";
 import { Check, ChevronUp, Layers } from "lucide-react";
+import type { LegendCategory } from "@/lib/curated-themes";
 
-/** One toggleable row of the active view. */
-export type LegendCategory = {
-  id: string;
-  label: string;
-  color: string;
-  count: number;
-  /** De-emphasize the label (synthetic rows like "Missing"). */
-  muted?: boolean;
-};
+export type { LegendCategory };
 
 /** One entry of the header view dropdown. */
 export type LegendViewOption = {

--- a/src/components/dataset/map/layers/detailed-features-layer-group.tsx
+++ b/src/components/dataset/map/layers/detailed-features-layer-group.tsx
@@ -21,6 +21,22 @@ import type { CuratedTheme } from "@/lib/curated-themes";
 import { buildCuratedColorExpression } from "@/lib/curated-themes";
 import { PALETTES } from "@/lib/map-palettes";
 
+// Shared circle paint for the point + proxy-point layers. In a curated tag view
+// the color comes from the theme expression; otherwise it falls back to the
+// count-scaled default point style. Callers add their own opacity (e.g. the
+// proxy fade) on top.
+function buildThemePointPaint(themeColor: unknown[] | null, count: number) {
+  return {
+    ...POINT_STYLE,
+    "circle-radius": themeColor ? 4 : buildPointRadiusForCount(count),
+    "circle-color": themeColor ?? POINT_STYLE["circle-color"],
+    "circle-stroke-color": themeColor
+      ? PALETTES.categorical.stroke
+      : POINT_STYLE["circle-stroke-color"],
+    "circle-stroke-width": themeColor ? 1 : POINT_STYLE["circle-stroke-width"],
+  };
+}
+
 type DetailedFeaturesLayerGroupProps = {
   polygonFeatures: Feature[];
   lineFeatures: Feature[];
@@ -36,9 +52,14 @@ export function DetailedFeaturesLayerGroup({
   curatedTheme,
   visibilityFilter,
 }: DetailedFeaturesLayerGroupProps) {
+  // Small polygons are subpixel at city-wide zoom, so they get a circle proxy
+  // at their centroid until the real footprint resolves (~zoom 14). This must
+  // apply to curated tag views too — otherwise a category made only of small
+  // polygons (e.g. covered=roof) is invisible on the map. Proxies keep the
+  // feature properties, so they colour by theme like any other point.
   const proxyPoints = useMemo(
-    () => (curatedTheme ? [] : createSmallPolygonProxyPoints(polygonFeatures)),
-    [curatedTheme, polygonFeatures]
+    () => createSmallPolygonProxyPoints(polygonFeatures),
+    [polygonFeatures]
   );
 
   const themeColor = useMemo(
@@ -55,8 +76,7 @@ export function DetailedFeaturesLayerGroup({
           layerType="circle"
           filter={visibilityFilter}
           paint={{
-            ...POINT_STYLE,
-            "circle-radius": buildPointRadiusForCount(proxyPoints.length),
+            ...buildThemePointPaint(themeColor, proxyPoints.length),
             "circle-opacity": PROXY_FADE,
             "circle-stroke-opacity": PROXY_FADE,
           }}
@@ -114,19 +134,7 @@ export function DetailedFeaturesLayerGroup({
           features={pointFeatures}
           layerType="circle"
           filter={visibilityFilter}
-          paint={{
-            ...POINT_STYLE,
-            "circle-radius": themeColor
-              ? 4
-              : buildPointRadiusForCount(pointFeatures.length),
-            "circle-color": themeColor ?? POINT_STYLE["circle-color"],
-            "circle-stroke-color": themeColor
-              ? PALETTES.categorical.stroke
-              : POINT_STYLE["circle-stroke-color"],
-            "circle-stroke-width": themeColor
-              ? 1
-              : POINT_STYLE["circle-stroke-width"],
-          }}
+          paint={buildThemePointPaint(themeColor, pointFeatures.length)}
           layout={themeColor ? undefined : { "circle-sort-key": AGE_SORT_KEY }}
         />
       )}

--- a/src/lib/__tests__/curated-themes.test.ts
+++ b/src/lib/__tests__/curated-themes.test.ts
@@ -7,10 +7,12 @@ import {
   buildAgeVisibilityFilter,
   buildTagVisibilityFilter,
   buildCuratedColorExpression,
+  buildLegendRows,
   sortForDisplay,
   OTHER_CATEGORY,
   MISSING_CATEGORY,
   TOP_VALUES_COUNT,
+  type CuratedTheme,
 } from "../curated-themes";
 import { PALETTES } from "../map-palettes";
 
@@ -72,6 +74,60 @@ describe("buildCuratedThemes — numeric display order", () => {
     expect(theme.topValues.map((v) => v.value)).toEqual(["2", "5", "10"]);
     // colors are assigned in the displayed (numeric) order
     expect(theme.colorMap.get("2")).toBe(PALETTES.categorical.tableau10[0]);
+  });
+});
+
+describe("buildLegendRows", () => {
+  // count-desc input where the alphabetical order differs, so a sort is visible
+  const baseTheme: CuratedTheme = {
+    field: "surface",
+    colorMap: new Map([
+      ["zebra", "#z"],
+      ["apple", "#a"],
+    ]),
+    topValues: [
+      { value: "zebra", count: 3 },
+      { value: "apple", count: 1 },
+    ],
+    otherCount: 0,
+    missingCount: 0,
+    presorted: false,
+  };
+  const opts = {
+    localizeValue: (v: string) => v,
+    locale: "en",
+    otherLabel: "Other",
+    missingLabel: "Missing",
+  };
+
+  it("sorts categorical rows by localized label", () => {
+    const rows = buildLegendRows(baseTheme, opts);
+    expect(rows.map((r) => r.id)).toEqual(["apple", "zebra"]);
+  });
+
+  it("keeps presorted (numeric) rows in their given order", () => {
+    const rows = buildLegendRows({ ...baseTheme, presorted: true }, opts);
+    expect(rows.map((r) => r.id)).toEqual(["zebra", "apple"]);
+  });
+
+  it("applies the value localizer to labels and sorts on the result", () => {
+    const rows = buildLegendRows(baseTheme, {
+      ...opts,
+      localizeValue: (v) => v.toUpperCase(),
+    });
+    expect(rows.map((r) => r.label)).toEqual(["APPLE", "ZEBRA"]);
+  });
+
+  it("appends Other then Missing (muted) after the value rows", () => {
+    const rows = buildLegendRows(
+      { ...baseTheme, otherCount: 5, missingCount: 2 },
+      opts
+    );
+    expect(rows.slice(0, 2).map((r) => r.id)).toEqual(["apple", "zebra"]);
+    const [other, missing] = rows.slice(-2);
+    expect(other.id).toBe(OTHER_CATEGORY);
+    expect(missing.id).toBe(MISSING_CATEGORY);
+    expect(missing.muted).toBe(true);
   });
 });
 

--- a/src/lib/__tests__/curated-themes.test.ts
+++ b/src/lib/__tests__/curated-themes.test.ts
@@ -7,6 +7,7 @@ import {
   buildAgeVisibilityFilter,
   buildTagVisibilityFilter,
   buildCuratedColorExpression,
+  sortForDisplay,
   OTHER_CATEGORY,
   MISSING_CATEGORY,
   TOP_VALUES_COUNT,
@@ -18,6 +19,61 @@ const feature = (properties: Record<string, unknown> | null): Feature =>
 
 const surfaceFeatures = (values: string[]) =>
   values.map((surface) => feature({ surface }));
+
+describe("sortForDisplay", () => {
+  it("sorts numeric values ascending", () => {
+    const sorted = sortForDisplay([
+      { value: "10", count: 3 },
+      { value: "2", count: 2 },
+      { value: "5", count: 1 },
+    ]);
+    expect(sorted.map((v) => v.value)).toEqual(["2", "5", "10"]);
+  });
+
+  it("keeps count order for non-numeric values", () => {
+    const values = [
+      { value: "asphalt", count: 3 },
+      { value: "gravel", count: 1 },
+    ];
+    expect(sortForDisplay(values)).toEqual(values);
+  });
+
+  it("keeps count order when values are mixed numeric/non-numeric", () => {
+    const values = [
+      { value: "yes", count: 3 },
+      { value: "2", count: 1 },
+    ];
+    expect(sortForDisplay(values)).toEqual(values);
+  });
+
+  it("handles decimals and negatives numerically", () => {
+    const sorted = sortForDisplay([
+      { value: "1.5", count: 1 },
+      { value: "-2", count: 1 },
+      { value: "10", count: 1 },
+    ]);
+    expect(sorted.map((v) => v.value)).toEqual(["-2", "1.5", "10"]);
+  });
+});
+
+describe("buildCuratedThemes — numeric display order", () => {
+  it("selects top values by count but displays them ascending numerically", () => {
+    const features = [
+      feature({ capacity: "10" }),
+      feature({ capacity: "10" }),
+      feature({ capacity: "10" }),
+      feature({ capacity: "2" }),
+      feature({ capacity: "2" }),
+      feature({ capacity: "5" }),
+    ];
+
+    const [theme] = buildCuratedThemes(features, ["capacity"]);
+
+    expect(theme.topValues.map((v) => v.value)).toEqual(["2", "5", "10"]);
+    // colors are assigned in the displayed (numeric) order
+    expect(theme.colorMap.get("2")).toBe(PALETTES.categorical.tableau10[0]);
+  });
+});
 
 describe("buildCuratedThemes", () => {
   it("builds one theme per allow-listed tag present, skipping absent tags", () => {

--- a/src/lib/__tests__/tag-i18n.test.ts
+++ b/src/lib/__tests__/tag-i18n.test.ts
@@ -1,0 +1,62 @@
+// src/lib/__tests__/tag-i18n.test.ts
+
+import { describe, it, expect } from "vitest";
+import { tagLabel, tagValue, toTitleCase, type MessageResolver } from "../tag-i18n";
+
+/**
+ * Build a MessageResolver over a flat dict of dot-joined keys, e.g.
+ * { "access.private": "Private", "__common__.yes": "Yes" }.
+ */
+const resolver = (dict: Record<string, string>): MessageResolver => {
+  const fn = ((key: string) => {
+    if (key in dict) return dict[key];
+    throw new Error(`missing key: ${key}`);
+  }) as MessageResolver;
+  fn.has = (key: string) => key in dict;
+  return fn;
+};
+
+describe("toTitleCase", () => {
+  it("prettifies snake_case keys", () => {
+    expect(toTitleCase("tactile_paving")).toBe("Tactile paving");
+    expect(toTitleCase("covered")).toBe("Covered");
+  });
+});
+
+describe("tagLabel", () => {
+  it("returns the translated key when present", () => {
+    const t = resolver({ covered: "Covered" });
+    expect(tagLabel(t, "covered")).toBe("Covered");
+  });
+
+  it("falls back to title-case when the key is missing", () => {
+    const t = resolver({});
+    expect(tagLabel(t, "tactile_paving")).toBe("Tactile paving");
+  });
+});
+
+describe("tagValue — fallback chain", () => {
+  it("prefers a scoped <key>.<value> translation", () => {
+    const t = resolver({
+      "access.private": "Private",
+      "__common__.private": "WRONG",
+    });
+    expect(tagValue(t, "access", "private")).toBe("Private");
+  });
+
+  it("falls back to __common__ for shared booleans", () => {
+    const t = resolver({ "__common__.yes": "Yes" });
+    expect(tagValue(t, "covered", "yes")).toBe("Yes");
+  });
+
+  it("falls back to the raw value (dominant casing) when unmapped", () => {
+    const t = resolver({});
+    expect(tagValue(t, "capacity", "12")).toBe("12");
+    expect(tagValue(t, "surface", "Sett")).toBe("Sett");
+  });
+
+  it("looks up case-folded but returns the localized string", () => {
+    const t = resolver({ "access.private": "Private" });
+    expect(tagValue(t, "access", "PRIVATE")).toBe("Private");
+  });
+});

--- a/src/lib/curated-themes.ts
+++ b/src/lib/curated-themes.ts
@@ -12,7 +12,7 @@ import {
 import { PALETTES } from "./map-palettes";
 
 /**
- * A curated categorical theme for an allow-listed tag (#184). Unlike the old
+ * A curated categorical theme for an allow-listed tag. Unlike the old
  * auto-detected themes, curation means the tag was explicitly approved as
  * meaningful to color by — no scoring, no coverage gating.
  */
@@ -26,6 +26,8 @@ export type CuratedTheme = {
   otherCount: number;
   /** Features lacking the tag entirely */
   missingCount: number;
+  /** topValues are already in final display order; the legend must not re-sort them. */
+  presorted: boolean;
 };
 
 /** Legend/category ids for the synthetic buckets of a tag view. */
@@ -49,6 +51,28 @@ export function buildCuratedThemes(
   );
 }
 
+/** A value is numeric if it is an integer or decimal (e.g. capacity "12"). */
+const NUMERIC_VALUE = /^-?\d+(\.\d+)?$/;
+
+/** True when the dimension is numeric — every shown value parses as a number. */
+export function isNumericValues(
+  values: Array<{ value: string; count: number }>
+): boolean {
+  return values.length > 0 && values.every((v) => NUMERIC_VALUE.test(v.value));
+}
+
+/**
+ * Order legend rows for display: numeric fields ascending (2,4,6,...), otherwise
+ * keep the incoming count-desc order (the component re-sorts categorical rows by
+ * localized label). Returns a new array only when it sorts.
+ */
+export function sortForDisplay(
+  values: Array<{ value: string; count: number }>
+): Array<{ value: string; count: number }> {
+  if (!isNumericValues(values)) return values;
+  return [...values].sort((a, b) => Number(a.value) - Number(b.value));
+}
+
 /**
  * Variant taking precomputed dimensions, so callers that also need the age
  * dimension can run computeFilterDimensions once and derive both from it.
@@ -59,7 +83,11 @@ export function buildCuratedThemesFromDimensions(
   return dimensions
     .filter((dim) => dim.kind === "tag")
     .map((dim) => {
-      const topValues = dim.values.slice(0, TOP_VALUES_COUNT);
+      // Keep the top values (dim.values is count-desc); sortForDisplay orders
+      // numeric fields ascending and leaves categorical ones for the component.
+      const selected = dim.values.slice(0, TOP_VALUES_COUNT);
+      const topValues = sortForDisplay(selected);
+      const presorted = isNumericValues(selected);
       const otherCount = dim.values
         .slice(TOP_VALUES_COUNT)
         .reduce((sum, v) => sum + v.count, 0);
@@ -75,6 +103,7 @@ export function buildCuratedThemesFromDimensions(
         topValues,
         otherCount,
         missingCount: dim.missing,
+        presorted,
       };
     });
 }

--- a/src/lib/curated-themes.ts
+++ b/src/lib/curated-themes.ts
@@ -30,6 +30,16 @@ export type CuratedTheme = {
   presorted: boolean;
 };
 
+/** One toggleable row of the active legend view. */
+export type LegendCategory = {
+  id: string;
+  label: string;
+  color: string;
+  count: number;
+  /** De-emphasize the label (synthetic rows like "Missing"). */
+  muted?: boolean;
+};
+
 /** Legend/category ids for the synthetic buckets of a tag view. */
 export const OTHER_CATEGORY = "__other__";
 export const MISSING_CATEGORY = "__missing__";
@@ -87,7 +97,10 @@ export function buildCuratedThemesFromDimensions(
       // numeric fields ascending and leaves categorical ones for the component.
       const selected = dim.values.slice(0, TOP_VALUES_COUNT);
       const topValues = sortForDisplay(selected);
-      const presorted = isNumericValues(selected);
+      // sortForDisplay returns a new array only for numeric fields (it sorts
+      // them); an identical reference means categorical, so the component
+      // re-sorts those by localized label instead.
+      const presorted = topValues !== selected;
       const otherCount = dim.values
         .slice(TOP_VALUES_COUNT)
         .reduce((sum, v) => sum + v.count, 0);
@@ -106,6 +119,53 @@ export function buildCuratedThemesFromDimensions(
         presorted,
       };
     });
+}
+
+/**
+ * Assemble the legend rows for a curated tag theme: one localized, colored row
+ * per top value, sorted by localized label unless the theme is presorted
+ * (numeric), then the synthetic Other/Missing rows appended last. Pure — the
+ * caller supplies the localizers (labels + value formatter) so it stays testable
+ * and free of next-intl.
+ */
+export function buildLegendRows(
+  theme: CuratedTheme,
+  opts: {
+    localizeValue: (value: string) => string;
+    locale: string;
+    otherLabel: string;
+    missingLabel: string;
+  }
+): LegendCategory[] {
+  const rows: LegendCategory[] = theme.topValues.map(({ value, count }) => ({
+    id: value.toLowerCase(),
+    label: opts.localizeValue(value),
+    color: theme.colorMap.get(value.toLowerCase())!,
+    count,
+  }));
+  // Localized categorical rows read as unsorted in count order, so sort them by
+  // label. Presorted (numeric) rows are already ordered and left as-is.
+  if (!theme.presorted) {
+    rows.sort((a, b) => a.label.localeCompare(b.label, opts.locale));
+  }
+  if (theme.otherCount > 0) {
+    rows.push({
+      id: OTHER_CATEGORY,
+      label: opts.otherLabel,
+      color: PALETTES.categorical.other,
+      count: theme.otherCount,
+    });
+  }
+  if (theme.missingCount > 0) {
+    rows.push({
+      id: MISSING_CATEGORY,
+      label: opts.missingLabel,
+      color: PALETTES.categorical.missing,
+      count: theme.missingCount,
+      muted: true,
+    });
+  }
+  return rows;
 }
 
 /** Normalized tag accessor: lowercased string value of the field. */

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -92,6 +92,7 @@ async function getDatasetWithDetails(areaId: number, templateId: string, locale:
             },
           },
           tags: true,
+          filterableTags: true,
           translations: {
             select: {
               locale: true,
@@ -252,6 +253,7 @@ async function createDatasetOnDemand(
               },
             },
             tags: true,
+            filterableTags: true,
             translations: {
               select: {
                 locale: true,
@@ -380,6 +382,7 @@ export async function getDatasetMetadata(
           description: true,
           category: true,
           tags: true,
+          filterableTags: true,
           translations: true,
         },
       },

--- a/src/lib/filter-dimensions.ts
+++ b/src/lib/filter-dimensions.ts
@@ -24,11 +24,10 @@ export type FilterDimension = {
 };
 
 /**
- * Allow-list of tag keys that become filter dimensions. Introduced progressively:
- * grow this list as more tags prove useful to filter on.
- *
- * TODO(#184): move allow-list to per-template config (templates.yml) so datasets
- * expose the tags meaningful to them (e.g. trees -> genus/leaf_type).
+ * Default allow-list of tag keys that become filter dimensions, used only when a
+ * caller omits the `filterableTags` argument. The dataset map always passes a
+ * template's explicit list (empty -> age-only), so this default does not act as a
+ * per-template fallback; per-template lists live in templates.yml.
  */
 export const FILTERABLE_TAGS: readonly string[] = [
   "surface",

--- a/src/lib/tag-i18n.ts
+++ b/src/lib/tag-i18n.ts
@@ -1,0 +1,57 @@
+/**
+ * Localization helpers for curated OSM tag keys and values shown in the
+ * interactive map legend.
+ *
+ * - Tag KEYS (legend view labels) resolve from the `TagLabel` namespace.
+ * - Tag VALUES (legend category rows) resolve from the `TagValue` namespace with
+ *   a fallback chain: `"<key>.<value>"` -> `"__common__.<value>"` (yes/no/limited)
+ *   -> the raw value. Unbounded values (names, species, cuisine tail) and numbers
+ *   (capacity) intentionally fall through to raw.
+ *
+ * The helpers take an already-scoped next-intl translator so they stay pure and
+ * unit-testable, and keep the component body free of lookup logic.
+ */
+
+/**
+ * Minimal structural view of a next-intl namespace translator. Tag keys/values
+ * are resolved dynamically (from OSM data), which cannot be checked against
+ * next-intl's strict literal message-key types — so callers pass their scoped
+ * translator cast to this loose shape.
+ */
+export type MessageResolver = {
+  (key: string): string;
+  has(key: string): boolean;
+};
+
+/** Fallback prettifier: "tactile_paving" -> "Tactile paving". */
+export function toTitleCase(raw: string): string {
+  const spaced = raw.replace(/_/g, " ").trim();
+  if (!spaced) return raw;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Localized label for a curated tag key (legend view dropdown). Falls back to a
+ * title-cased key when no translation exists, so newly curated tags never render
+ * a missing-key error.
+ */
+export function tagLabel(tTagLabel: MessageResolver, field: string): string {
+  return tTagLabel.has(field) ? tTagLabel(field) : toTitleCase(field);
+}
+
+/**
+ * Localized label for a tag value (legend category row). Lookup is case-folded;
+ * the raw value (dominant casing preserved by the caller) is the final fallback.
+ */
+export function tagValue(
+  tTagValue: MessageResolver,
+  field: string,
+  value: string
+): string {
+  const folded = value.toLowerCase();
+  const scoped = `${field}.${folded}`;
+  if (tTagValue.has(scoped)) return tTagValue(scoped);
+  const common = `__common__.${folded}`;
+  if (tTagValue.has(common)) return tTagValue(common);
+  return value;
+}

--- a/src/lib/template-resolver.ts
+++ b/src/lib/template-resolver.ts
@@ -11,6 +11,7 @@ export async function resolveTemplate(identifier: TemplateIdentifier) {
       description: true,
       category: true,
       tags: true,
+      filterableTags: true,
       overpassQuery: true,
       isActive: true,
       deprecatesAt: true,

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -64,6 +64,7 @@ export const DatasetSchema = z.object({
       slug: z.string(),
     }).nullable(),
     description: z.string().nullable(),
+    filterableTags: z.array(z.string()).optional(),
   }),
   user: z
     .object({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,7 +49,10 @@ export default defineConfig({
         test: {
           name: 'unit',
           environment: 'node',
-          include: ['src/**/__tests__/**/*.test.ts'],
+          include: [
+            'src/**/__tests__/**/*.test.ts',
+            'prisma/**/__tests__/**/*.test.ts',
+          ],
           exclude: ['**/node_modules/**', '**/tests/**'],
         },
       }),


### PR DESCRIPTION
## Summary

The interactive legend built tag views from a single global allow-list, so datasets showed irrelevant views (e.g. `surface` on bicycle parking). This makes the allow-list **per-template** and localizes the legend.

## Changes

- **Per-template allow-list** — `filterableTags:` map in `templates.yml` -> `Template.filterableTags` -> dataset query -> legend. Curated: `bus-stops`, `bicycle-parking`. Uncurated templates default to age-only (no tag views).
- **i18n** — tag keys (`TagLabel`) and values (`TagValue`) localized across en/es/pt-BR, with a fallback chain (`<key>.<value>` -> `__common__` -> raw). Unbounded/numeric values fall through to raw.
- **Sorting** — numeric views ascending (capacity), categorical views by localized label.
- **Map fix** — small-polygon proxy circles now render in curated tag views; categories made only of small polygons (e.g. `covered=roof`) were previously invisible.

## Testing

- `pnpm type-check`, `i18n:check`, unit tests green (parser tests now run in CI).
- Verified in-browser (es): curated views localized, categorical sort correct, 191 proxies incl. `roof` render in the Covered view, uncurated `pitches` shows age-only, 0 console errors.

## Notes

- New DB column `Template.filterableTags` (migration included).
- Adding tag views later = extend the `templates.yml` map + `TagLabel`/`TagValue`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added template-specific curated legend filter controls (now driven by per-template tag allow-lists, including bus stops and bicycle parking options).
  * Added localized curated legend tag labels/values (English, Spanish, Portuguese).
* **Bug Fixes**
  * Improved curated legend behavior so small-polygon categories render reliably in curated tag views.
  * Fixed legend numeric ordering and improved locale-aware formatting.
* **Tests**
  * Expanded unit test coverage for curated theme sorting, tag i18n fallback behavior, and template parsing.
  * Updated test discovery to include Prisma unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->