### PR TITLE
fix(home): prevent hero map clipping on short windows

### DIFF
--- a/src/components/home/hero/hero-layout.tsx
+++ b/src/components/home/hero/hero-layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 export function HeroLayout({ children }: { children: ReactNode }) {
   return (
     <section
-      className="border-b border-neutral-200 dark:border-neutral-800 relative lg:min-h-[640px] xl:min-h-[700px] 2xl:min-h-[750px]"
+      className="border-b border-neutral-200 dark:border-neutral-800 relative"
       style={{ height: 'calc(100vh - var(--nav-height))' }}
     >
       <div className="grid grid-rows-[auto_1fr] md:grid-rows-1 md:grid-cols-[minmax(380px,42%)_1fr] h-full md:[&>*]:h-full [&>*]:flex [&>*]:flex-col">


### PR DESCRIPTION
## Home hero map clips on short windows

Origin: #178 (featured dataset on home page) introduced this hero.

**Problem:** On a short viewport at desktop widths, the hero map's bottom (and the "See how it works" CTA) is pushed below the fold. The hero `<section>` sets `height: calc(100vh - var(--nav-height))` but also carries `lg:min-h-[640px] xl:min-h-[700px] 2xl:min-h-[750px]`. Those min-heights only take effect when the viewport is shorter than them — exactly the short-window case — forcing the hero taller than the viewport.

**Changes:** Remove the three min-heights from the hero section. Hero now always equals `calc(100vh - nav-height)` at desktop widths, so it fits the viewport and the map stays fully visible. On normal-height desktops the calc already exceeded the min, so no visual change there. Mobile/tablet unaffected (min-heights were `lg+` only).

**Verified:** at 1280x560 the section drops from a clipped 700px (205px below fold) to 494px (fully visible), confirmed with the real featured map; 1280x900 and 390x844 unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive hero-section sizing by removing conflicting minimum-height constraints.
  * The hero section now consistently fills the available viewport height beneath the navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->