### PR TITLE
feat(dataset-panel): render stats sections as separated cards

### DIFF
--- a/src/components/dataset/dataset-interactive-section.tsx
+++ b/src/components/dataset/dataset-interactive-section.tsx
@@ -99,7 +99,7 @@ export function DatasetInteractiveSection({
               role="region"
               aria-label={t("statsRegion")}
               tabIndex={0}
-              className="flex-1 min-h-0 overflow-y-auto flex flex-col border-y border-gray-200 my-3 -mx-6 bg-gray-50 px-6 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-olive-500"
+              className="flex-1 min-h-0 overflow-y-auto [scrollbar-gutter:stable_both-edges] flex flex-col border-y border-gray-200 my-3 -mx-6 bg-gray-50 px-6 py-3 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-olive-500"
             >
               <DatasetPanelStats dataset={dataset} />
             </div>

--- a/src/components/dataset/dataset-interactive-section.tsx
+++ b/src/components/dataset/dataset-interactive-section.tsx
@@ -88,9 +88,13 @@ export function DatasetInteractiveSection({
               </div>
             </div>
 
-            {/* Section 2 — tiered stats: the only scrollable region. Framed by top
-                and bottom rules so the scroll boundary is clear. */}
-            <div className="flex-1 min-h-0 overflow-y-auto flex flex-col border-y border-gray-200 my-3 py-3 pr-3">
+            {/* Section 2 — tiered stats: the only scrollable region. A tinted
+                well framed by top and bottom rules; the white stat cards inside
+                read as cards against it. Breaks out of the aside's px-6 gutters
+                (-mx-6) so the well spans full width and its scrollbar sits flush
+                to the container's right edge; the inner px-6 keeps card content
+                aligned with the header above. */}
+            <div className="flex-1 min-h-0 overflow-y-auto flex flex-col border-y border-gray-200 my-3 -mx-6 bg-gray-50 px-6 py-3">
               <DatasetPanelStats dataset={dataset} />
             </div>
 

--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -345,7 +345,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
           </SubBlock>
         )}
         {freshnessSegments && (
-          <SubBlock eyebrow={t("recentlyEdited")} unit="%" divider>
+          <SubBlock eyebrow={t("recentlyEdited")} unit="%" spaced>
             <SegmentedBar
               segments={freshnessSegments}
               showLegend={false}
@@ -358,7 +358,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
 
       {/* Mappers — secondary to Features; its recency bar reuses the shared
           recency legend/colors. */}
-      <Section divided>
+      <Section>
         <SectionHeader
           title={t("titleMappers")}
           value={editors != null ? formatCompactNumber(editors) : "—"}
@@ -379,7 +379,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       {/* Tags — its own section: a leading tag icon + title, then the ranked
           key-presence list. */}
       {(coverageItems.length > 0 || tagGroups.length > 0) && (
-        <Section divided>
+        <Section>
           <SectionHeader title={t("titleTags")} icon={Tag} />
           {coverageItems.length > 0 ? (
             <SubBlock eyebrow={t("tagCoverage")}>
@@ -425,27 +425,18 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   );
 }
 
-// A top-level panel section. `divided` draws the separator rule that sets it
-// apart from the section above (Features, Tags).
-function Section({
-  divided,
-  children,
-}: {
-  divided?: boolean;
-  children: ReactNode;
-}) {
+// A top-level panel section, rendered as a separated white card sitting in the
+// tinted stats well (see dataset-interactive-section). Cards self-separate via
+// the root flex `gap-4`.
+function Section({ children }: { children: ReactNode }) {
   return (
-    <section
-      className={`flex flex-col gap-2.5${
-        divided ? " border-t border-gray-200 pt-4" : ""
-      }`}
-    >
+    <section className="flex flex-col gap-2.5 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
       {children}
     </section>
   );
 }
 
-// An eyebrow-labeled block nested inside a section (e.g. "By type"). `unit`
+// An eyebrow-labeled block nested inside a section card (e.g. "By type"). `unit`
 // renders a muted marker on the right of the eyebrow (e.g. "%") to signal what
 // the bar's proportions represent when the bar itself shows no numbers.
 function SubBlock({
@@ -453,21 +444,22 @@ function SubBlock({
   unit,
   children,
   className,
-  divider,
+  spaced,
 }: {
   eyebrow: string;
   unit?: string;
   children: ReactNode;
   className?: string;
-  // Draws a light rule + extra top padding above the block, separating it from
-  // a preceding chart in the same section (subordinate to the section divider).
-  divider?: boolean;
+  // Adds extra top space when this block follows another chart in the same card.
+  // The card outline already frames the group, so sub-sections separate with
+  // whitespace + their eyebrow labels rather than an internal rule.
+  spaced?: boolean;
 }) {
   return (
     <div
-      className={`flex flex-col gap-1.5${
-        divider ? " mt-1 border-t border-gray-100 pt-3" : ""
-      }${className ? ` ${className}` : ""}`}
+      className={`flex flex-col gap-1.5${spaced ? " mt-2.5" : ""}${
+        className ? ` ${className}` : ""
+      }`}
     >
       <p className="flex items-baseline justify-between text-[10px] font-bold uppercase tracking-[0.09em] text-gray-400">
         <span>{eyebrow}</span>


### PR DESCRIPTION
@coderabbitai ignore

## Summary

Implements the **"Sections as separated cards"** follow-up from #384. The
Features / Mappers / Tags stats sections now render as visually separated cards
instead of divider rules.

- Each section is a white card (`rounded-lg border bg-white shadow-sm`) sitting
  in a tinted (`bg-gray-50`) stats well.
- The well breaks out of the side-panel gutters so it spans full width; `scrollbar-gutter: stable both-edges` keeps the card margins symmetric (the scrollbar
  no longer eats only the right side).
- Sub-sections inside a card (e.g. Features' "By type" + "Recently edited")
  separate with whitespace + their eyebrow labels rather than an internal
  hairline — the card outline already frames them.

Scoped to styling only. No schema change, no new deps, no i18n keys. The
`Dataset.stats` precompute ("Fast data loading") remains a separate follow-up.
Merged the latest base (#385) — the keyboard-scrollable stats region + `<h3>`
section headings are preserved; the region's focus ring is drawn inside the well
(`-outline-offset-2`) so on the full-bleed region it isn't clipped or spilled
over the map.

## Screenshots

**Desktop — dense dataset (Cycleways in Amsterdam, lines):**

![Desktop Amsterdam](https://raw.githubusercontent.com/osmforcities/osmforcities/pr387-assets/desktop-amsterdam.png)

**Desktop — sparse dataset (Bus Stops in Luanda, points):**

![Desktop Luanda](https://raw.githubusercontent.com/osmforcities/osmforcities/pr387-assets/desktop-luanda.png)

**Keyboard focus on the stats region (WCAG 2.1.1, from #385):**

![Focus ring](https://raw.githubusercontent.com/osmforcities/osmforcities/pr387-assets/focus-ring.png)

**Mobile (iPhone 12) — stacked panel:**

![Mobile Amsterdam](https://raw.githubusercontent.com/osmforcities/osmforcities/pr387-assets/mobile-amsterdam.png)

<sub>The red "1 Issue" badge is the Next.js dev overlay, not part of the panel.</sub>

## Exploration

Compared three card treatments (outline / soft-tinted / white+shadow) and four
internal treatments (hairline / air / labeled-rule / inset) via real screenshots
on the dense and sparse datasets above. Landed on white-cards-on-a-tinted-well +
whitespace-separated sub-sections. Verified on desktop and mobile.

## Verify

- `pnpm type-check` — clean
- `pnpm lint` — 0 errors
- Dataset detail panel renders correctly for dense/sparse data, desktop + mobile;
  scroll region and pinned actions unaffected; keyboard focus ring uniform.

Base: `feature/simplify-dataset-panel` (integration branch for #384). Draft until
reviewed.
