### PR TITLE
feat(area): render area names in the active locale (#362)

### DIFF
--- a/prisma/migrations/20260721151435_add_area_localized_names/migration.sql
+++ b/prisma/migrations/20260721151435_add_area_localized_names/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "areas" ADD COLUMN     "names" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,6 +98,7 @@ model TemplateTranslation {
 model Area {
   id          Int       @id
   name        String
+  names       Json?
   countryCode String?
   bounds      String?
   centerLat   Float?

--- a/scripts/backfill-area-names.ts
+++ b/scripts/backfill-area-names.ts
@@ -1,0 +1,52 @@
+/**
+ * Backfill localized area names (Area.names) for existing areas.
+ *
+ * Re-runs the app's own refreshAreaInfo for every stored area, which captures
+ * the OSM name:* translations from Overpass + Nominatim. Bypasses the 30-day
+ * AREA_INFO_TTL so names populate immediately. Uses the app's ORM path — no
+ * raw SQL.
+ *
+ * Requires the Overpass tunnel to be up locally:
+ *   cd infra/ansible && ./scripts/overpass-tunnel.sh start
+ *
+ * Run: pnpm tsx scripts/backfill-area-names.ts
+ */
+import { loadEnvConfig } from "@next/env";
+
+loadEnvConfig(process.cwd());
+
+async function main() {
+  // Import after env is loaded so the Prisma client picks up DATABASE_URL.
+  const { prisma } = await import("@/lib/db");
+  const { refreshAreaInfo } = await import("@/lib/area-refresh");
+
+  const areas = await prisma.area.findMany({
+    select: { id: true, bounds: true },
+    orderBy: { id: "asc" },
+  });
+
+  console.log(`Backfilling names for ${areas.length} area(s)...`);
+  let refreshed = 0;
+  let failed = 0;
+
+  for (const area of areas) {
+    try {
+      await refreshAreaInfo(area.id, area.bounds);
+      refreshed++;
+      console.log(`  [${refreshed + failed}/${areas.length}] area ${area.id} ✓`);
+    } catch (error) {
+      failed++;
+      console.error(`  [${refreshed + failed}/${areas.length}] area ${area.id} ✗`, error);
+    }
+  }
+
+  console.log(`Done. ${refreshed} refreshed, ${failed} failed.`);
+  await prisma.$disconnect();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/backfill-area-names.ts
+++ b/scripts/backfill-area-names.ts
@@ -33,10 +33,10 @@ async function main() {
     try {
       await refreshAreaInfo(area.id, area.bounds);
       refreshed++;
-      console.log(`  [${refreshed + failed}/${areas.length}] area ${area.id} ✓`);
+      console.log(`  [${refreshed + failed}/${areas.length}] area ${area.id} ok`);
     } catch (error) {
       failed++;
-      console.error(`  [${refreshed + failed}/${areas.length}] area ${area.id} ✗`, error);
+      console.error(`  [${refreshed + failed}/${areas.length}] area ${area.id} FAILED`, error);
     }
   }
 

--- a/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/dataset/[templateId]/page.tsx
@@ -8,6 +8,7 @@ import { Link } from "@/i18n/navigation";
 import { getOrCreateDataset } from "@/lib/dataset-operations";
 import { DatasetTooLargeError } from "@/lib/dataset-snapshot";
 import { getAreaDetailsById } from "@/lib/nominatim";
+import { resolveAreaName } from "@/lib/area-name";
 import {
   isValidTemplateIdentifier,
   resolveTemplate,
@@ -48,11 +49,12 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
     return <TemplateNotFoundError templateId={templateId} />;
   }
 
+  const locale = await getLocale();
   const session = await auth();
   if (!session?.user) {
     const [template, areaInfo] = await Promise.all([
       resolveTemplate(templateId),
-      getAreaDetailsById(osmRelationId),
+      getAreaDetailsById(osmRelationId, locale),
     ]);
 
     if (!template) {
@@ -94,7 +96,7 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
         />
         <DatasetUpsellPage
           datasetName={template.name}
-          areaName={areaInfo.name}
+          areaName={resolveAreaName(areaInfo, locale)}
           areaId={areaId}
         />
       </>
@@ -128,7 +130,7 @@ async function AreaTemplateDatasetView({
       getOrCreateDataset(areaId, templateId, locale, {
         allowCreate: !!session?.user,
       }),
-      getAreaDetailsById(areaId),
+      getAreaDetailsById(areaId, locale),
     ]);
 
     // Check if current user has saved this dataset, and total save count for quota UI
@@ -159,7 +161,9 @@ async function AreaTemplateDatasetView({
       />
     );
 
-    const areaName = areaInfo?.name || dataset.area.name;
+    const areaName = areaInfo
+      ? resolveAreaName(areaInfo, locale)
+      : resolveAreaName(dataset.area, locale);
 
     // Empty state: dataset has no features in this area.
     if (result.dataset.dataCount === 0) {
@@ -205,12 +209,12 @@ async function AreaTemplateDatasetView({
     if (error instanceof DatasetTooLargeError) {
       const [template, areaInfo] = await Promise.all([
         resolveTemplate(templateId),
-        getAreaDetailsById(areaId),
+        getAreaDetailsById(areaId, locale),
       ]);
       return (
         <DatasetTooLargeState
           templateName={template?.name ?? templateId}
-          areaName={areaInfo?.name ?? String(areaId)}
+          areaName={areaInfo ? resolveAreaName(areaInfo, locale) : String(areaId)}
           areaId={areaId}
           overpassQuery={
             template?.overpassQuery.replace(

--- a/src/app/[locale]/area/[areaId]/page.tsx
+++ b/src/app/[locale]/area/[areaId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getAreaDetailsById } from "@/lib/nominatim";
+import { resolveAreaName } from "@/lib/area-name";
 import { getAreaDataTypes } from "@/lib/area-templates";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
 import { DatasetGrid } from "@/components/ui/template-grid";
@@ -27,7 +28,7 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
   }
 
   const [areaInfo, dataTypes, session] = await Promise.all([
-    getAreaDetailsById(osmRelationId),
+    getAreaDetailsById(osmRelationId, locale),
     getAreaDataTypes(osmRelationId, locale),
     auth(),
   ]);
@@ -35,6 +36,8 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
   if (!areaInfo) {
     notFound();
   }
+
+  const areaName = resolveAreaName(areaInfo, locale);
 
   const breadcrumbItems = [
     { label: navT("home"), href: "/" },
@@ -58,7 +61,7 @@ export default async function AreaPage({ params, searchParams }: AreaPageProps) 
           <BreadcrumbNav items={breadcrumbItems} />
         </div>
         <h1 className="text-4xl lg:text-5xl font-bold tracking-tight text-gray-900">
-          {areaInfo.name}
+          {areaName}
         </h1>
       </div>
 

--- a/src/app/[locale]/explore/featured/page.tsx
+++ b/src/app/[locale]/explore/featured/page.tsx
@@ -3,6 +3,7 @@ import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { processDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { getDatasetPath } from "@/lib/urls";
@@ -34,6 +35,8 @@ const DATASET_SELECT = {
   area: {
     select: {
       id: true,
+      name: true,
+      names: true,
       countryCode: true,
     },
   },
@@ -99,7 +102,7 @@ export default async function FeaturedPage({
               <DatasetCard
                 key={dataset.id}
                 name={resolvedTemplate.name}
-                city={dataset.cityName}
+                city={resolveDatasetAreaName(dataset, locale)}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.slug ?? "other"}
                 templateId={dataset.templateId}

--- a/src/app/[locale]/explore/largest/page.tsx
+++ b/src/app/[locale]/explore/largest/page.tsx
@@ -3,6 +3,7 @@ import { CATALOG_FILTER } from "@/lib/dataset-catalog-filter";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { getDatasetPath } from "@/lib/urls";
@@ -33,6 +34,8 @@ const DATASET_SELECT = {
   area: {
     select: {
       id: true,
+      name: true,
+      names: true,
       countryCode: true,
     },
   },
@@ -95,7 +98,7 @@ export default async function LargestPage({
               <DatasetCard
                 key={dataset.id}
                 name={resolvedTemplate.name}
-                city={dataset.cityName}
+                city={resolveDatasetAreaName(dataset, locale)}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.slug ?? "other"}
                 templateId={dataset.templateId}

--- a/src/app/[locale]/explore/most-contributors/page.tsx
+++ b/src/app/[locale]/explore/most-contributors/page.tsx
@@ -3,6 +3,7 @@ import { CATALOG_FILTER } from "@/lib/dataset-catalog-filter";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { getDatasetPath } from "@/lib/urls";
@@ -33,6 +34,8 @@ const DATASET_SELECT = {
   area: {
     select: {
       id: true,
+      name: true,
+      names: true,
       countryCode: true,
     },
   },
@@ -96,7 +99,7 @@ export default async function MostContributorsPage({
               <DatasetCard
                 key={dataset.id}
                 name={resolvedTemplate.name}
-                city={dataset.cityName}
+                city={resolveDatasetAreaName(dataset, locale)}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.slug ?? "other"}
                 templateId={dataset.templateId}

--- a/src/app/[locale]/explore/most-saved/page.tsx
+++ b/src/app/[locale]/explore/most-saved/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/db";
 import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { getDatasetPath } from "@/lib/urls";
@@ -32,6 +33,8 @@ const DATASET_SELECT = {
   area: {
     select: {
       id: true,
+      name: true,
+      names: true,
       countryCode: true,
     },
   },
@@ -94,7 +97,7 @@ export default async function MostSavedPage({
               <DatasetCard
                 key={dataset.id}
                 name={resolvedTemplate.name}
-                city={dataset.cityName}
+                city={resolveDatasetAreaName(dataset, locale)}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.slug ?? "other"}
                 templateId={dataset.templateId}

--- a/src/app/[locale]/explore/recently-edited/page.tsx
+++ b/src/app/[locale]/explore/recently-edited/page.tsx
@@ -4,6 +4,7 @@ import { DatasetCard } from "@/components/ui/dataset-card";
 import { ExplorePageLayout, ExploreSectionHeader } from "@/components/explore/explore-components";
 import { formatRelativeTime } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Locale } from "next-intl";
 import { getDatasetPath } from "@/lib/urls";
@@ -34,6 +35,8 @@ const DATASET_SELECT = {
   area: {
     select: {
       id: true,
+      name: true,
+      names: true,
       countryCode: true,
     },
   },
@@ -98,7 +101,7 @@ export default async function RecentlyEditedPage({
               <DatasetCard
                 key={dataset.id}
                 name={resolvedTemplate.name}
-                city={dataset.cityName}
+                city={resolveDatasetAreaName(dataset, locale)}
                 country={dataset.area.countryCode ?? ""}
                 category={resolvedTemplate.category?.slug ?? "other"}
                 templateId={dataset.templateId}

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -5,6 +5,7 @@ import { CreateDatasetSchema } from "@/schemas/dataset";
 import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
 import { refreshAreaInfoIfStale, resolveAreaCenter } from "@/lib/area-refresh";
+import { mergeAreaNames, toStoredNames } from "@/lib/area-name";
 import {
   fetchDatasetSnapshot,
   DatasetTooLargeError,
@@ -62,10 +63,13 @@ export async function POST(req: NextRequest) {
 
       const center = resolveAreaCenter(fetched, areaDetails);
 
+      const mergedNames = mergeAreaNames(areaDetails?.names, fetched.names);
+
       area = await prisma.area.create({
         data: {
           id: osmRelationId,
           name: fetched.name,
+          names: toStoredNames(mergedNames),
           bounds: fetched.bounds,
           countryCode: areaDetails?.countryCode ?? null,
           centerLat: center?.centerLat ?? null,

--- a/src/components/dashboard/dashboard-grid.tsx
+++ b/src/components/dashboard/dashboard-grid.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { GridList, GridListItem } from "react-aria-components";
 import { Card, CardHeader, CardFooter } from "@/components/ui/card";
 import { getTemplateIcon } from "@/lib/category-icons";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { QuotaIndicator } from "@/components/dashboard/quota-indicator";
 
 type Dataset = {
@@ -18,6 +19,8 @@ type Dataset = {
   };
   area: {
     id: number;
+    name: string;
+    names?: unknown;
     countryCode: string | null;
   };
   _count?: {
@@ -38,6 +41,7 @@ type DashboardGridProps = {
  */
 export function DashboardGrid({ datasets, saveLimit }: DashboardGridProps) {
   const t = useTranslations("TabLayout");
+  const locale = useLocale();
 
   if (datasets.length === 0) {
     return (
@@ -98,11 +102,13 @@ export function DashboardGrid({ datasets, saveLimit }: DashboardGridProps) {
         data-testid="saved-datasets-grid"
         aria-label={t("savedDatasetsGridLabel")}
       >
-        {(dataset) => (
+        {(dataset) => {
+          const areaName = resolveDatasetAreaName(dataset, locale);
+          return (
           <GridListItem key={dataset.id} className="group h-full">
             <Card
               href={`/area/${dataset.area.id}/dataset/${dataset.template.id}`}
-              description={`${dataset.template.category.slug} dataset for ${dataset.cityName}`}
+              description={`${dataset.template.category.slug} dataset for ${areaName}`}
             >
               <CardHeader>
                 <div className="flex items-center gap-3">
@@ -114,7 +120,7 @@ export function DashboardGrid({ datasets, saveLimit }: DashboardGridProps) {
                       {dataset.template.name}
                     </h3>
                     <p className="text-sm text-gray-500">
-                      {dataset.cityName}
+                      {areaName}
                       {dataset.area.countryCode &&
                         ` (${dataset.area.countryCode})`}
                     </p>
@@ -145,7 +151,8 @@ export function DashboardGrid({ datasets, saveLimit }: DashboardGridProps) {
               </CardFooter>
             </Card>
           </GridListItem>
-        )}
+          );
+        }}
       </GridList>
     </div>
   );

--- a/src/components/dataset/dataset-interactive-section.tsx
+++ b/src/components/dataset/dataset-interactive-section.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { ArrowLeft } from "lucide-react";
 import type { Feature, FeatureCollection } from "geojson";
 import type { Dataset } from "@/schemas/dataset";
 import { Link } from "@/i18n/navigation";
+import { resolveAreaName } from "@/lib/area-name";
 import { DatasetMapWrapper, type DatasetFullMapHandle } from "@/components/dataset/map-wrapper";
 import { DatasetInfoPanel } from "@/components/dataset/dataset-info-panel";
 import { DatasetStatsTable } from "@/components/dataset/dataset-stats-table";
@@ -28,6 +29,8 @@ export function DatasetInteractiveSection({
   const [selectedFeature, setSelectedFeature] = useState<Feature | null>(null);
   const mapRef = useRef<DatasetFullMapHandle>(null);
   const t = useTranslations("DatasetPage");
+  const locale = useLocale();
+  const areaName = resolveAreaName(dataset.area, locale);
 
   useEffect(() => {
     // Expose test hook in test mode or development
@@ -56,11 +59,11 @@ export function DatasetInteractiveSection({
           <>
             <Link
               href={`/area/${dataset.area.id}`}
-              aria-label={t("backToAreaLabel", { area: dataset.area.name })}
+              aria-label={t("backToAreaLabel", { area: areaName })}
               className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 -ml-1 mb-4 transition-colors"
             >
               <ArrowLeft className="size-4" />
-              {dataset.area.name}
+              {areaName}
             </Link>
             <div className="flex-1 overflow-y-auto space-y-6" data-testid="dataset-sidebar-default">
               <DatasetInfoPanel dataset={dataset} />

--- a/src/components/dataset/dataset-sections.tsx
+++ b/src/components/dataset/dataset-sections.tsx
@@ -5,6 +5,7 @@ import { DatasetCard } from "@/components/ui/dataset-card";
 import type { StatType } from "@/components/ui/dataset-stats-row";
 import { processDatasetStats, formatRelativeTime } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { getDatasetPath } from "@/lib/urls";
 
 type SectionTemplate = {
@@ -22,7 +23,11 @@ export type SectionDataset = {
   stats: Prisma.JsonValue;
   areaId: number;
   templateId: string;
-  area: { countryCode: string | null };
+  area: {
+    countryCode: string | null;
+    name: string;
+    names?: unknown;
+  };
   template: SectionTemplate;
   _count: { savedBy: number };
   lastEditedAt?: Date | null;
@@ -63,7 +68,7 @@ export async function DatasetSections({
       <DatasetCard
         key={dataset.id}
         name={resolved.name}
-        city={dataset.cityName}
+        city={resolveDatasetAreaName(dataset, locale)}
         country={dataset.area.countryCode ?? ""}
         category={resolved.category?.slug ?? "other"}
         templateId={dataset.templateId}

--- a/src/components/home/shared/featured-dataset-map.tsx
+++ b/src/components/home/shared/featured-dataset-map.tsx
@@ -3,6 +3,7 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/db";
 import { processDatasetStats } from "@/lib/dataset-stats";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
+import { resolveDatasetAreaName } from "@/lib/area-name";
 import { getDatasetPath } from "@/lib/urls";
 import { HeroMap } from "./hero-map";
 import { FeaturedDatasetMapClient } from "./featured-dataset-map-client";
@@ -17,6 +18,8 @@ const FEATURED_DATASET_SELECT = {
   area: {
     select: {
       id: true,
+      name: true,
+      names: true,
       countryCode: true,
       bounds: true,
       centerLat: true,
@@ -86,7 +89,7 @@ export async function FeaturedDatasetMap() {
       area={dataset.area}
       title={t("title", {
         template: resolvedTemplate.name,
-        city: dataset.cityName,
+        city: resolveDatasetAreaName(dataset, locale),
       })}
       category={resolvedTemplate.category?.slug ?? "other"}
       templateId={dataset.templateId}

--- a/src/lib/__tests__/area-name.test.ts
+++ b/src/lib/__tests__/area-name.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractOsmNames,
+  localeToNameKeys,
+  mergeAreaNames,
+  resolveAreaName,
+  resolveDatasetAreaName,
+  toStoredNames,
+} from "@/lib/area-name";
+
+describe("extractOsmNames", () => {
+  it("pulls name:* tags into a locale-keyed map plus default", () => {
+    expect(
+      extractOsmNames({
+        name: "東京都",
+        "name:en": "Tokyo",
+        "name:ja": "東京都",
+        "name:pt": "Tóquio",
+        population: "14000000",
+      })
+    ).toEqual({
+      default: "東京都",
+      en: "Tokyo",
+      ja: "東京都",
+      pt: "Tóquio",
+    });
+  });
+
+  it("ignores empty values and non-name tags", () => {
+    expect(extractOsmNames({ name: "  ", "name:en": "Berlin", boundary: "administrative" })).toEqual({
+      en: "Berlin",
+    });
+  });
+
+  it("returns {} for missing tags", () => {
+    expect(extractOsmNames(undefined)).toEqual({});
+    expect(extractOsmNames(null)).toEqual({});
+  });
+});
+
+describe("localeToNameKeys", () => {
+  it("maps pt-BR to [pt-BR, pt] (OSM uses name:pt)", () => {
+    expect(localeToNameKeys("pt-BR")).toEqual(["pt-BR", "pt"]);
+  });
+
+  it("returns [locale] for locales with no mapping change", () => {
+    expect(localeToNameKeys("en")).toEqual(["en"]);
+    expect(localeToNameKeys("es")).toEqual(["es"]);
+  });
+});
+
+describe("mergeAreaNames", () => {
+  it("later maps win on key conflicts", () => {
+    expect(
+      mergeAreaNames({ en: "A", pt: "B" }, { en: "C", ja: "D" })
+    ).toEqual({ en: "C", pt: "B", ja: "D" });
+  });
+
+  it("tolerates null/undefined", () => {
+    expect(mergeAreaNames(null, { en: "X" }, undefined)).toEqual({ en: "X" });
+  });
+});
+
+describe("resolveAreaName", () => {
+  const area = {
+    name: "東京都",
+    names: { default: "東京都", en: "Tokyo", ja: "東京都", pt: "Tóquio" },
+  };
+
+  it("uses the exact locale key when present", () => {
+    expect(resolveAreaName(area, "en")).toBe("Tokyo");
+  });
+
+  it("maps pt-BR to the pt tag", () => {
+    expect(resolveAreaName(area, "pt-BR")).toBe("Tóquio");
+  });
+
+  it("prefers an exact pt-BR tag over pt", () => {
+    const a = { name: "x", names: { "pt-BR": "São Paulo BR", pt: "São Paulo" } };
+    expect(resolveAreaName(a, "pt-BR")).toBe("São Paulo BR");
+  });
+
+  it("falls back to English when the locale has no tag", () => {
+    expect(resolveAreaName(area, "es")).toBe("Tokyo");
+  });
+
+  it("falls back to the OSM default when there is no name:en", () => {
+    const a = { name: "x", names: { default: "東京都", pt: "Tóquio" } };
+    expect(resolveAreaName(a, "en")).toBe("東京都");
+  });
+
+  it("falls back to area.name when names is missing", () => {
+    expect(resolveAreaName({ name: "Fallback City" }, "en")).toBe("Fallback City");
+    expect(resolveAreaName({ name: "Fallback City", names: null }, "pt-BR")).toBe(
+      "Fallback City"
+    );
+  });
+});
+
+describe("resolveDatasetAreaName", () => {
+  it("resolves from the joined area's localized names", () => {
+    const dataset = {
+      cityName: "München",
+      area: { name: "München", names: { en: "Munich", pt: "Munique" } },
+    };
+    expect(resolveDatasetAreaName(dataset, "pt-BR")).toBe("Munique");
+    expect(resolveDatasetAreaName(dataset, "en")).toBe("Munich");
+  });
+
+  it("falls back to cityName when the area has no name", () => {
+    const dataset = { cityName: "Legacy City", area: { name: null, names: null } };
+    expect(resolveDatasetAreaName(dataset, "en")).toBe("Legacy City");
+  });
+});
+
+describe("toStoredNames", () => {
+  it("returns the map when non-empty, undefined when empty", () => {
+    expect(toStoredNames({ en: "Tokyo" })).toEqual({ en: "Tokyo" });
+    expect(toStoredNames({})).toBeUndefined();
+  });
+});

--- a/src/lib/area-boundary.ts
+++ b/src/lib/area-boundary.ts
@@ -7,6 +7,7 @@ import {
 import { OverpassResponseSchema } from "@/types/overpass";
 import type { OSMNode, OSMRelation } from "@/types/osm";
 import { BOUNDARY_SIMPLIFICATION_TOLERANCE } from "@/lib/constants";
+import { extractOsmNames } from "@/lib/area-name";
 import { createLogger } from "@/lib/logger";
 import type { FeatureCollection } from "geojson";
 
@@ -119,6 +120,7 @@ export async function fetchOsmRelationData(relationId: number) {
 
   return {
     name: rel.tags?.name || `Relation ${relationId}`,
+    names: extractOsmNames(rel.tags),
     bounds: rel.bounds
       ? `${rel.bounds.minlat},${rel.bounds.minlon},${rel.bounds.maxlat},${rel.bounds.maxlon}`
       : null,

--- a/src/lib/area-conversion.ts
+++ b/src/lib/area-conversion.ts
@@ -1,6 +1,7 @@
 import type { Area } from "@/types/area";
 import type { NominatimResult } from "@/schemas/nominatim";
 import type { OSMRelation } from "@/types/osm";
+import { extractOsmNames } from "@/lib/area-name";
 
 export class InvalidAreaError extends Error {
   constructor(message: string) {
@@ -88,6 +89,7 @@ export function fromNominatim(result: NominatimResult): Area {
     ...parseCenter(result.lat, result.lon),
     id: result.osm_id,
     name: result.name?.trim() || result.display_name?.split(",")[0].trim() || "",
+    names: extractOsmNames(result.namedetails ?? undefined),
     displayName: result.display_name?.trim() || "",
     osmType: result.osm_type,
     class: result.class,

--- a/src/lib/area-name.ts
+++ b/src/lib/area-name.ts
@@ -1,0 +1,67 @@
+import { YML_LOCALE_MAP } from "@/lib/constants";
+import { DEFAULT_LOCALE } from "@/i18n/constants";
+
+// Keyed by OSM language subtag (en, es, pt, ...), plus a `default` key = the local `name` tag.
+export type AreaNames = Record<string, string>;
+
+// Accepts either Overpass relation tags or Nominatim namedetails — both key by name / name:<code>.
+export function extractOsmNames(
+  tags: Record<string, string> | undefined | null
+): AreaNames {
+  const names: AreaNames = {};
+  if (!tags) return names;
+  if (tags.name?.trim()) names.default = tags.name.trim();
+  for (const [key, value] of Object.entries(tags)) {
+    const match = key.match(/^name:(.+)$/);
+    if (match && typeof value === "string" && value.trim()) {
+      names[match[1]] = value.trim();
+    }
+  }
+  return names;
+}
+
+/** Merge name maps; later arguments win on key conflicts. Empty result → {}. */
+export function mergeAreaNames(
+  ...maps: (AreaNames | undefined | null)[]
+): AreaNames {
+  return Object.assign({}, ...maps.map((m) => m ?? {}));
+}
+
+/** A merged map ready for a Prisma write: the map, or undefined when empty so the column is left unchanged. */
+export function toStoredNames(map: AreaNames): AreaNames | undefined {
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
+// pt-BR → ["pt-BR", "pt"] because OSM tags Portuguese as name:pt, not name:pt-BR.
+export function localeToNameKeys(appLocale: string): string[] {
+  const keys = [appLocale];
+  const mapped = YML_LOCALE_MAP[appLocale];
+  if (mapped && mapped !== appLocale) keys.push(mapped);
+  return keys;
+}
+
+export function resolveAreaName(
+  area: { name: string; names?: unknown },
+  appLocale: string
+): string {
+  const names = (area.names ?? null) as AreaNames | null;
+  if (names && typeof names === "object") {
+    for (const key of localeToNameKeys(appLocale)) {
+      if (names[key]) return names[key];
+    }
+    if (names[DEFAULT_LOCALE]) return names[DEFAULT_LOCALE];
+    if (names.default) return names.default;
+  }
+  return area.name;
+}
+
+// Uses the denormalized `cityName` only as a last resort when the joined area has no name.
+export function resolveDatasetAreaName(
+  dataset: { cityName?: string | null; area: { name?: string | null; names?: unknown } },
+  appLocale: string
+): string {
+  return resolveAreaName(
+    { name: dataset.area.name ?? dataset.cityName ?? "", names: dataset.area.names },
+    appLocale
+  );
+}

--- a/src/lib/area-refresh.ts
+++ b/src/lib/area-refresh.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/db";
 import { Prisma } from "@prisma/client";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
 import { getAreaDetailsById } from "@/lib/nominatim";
+import { mergeAreaNames, toStoredNames } from "@/lib/area-name";
 import { AREA_INFO_TTL_DAYS } from "@/lib/constants";
 import { createLogger } from "@/lib/logger";
 
@@ -51,10 +52,14 @@ export async function refreshAreaInfo(
     currentBounds != null &&
     osmData.bounds !== currentBounds;
 
+  // Overpass carries the full name:* set, so it wins over Nominatim on conflicts.
+  const mergedNames = mergeAreaNames(areaDetails?.names, osmData?.names);
+
   return prisma.area.update({
     where: { id: areaId },
     data: {
       name: osmData?.name ?? areaDetails?.name ?? undefined,
+      names: toStoredNames(mergedNames),
       bounds: osmData?.bounds ?? undefined,
       countryCode: areaDetails?.countryCode ?? undefined,
       centerLat: center?.centerLat,

--- a/src/lib/dataset-operations.ts
+++ b/src/lib/dataset-operations.ts
@@ -4,6 +4,7 @@ import { resolveTemplate } from "@/lib/template-resolver";
 import { resolveTemplateForLocale } from "@/lib/template-locale";
 import { fetchOsmRelationData } from "@/lib/area-boundary";
 import { refreshAreaInfoIfStale, resolveAreaCenter } from "@/lib/area-refresh";
+import { mergeAreaNames, toStoredNames } from "@/lib/area-name";
 import {
   fetchDatasetSnapshot,
   DatasetTooLargeError,
@@ -105,6 +106,7 @@ async function getDatasetWithDetails(areaId: number, templateId: string, locale:
         select: {
           id: true,
           name: true,
+          names: true,
           countryCode: true,
           bounds: true,
           centerLat: true,
@@ -170,11 +172,13 @@ async function createDatasetOnDemand(
       // City OSM relations don't carry ISO3166 tags — Nominatim is the
       // only reliable source for country code.
       const center = resolveAreaCenter(osmData, areaDetails);
+      const mergedNames = mergeAreaNames(areaDetails?.names, osmData?.names);
       const shared = {
         countryCode: areaDetails?.countryCode ?? null,
         centerLat: center?.centerLat ?? null,
         centerLon: center?.centerLon ?? null,
         refreshedAt: new Date(),
+        names: toStoredNames(mergedNames),
       };
 
       const data = osmData
@@ -265,6 +269,7 @@ async function createDatasetOnDemand(
           select: {
             id: true,
             name: true,
+            names: true,
             countryCode: true,
             bounds: true,
             centerLat: true,

--- a/src/lib/dataset-section-select.ts
+++ b/src/lib/dataset-section-select.ts
@@ -13,6 +13,8 @@ export const DATASET_SELECT = {
   area: {
     select: {
       id: true,
+      name: true,
+      names: true,
       countryCode: true,
     },
   },

--- a/src/lib/nominatim.ts
+++ b/src/lib/nominatim.ts
@@ -81,7 +81,7 @@ export async function getAreaDetailsById(
 
   try {
     const response = await fetch(
-      `https://nominatim.openstreetmap.org/lookup?osm_ids=R${osmRelationId}&format=json&addressdetails=1&extratags=1&accept-language=${language}`,
+      `https://nominatim.openstreetmap.org/lookup?osm_ids=R${osmRelationId}&format=json&addressdetails=1&extratags=1&namedetails=1&accept-language=${language}`,
       {
         next: { revalidate: 86400 }, // 24 hours
         headers: {

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -75,6 +75,7 @@ export const DatasetSchema = z.object({
   area: z.object({
     id: z.number(),
     name: z.string(),
+    names: z.record(z.string(), z.string()).nullish(),
     countryCode: z.string().nullable(),
     bounds: z.string().nullable(),
     centerLat: z.number().nullish(),

--- a/src/schemas/nominatim.ts
+++ b/src/schemas/nominatim.ts
@@ -7,6 +7,8 @@ export const NominatimResultSchema = z.object({
   osm_id: z.number(),
   display_name: z.string(),
   name: z.string(),
+  // name / name:<lang> tags; only present when the request includes namedetails=1.
+  namedetails: z.record(z.string(), z.string()).nullish(),
   class: z.string(), // Primary category (e.g., "place", "amenity")
   type: z.string(), // Subcategory within class (e.g., "city", "village", "town")
   addresstype: z.string().optional(), // Address type (e.g., "municipality", "city", "village")

--- a/src/types/area.ts
+++ b/src/types/area.ts
@@ -1,6 +1,8 @@
 export type Area = {
   id: number;
   name: string;
+  /** OSM name:* translations keyed by subtag (en, es, pt, ...), plus `default`. */
+  names?: Record<string, string>;
   displayName: string;
   osmType: string;
   class: string;


### PR DESCRIPTION
## Summary

Area names rendered in the OSM local script for everyone ("München", "東京都"), regardless of language. This stores OSM `name:*` per area and resolves the name to the viewer's locale (fallback: English → local name). Closes #362.

## Changes

- `Area.names` JSON column, captured from Overpass + Nominatim (`namedetails=1`)
- `resolveAreaName` resolves by locale (`pt-BR → pt`), applied to area/dataset pages, all explore cards, dashboard, and home hero
- `scripts/backfill-area-names.ts` to populate existing areas (run post-deploy)

## Note for review

Fallback resolves English *before* the OSM local name ("Tokyo", not "東京都") — deliberate, deviates from #362's literal "fall back to default `name`".

## Testing

16 unit tests (fallback chain, `name:*` extraction). Verified in-app across en/pt-BR/es on dataset + area pages, `/explore` cards, and the home hero (Munich → Munique/Múnich, São Paulo → San Pablo). `type-check` / `lint` / `i18n:check` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized area names across area pages, dataset cards, dashboards, and navigation links.
  * Area names now adapt to the selected language, with sensible fallback names when translations are unavailable.
  * Newly created and refreshed areas automatically capture available translations from map data.
* **Bug Fixes**
  * Improved consistency of area and city labels throughout the application.
* **Tests**
  * Added coverage for localized name extraction, merging, resolution, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->