### PR TITLE
feat(dataset): persist edit/mapper recency bands into Dataset.stats

### DIFF
--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -11,6 +11,7 @@ import length from "@turf/length";
 import type { Dataset } from "@/schemas/dataset";
 import { SegmentedBar, type BarSegment } from "@/components/ui/segmented-bar";
 import { formatCompactNumber } from "@/lib/dataset-stats";
+import { computeRecencyBands, RECENCY_BANDS } from "@/lib/dataset-recency";
 import { tagLabel, type MessageResolver } from "@/lib/tag-i18n";
 
 type DatasetPanelStatsProps = {
@@ -31,18 +32,6 @@ const NON_TAG_KEYS = new Set([
   "uid",
 ]);
 
-const DAY = 86_400_000;
-
-// Exclusive recency bands, matching the cutoffs used server-side in
-// dataset-snapshot.ts (90 days, 365 days, 730 days).
-function ageBand(ageMs: number): 0 | 1 | 2 | 3 {
-  const days = ageMs / DAY;
-  if (days <= 90) return 0;
-  if (days <= 365) return 1;
-  if (days <= 730) return 2;
-  return 3;
-}
-
 type GeomItem = {
   count: number;
   pct: number;
@@ -56,6 +45,7 @@ type GeomItem = {
   noneLabel: string;
 };
 
+// One color per RECENCY_BANDS entry, in order (freshest olive -> oldest gray).
 const RECENCY_COLORS = [
   "bg-olive-500",
   "bg-olive-400",
@@ -69,9 +59,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   const locale = useLocale();
   const nf = useMemo(() => new Intl.NumberFormat(locale), [locale]);
 
-  // Single pass over the dataset geojson derives every bar on the panel. Same
-  // deterministic, SSR-safe pattern as the map's own feature processing; null
-  // when the dataset ships stats but no geojson (very large datasets).
+  // Panel bars derived from the geojson; null when none is shipped.
   const derived = useMemo(() => {
     const gj = dataset.geojson as { features?: Feature[] } | null;
     if (!gj || !Array.isArray(gj.features) || gj.features.length === 0) {
@@ -97,9 +85,6 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
     let lineKm = 0;
     let areaKm2 = 0;
     const tagCounts = new Map<string, number>();
-    const editorLatest = new Map<string, number>();
-    const featureBands = [0, 0, 0, 0];
-    let timestamped = 0;
 
     for (const f of features) {
       const geomType = f.geometry?.type;
@@ -128,20 +113,6 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
           continue;
         tagCounts.set(key, (tagCounts.get(key) ?? 0) + 1);
       }
-
-      const tsRaw = props["timestamp"];
-      if (typeof tsRaw === "string") {
-        const ts = Date.parse(tsRaw);
-        if (!Number.isNaN(ts)) {
-          featureBands[ageBand(now - ts)]++;
-          timestamped++;
-          const user = props["user"];
-          if (typeof user === "string") {
-            const prev = editorLatest.get(user);
-            if (prev === undefined || ts > prev) editorLatest.set(user, ts);
-          }
-        }
-      }
     }
 
     const total = features.length;
@@ -150,8 +121,11 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       .sort((a, b) => b[1] - a[1])
       .map(([key, count]) => ({ key, pct: (count / total) * 100 }));
 
-    const editorBands = [0, 0, 0, 0];
-    for (const ts of editorLatest.values()) editorBands[ageBand(now - ts)]++;
+    // Same helper the server uses, so this matches the stored bands.
+    const { editRecencyBands, mapperRecencyBands } = computeRecencyBands(
+      features,
+      now
+    );
 
     return {
       total,
@@ -161,13 +135,8 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       lineKm,
       areaKm2,
       sortedTags,
-      // Percentages of the timestamped features, so the four bands sum to 100.
-      featureBandPct: featureBands.map((c) =>
-        timestamped > 0 ? (c / timestamped) * 100 : 0
-      ),
-      timestamped,
-      editorBands,
-      editorTotal: editorLatest.size,
+      editRecencyBands,
+      mapperRecencyBands,
     };
   }, [dataset.geojson, dataset.template.tags]);
 
@@ -209,12 +178,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       .sort((a, b) => b.pct - a.pct);
   }, [derived, dataset.template.filterableTags, tTagLabel]);
 
-  const recencyLabels = [
-    t("band90d"),
-    t("band90dTo1y"),
-    t("band1yTo2y"),
-    t("band2yPlus"),
-  ];
+  const recencyLabels = RECENCY_BANDS.map((band) => t(band.labelKey));
 
   // --- Features by type ---------------------------------------------------
   // A stacked proportion bar (like the recency bars), with a compact legend
@@ -274,18 +238,15 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       : null;
 
   // --- Freshness (recency of each feature's last edit) --------------------
-  // Prefer the per-feature geojson timestamps; fall back to the stored
-  // cumulative percentages (3-band) when geojson is absent.
+  // Priority: persisted bands -> geojson-derived -> legacy 3-band qualityMetrics.
+  const editBands =
+    bandsIfPopulated(dataset.stats?.editRecencyBands) ??
+    bandsIfPopulated(derived?.editRecencyBands);
   const stale = dataset.stats?.qualityMetrics?.staleElementsPercentage;
   const within1y = dataset.stats?.qualityMetrics?.recentlyUpdatedElementsPercentage;
   let freshnessSegments: BarSegment[] | null = null;
-  if (derived && derived.timestamped > 0) {
-    freshnessSegments = derived.featureBandPct.map((pct, i) => ({
-      pct,
-      colorClass: RECENCY_COLORS[i],
-      label: recencyLabels[i],
-      value: formatPct(pct),
-    }));
+  if (editBands) {
+    freshnessSegments = recencyBandSegments(editBands, recencyLabels, formatPct);
   } else if (stale != null && within1y != null) {
     const midPct = Math.max(0, 100 - within1y - stale);
     freshnessSegments = [
@@ -311,15 +272,14 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   }
 
   // --- Mappers (recency of each mapper's latest edit) --------------------
-  const mappersSegments: BarSegment[] | null =
-    derived && derived.editorTotal > 0
-      ? derived.editorBands.map((count, i) => ({
-          pct: (count / derived.editorTotal) * 100,
-          colorClass: RECENCY_COLORS[i],
-          label: recencyLabels[i],
-          value: nf.format(count),
-        }))
-      : null;
+  const mapperBands =
+    bandsIfPopulated(dataset.stats?.mapperRecencyBands) ??
+    bandsIfPopulated(derived?.mapperRecencyBands);
+  const mappersSegments: BarSegment[] | null = mapperBands
+    ? recencyBandSegments(mapperBands, recencyLabels, (_pct, count) =>
+        nf.format(count)
+      )
+    : null;
 
   const editors = dataset.stats?.editorsCount;
 
@@ -601,4 +561,28 @@ function formatPct(pct: number): string {
     return `${pct.toFixed(1)}%`;
   }
   return `${Math.round(pct)}%`;
+}
+
+// Well-formed, non-empty band array or null (all-zero = no signal, fall through).
+function bandsIfPopulated(bands: number[] | undefined): number[] | null {
+  if (!bands || bands.length !== RECENCY_BANDS.length) return null;
+  return bands.some((c) => c > 0) ? bands : null;
+}
+
+// Percentages are of the band sum, so the bands total 100%.
+function recencyBandSegments(
+  bands: number[],
+  labels: string[],
+  formatValue: (pct: number, count: number) => string
+): BarSegment[] {
+  const total = bands.reduce((a, b) => a + b, 0);
+  return bands.map((count, i) => {
+    const pct = total > 0 ? (count / total) * 100 : 0;
+    return {
+      pct,
+      colorClass: RECENCY_COLORS[i],
+      label: labels[i],
+      value: formatValue(pct, count),
+    };
+  });
 }

--- a/src/lib/__tests__/dataset-recency.test.ts
+++ b/src/lib/__tests__/dataset-recency.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import type { Feature, Point } from "geojson";
+import {
+  computeRecencyBands,
+  recencyBand,
+  RECENCY_BANDS,
+} from "@/lib/dataset-recency";
+
+const NOW = Date.parse("2026-01-01T00:00:00Z");
+const DAY = 86_400_000;
+
+// A point feature edited `daysAgo` days before NOW by `user`.
+function feat(daysAgo: number | null, user?: string): Feature<Point> {
+  const props: Record<string, unknown> = {};
+  if (daysAgo !== null) {
+    props.timestamp = new Date(NOW - daysAgo * DAY).toISOString();
+  }
+  if (user) props.user = user;
+  return {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties: props,
+  };
+}
+
+describe("recencyBand", () => {
+  it("maps ages to the four exclusive bands by the shared cutoffs", () => {
+    const [c0, c1, c2] = RECENCY_BANDS.map((b) => b.maxDays);
+    expect(recencyBand(0)).toBe(0);
+    expect(recencyBand(c0 * DAY)).toBe(0); // boundary inclusive
+    expect(recencyBand((c0 + 1) * DAY)).toBe(1);
+    expect(recencyBand(c1 * DAY)).toBe(1);
+    expect(recencyBand((c1 + 1) * DAY)).toBe(2);
+    expect(recencyBand(c2 * DAY)).toBe(2);
+    expect(recencyBand((c2 + 1) * DAY)).toBe(3);
+  });
+});
+
+describe("computeRecencyBands", () => {
+  it("buckets features across all four bands and sums to the timestamped count", () => {
+    const features = [
+      feat(10, "a"), // band 0
+      feat(200, "b"), // band 1
+      feat(500, "c"), // band 2
+      feat(1000, "d"), // band 3
+      feat(30, "e"), // band 0
+    ];
+    const { editRecencyBands } = computeRecencyBands(features, NOW);
+    expect(editRecencyBands).toEqual([2, 1, 1, 1]);
+    expect(editRecencyBands.reduce((a, b) => a + b, 0)).toBe(5);
+  });
+
+  it("buckets each mapper by their most-recent edit only", () => {
+    const features = [
+      feat(1000, "alice"), // old
+      feat(10, "alice"), // alice's latest -> band 0
+      feat(500, "bob"), // bob's only edit -> band 2
+    ];
+    const { mapperRecencyBands } = computeRecencyBands(features, NOW);
+    expect(mapperRecencyBands).toEqual([1, 0, 1, 0]);
+    expect(mapperRecencyBands.reduce((a, b) => a + b, 0)).toBe(2);
+  });
+
+  it("skips features with a missing or unparsable timestamp", () => {
+    const features = [
+      feat(10, "a"),
+      feat(null, "b"), // no timestamp
+      { ...feat(10, "c"), properties: { timestamp: "not-a-date", user: "c" } },
+    ];
+    const { editRecencyBands, mapperRecencyBands } = computeRecencyBands(
+      features as Feature[],
+      NOW
+    );
+    expect(editRecencyBands).toEqual([1, 0, 0, 0]);
+    expect(mapperRecencyBands).toEqual([1, 0, 0, 0]);
+  });
+
+  it("counts a timestamped feature with no user in edit bands but not mappers", () => {
+    const { editRecencyBands, mapperRecencyBands } = computeRecencyBands(
+      [feat(10)],
+      NOW
+    );
+    expect(editRecencyBands).toEqual([1, 0, 0, 0]);
+    expect(mapperRecencyBands).toEqual([0, 0, 0, 0]);
+  });
+
+  it("returns all-zero bands for empty input", () => {
+    const { editRecencyBands, mapperRecencyBands } = computeRecencyBands([], NOW);
+    expect(editRecencyBands).toEqual([0, 0, 0, 0]);
+    expect(mapperRecencyBands).toEqual([0, 0, 0, 0]);
+  });
+});

--- a/src/lib/__tests__/dataset-snapshot.test.ts
+++ b/src/lib/__tests__/dataset-snapshot.test.ts
@@ -114,6 +114,20 @@ describe("fetchDatasetSnapshot", () => {
     expect(snapshot.stats.editorsCount).toBe(2);
   });
 
+  it("persists recency bands summing to the timestamped features / distinct mappers", async () => {
+    const snapshot = await fetchDatasetSnapshot(1, "query", "tpl-1");
+    // Exact buckets depend on the current date (covered in dataset-recency
+    // tests); here assert shape and totals: 2 timestamped features, 2 mappers.
+    expect(snapshot.stats.editRecencyBands).toHaveLength(4);
+    expect(snapshot.stats.mapperRecencyBands).toHaveLength(4);
+    expect(
+      snapshot.stats.editRecencyBands?.reduce((a, b) => a + b, 0)
+    ).toBe(2);
+    expect(
+      snapshot.stats.mapperRecencyBands?.reduce((a, b) => a + b, 0)
+    ).toBe(2);
+  });
+
   it("returns bbox as null when no features produced", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/lib/dataset-recency.ts
+++ b/src/lib/dataset-recency.ts
@@ -1,0 +1,68 @@
+/**
+ * Recency bands: how an element's edit age maps to one of four buckets
+ * (<=90d, 90d-1y, 1y-2y, 2y+), defined in one place so the server and the
+ * dataset panel bucket identically.
+ *
+ * The server precomputes each dataset's band counts from its geojson and
+ * persists them in `Dataset.stats` (dataset-snapshot.ts). The panel renders
+ * those stored counts, falling back to computing them here from the geojson for
+ * datasets saved before they were persisted (dataset-panel-stats.tsx). Sharing
+ * the cutoffs and the accumulation is what lets the panel trust the stored
+ * counts instead of reprocessing the geojson on every render.
+ */
+import type { Feature } from "geojson";
+
+const DAY = 86_400_000;
+
+// The bands in order — also the shape of the persisted count arrays (one entry
+// each). Exclusive: a band covers ages above the previous bound up to its
+// maxDays; the last is open-ended. `labelKey` is the DatasetPage i18n key.
+export const RECENCY_BANDS = [
+  { key: "upTo90d", maxDays: 90, labelKey: "band90d" },
+  { key: "d90dTo1y", maxDays: 365, labelKey: "band90dTo1y" },
+  { key: "d1yTo2y", maxDays: 730, labelKey: "band1yTo2y" },
+  { key: "over2y", maxDays: Infinity, labelKey: "band2yPlus" },
+] as const;
+
+export function recencyBand(ageMs: number): number {
+  const days = ageMs / DAY;
+  return RECENCY_BANDS.findIndex((band) => days <= band.maxDays);
+}
+
+export interface RecencyBands {
+  editRecencyBands: number[];
+  mapperRecencyBands: number[];
+}
+
+// Bucket features by last-edit timestamp and mappers by their latest edit,
+// reading the osmtogeojson `timestamp`/`user` properties. Features without a
+// valid timestamp are skipped.
+export function computeRecencyBands(
+  features: Feature[],
+  now: number = Date.now()
+): RecencyBands {
+  const editRecencyBands = RECENCY_BANDS.map(() => 0);
+  const editorLatest = new Map<string, number>();
+
+  for (const f of features) {
+    const props = (f.properties ?? {}) as Record<string, unknown>;
+    const tsRaw = props["timestamp"];
+    if (typeof tsRaw !== "string") continue;
+    const ts = Date.parse(tsRaw);
+    if (Number.isNaN(ts)) continue;
+
+    editRecencyBands[recencyBand(now - ts)]++;
+
+    const user = props["user"];
+    if (typeof user === "string") {
+      const prev = editorLatest.get(user);
+      if (prev === undefined || ts > prev) editorLatest.set(user, ts);
+    }
+  }
+
+  const mapperRecencyBands = RECENCY_BANDS.map(() => 0);
+  for (const ts of editorLatest.values())
+    mapperRecencyBands[recencyBand(now - ts)]++;
+
+  return { editRecencyBands, mapperRecencyBands };
+}

--- a/src/lib/dataset-snapshot.ts
+++ b/src/lib/dataset-snapshot.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/overpass/transport";
 import type { OverpassData } from "@/types/overpass";
 import { calculateBbox } from "@/lib/utils";
+import { computeRecencyBands } from "@/lib/dataset-recency";
 import type { Bbox } from "@/types/geojson";
 import { prisma } from "@/lib/db";
 import {
@@ -100,6 +101,9 @@ export interface DatasetStats {
     staleElementsPercentage: number;
     recentlyUpdatedElementsPercentage: number;
   };
+  // Set from the geojson in fetchDatasetSnapshot, not extractDatasetStats.
+  editRecencyBands?: number[];
+  mapperRecencyBands?: number[];
 }
 
 export interface DatasetSnapshot {
@@ -268,6 +272,13 @@ export async function fetchDatasetSnapshot(
   await recordSizeCheck(areaId, templateId, "ok", { estimatedBytes });
   const geojson = convertOverpassToGeoJSON(overpassData);
   const stats = extractDatasetStats(overpassData);
+  // From geojson features, not raw Overpass elements, so the counts match the
+  // panel's feature-based derivation.
+  const { editRecencyBands, mapperRecencyBands } = computeRecencyBands(
+    geojson.features
+  );
+  stats.editRecencyBands = editRecencyBands;
+  stats.mapperRecencyBands = mapperRecencyBands;
   const bbox = calculateBbox(geojson);
   return {
     geojson,

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 import { GeoJSONFeatureCollectionSchema } from "@/types/geojson";
+import { RECENCY_BANDS } from "@/lib/dataset-recency";
+
+export const RecencyBandsSchema = z.array(z.number()).length(RECENCY_BANDS.length);
 
 export const DatasetStatsSchema = z.object({
   lastEdited: z.coerce.date().nullable().optional(),
@@ -29,6 +32,11 @@ export const DatasetStatsSchema = z.object({
       recentlyUpdatedElementsPercentage: z.number(),
     })
     .optional(),
+
+  // Feature-based recency distributions. Optional: older datasets fall back to
+  // client-side derivation.
+  editRecencyBands: RecencyBandsSchema.optional(),
+  mapperRecencyBands: RecencyBandsSchema.optional(),
 });
 
 export const CreateDatasetSchema = z.object({


### PR DESCRIPTION
Follow-up to #384 ("Fast data loading" checklist item). Targets the panel integration branch, not develop.

**Problem:** The panel's Activity (edit-recency) and Mappers (activity) bars are derived client-side from the full geojson on every render. This precomputes those band distributions and persists them so the panel can read stored counts.

**Changes:**
- `RECENCY_BANDS` single source of truth + `computeRecencyBands` shared helper (used by both server and client, so persisted bands match the client's derivation).
- `fetchDatasetSnapshot` computes bands from the geojson features and sets them on `stats`; the 3 existing write paths persist them unchanged.
- Optional `editRecencyBands` / `mapperRecencyBands` added to `DatasetStatsSchema` (named `RecencyBandsSchema`). Additive — no Prisma migration, no backfill.
- Panel prefers stored bands, falls back to geojson derivation for older datasets (no visual change while geojson is still shipped).

**Verification:** type-check, lint, 17 unit tests (new `dataset-recency` helper + extended snapshot test). Verified live: panel renders identical bars driven by the persisted counts.

@coderabbitai ignore