### PR TITLE
feat(dataset-panel): restore heading outline + keyboard-scrollable stats region

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -160,6 +160,7 @@
     "titleMappers": "Mappers",
     "titleFeatures": "Features",
     "titleTags": "Tags",
+    "statsRegion": "Dataset statistics",
     "byType": "By type",
     "mostUsedTags": "Most used tags",
     "tagCoverage": "Critical coverage",

--- a/messages/es.json
+++ b/messages/es.json
@@ -159,6 +159,7 @@
     "titleMappers": "Mapeadores",
     "titleFeatures": "Elementos",
     "titleTags": "Etiquetas",
+    "statsRegion": "Estadísticas del conjunto de datos",
     "byType": "Por tipo",
     "mostUsedTags": "Etiquetas más usadas",
     "tagCoverage": "Cobertura crítica",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -159,6 +159,7 @@
     "titleMappers": "Mapeadores",
     "titleFeatures": "Feições",
     "titleTags": "Tags",
+    "statsRegion": "Estatísticas do conjunto de dados",
     "byType": "Por tipo",
     "mostUsedTags": "Tags mais usadas",
     "tagCoverage": "Cobertura crítica",

--- a/src/components/dataset/dataset-interactive-section.tsx
+++ b/src/components/dataset/dataset-interactive-section.tsx
@@ -88,9 +88,14 @@ export function DatasetInteractiveSection({
               </div>
             </div>
 
-            {/* Section 2 — tiered stats: the only scrollable region. Framed by top
-                and bottom rules so the scroll boundary is clear. */}
-            <div className="flex-1 min-h-0 overflow-y-auto flex flex-col border-y border-gray-200 my-3 py-3 pr-3">
+            {/* Section 2 — the only scrollable region; focusable + labelled so
+                keyboard-only users can scroll it (WCAG 2.1.1). */}
+            <div
+              role="region"
+              aria-label={t("statsRegion")}
+              tabIndex={0}
+              className="flex-1 min-h-0 overflow-y-auto flex flex-col border-y border-gray-200 my-3 py-3 pr-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-olive-500 focus-visible:ring-inset"
+            >
               <DatasetPanelStats dataset={dataset} />
             </div>
 

--- a/src/components/dataset/dataset-interactive-section.tsx
+++ b/src/components/dataset/dataset-interactive-section.tsx
@@ -94,7 +94,7 @@ export function DatasetInteractiveSection({
               role="region"
               aria-label={t("statsRegion")}
               tabIndex={0}
-              className="flex-1 min-h-0 overflow-y-auto flex flex-col border-y border-gray-200 my-3 py-3 pr-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-olive-500 focus-visible:ring-inset"
+              className="flex-1 min-h-0 overflow-y-auto flex flex-col border-y border-gray-200 my-3 py-3 pr-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-olive-500"
             >
               <DatasetPanelStats dataset={dataset} />
             </div>

--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -569,9 +569,9 @@ function SectionHeader({
 }) {
   return (
     <div className="flex items-baseline gap-2.5">
-      <span className="text-lg font-semibold leading-tight text-gray-900">
+      <h3 className="text-lg font-semibold leading-tight text-gray-900">
         {title}
-      </span>
+      </h3>
       {value != null && (
         <span className="ml-auto text-[15px] font-bold tabular-nums text-gray-600">
           {value}


### PR DESCRIPTION
Semantic-structure slice of the accessibility follow-up for #384.

- Section titles (Features/Mappers/Tags) as real `<h3>` under the `<h2>` title — restores the heading outline the redesign flattened.
- Stats scroll area gets `role=region` + `aria-label` + `tabIndex` so keyboard-only users can scroll it (WCAG 2.1.1), with a visible focus ring.
- Adds `statsRegion` i18n key (en/es/pt-BR).

Verified on a live Recife dataset: h2 -> h3 outline in the a11y tree, region reachable in one Tab, `i18n:check` + `type-check` green. Out of scope: interactive per-band figures/exact dates (the larger follow-up).