### PR TITLE
feat(dataset): persist geometry mix into Dataset.stats

### DIFF
--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -6,12 +6,11 @@ import type { Feature } from "geojson";
 import { useTranslations, useLocale } from "next-intl";
 import { MapPin, Users, Target, Spline, Pentagon, Tag } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import area from "@turf/area";
-import length from "@turf/length";
 import type { Dataset } from "@/schemas/dataset";
 import { SegmentedBar, type BarSegment } from "@/components/ui/segmented-bar";
 import { formatCompactNumber } from "@/lib/dataset-stats";
 import { computeRecencyBands, RECENCY_BANDS } from "@/lib/dataset-recency";
+import { computeGeometryMix } from "@/lib/dataset-geometry";
 import { tagLabel, type MessageResolver } from "@/lib/tag-i18n";
 
 type DatasetPanelStatsProps = {
@@ -79,35 +78,9 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       }
     }
 
-    let points = 0;
-    let lines = 0;
-    let areas = 0;
-    let lineKm = 0;
-    let areaKm2 = 0;
     const tagCounts = new Map<string, number>();
-
     for (const f of features) {
-      const geomType = f.geometry?.type;
-      if (geomType === "Point" || geomType === "MultiPoint") {
-        points++;
-      } else if (geomType === "LineString" || geomType === "MultiLineString") {
-        lines++;
-        try {
-          lineKm += length(f);
-        } catch {
-          /* skip malformed geometry */
-        }
-      } else if (geomType === "Polygon" || geomType === "MultiPolygon") {
-        areas++;
-        try {
-          areaKm2 += area(f) / 1_000_000;
-        } catch {
-          /* skip malformed geometry */
-        }
-      }
-
       const props = (f.properties ?? {}) as Record<string, unknown>;
-
       for (const key in props) {
         if (key.startsWith("@") || NON_TAG_KEYS.has(key) || queryKeys.has(key))
           continue;
@@ -121,22 +94,18 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       .sort((a, b) => b[1] - a[1])
       .map(([key, count]) => ({ key, pct: (count / total) * 100 }));
 
-    // Same helper the server uses, so this matches the stored bands.
+    // Same helpers the server uses, so these match the stored values.
     const { editRecencyBands, mapperRecencyBands } = computeRecencyBands(
       features,
       now
     );
+    const geometryMix = computeGeometryMix(features);
 
     return {
-      total,
-      points,
-      lines,
-      areas,
-      lineKm,
-      areaKm2,
       sortedTags,
       editRecencyBands,
       mapperRecencyBands,
+      geometryMix,
     };
   }, [dataset.geojson, dataset.template.tags]);
 
@@ -187,39 +156,43 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   // only needs to separate the slices. The legend always lists all three types:
   // points show their count, lines their total length, areas their total area;
   // absent types read "no lines" etc.
-  const geomItems: GeomItem[] | null = derived
+  // Persisted mix if present, else derived from geojson; its own total is the
+  // bar denominator, so the section is self-contained.
+  const geometryMix = dataset.stats?.geometryMix ?? derived?.geometryMix ?? null;
+  const geomTotal = geometryMix?.total ?? 0;
+  const geomItems: GeomItem[] | null = geometryMix
     ? [
         {
-          count: derived.points,
-          pct: (derived.points / derived.total) * 100,
+          count: geometryMix.points,
+          pct: (geometryMix.points / geomTotal) * 100,
           colorClass: "bg-olive-500",
           textClass: "text-olive-500",
           icon: Target,
           filled: false,
           label: t("geomPoints"),
-          display: formatCompactNumber(derived.points),
+          display: formatCompactNumber(geometryMix.points),
           noneLabel: t("geomNone", { type: t("geomPointsLower") }),
         },
         {
-          count: derived.lines,
-          pct: (derived.lines / derived.total) * 100,
+          count: geometryMix.lines,
+          pct: (geometryMix.lines / geomTotal) * 100,
           colorClass: "bg-olive-400",
           textClass: "text-olive-400",
           icon: Spline,
           filled: false,
           label: t("geomLines"),
-          display: `${formatKm(derived.lineKm, nf)} km`,
+          display: `${formatKm(geometryMix.lineKm, nf)} km`,
           noneLabel: t("geomNone", { type: t("geomLinesLower") }),
         },
         {
-          count: derived.areas,
-          pct: (derived.areas / derived.total) * 100,
+          count: geometryMix.areas,
+          pct: (geometryMix.areas / geomTotal) * 100,
           colorClass: "bg-olive-300",
           textClass: "text-olive-300",
           icon: Pentagon,
           filled: false,
           label: t("geomAreas"),
-          display: `${formatKm(derived.areaKm2, nf)} km²`,
+          display: `${formatKm(geometryMix.areaKm2, nf)} km²`,
           noneLabel: t("geomNone", { type: t("geomAreasLower") }),
         },
       ]

--- a/src/lib/__tests__/dataset-geometry.test.ts
+++ b/src/lib/__tests__/dataset-geometry.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import type { Feature, Geometry } from "geojson";
+import { computeGeometryMix } from "@/lib/dataset-geometry";
+
+function feat(geometry: Geometry | null): Feature {
+  return { type: "Feature", geometry: geometry as Geometry, properties: {} };
+}
+
+// A ~1 degree square near the equator: nonzero length and area.
+const RING: number[][] = [
+  [0, 0],
+  [1, 0],
+  [1, 1],
+  [0, 1],
+  [0, 0],
+];
+
+describe("computeGeometryMix", () => {
+  it("counts each geometry type, including Multi* variants", () => {
+    const mix = computeGeometryMix([
+      feat({ type: "Point", coordinates: [0, 0] }),
+      feat({ type: "MultiPoint", coordinates: [[0, 0]] }),
+      feat({ type: "LineString", coordinates: [[0, 0], [1, 1]] }),
+      feat({ type: "MultiLineString", coordinates: [[[0, 0], [1, 1]]] }),
+      feat({ type: "Polygon", coordinates: [RING] }),
+      feat({ type: "MultiPolygon", coordinates: [[RING]] }),
+    ]);
+    expect(mix.total).toBe(6);
+    expect(mix.points).toBe(2);
+    expect(mix.lines).toBe(2);
+    expect(mix.areas).toBe(2);
+  });
+
+  it("accumulates line length (km) and polygon area (km2)", () => {
+    const mix = computeGeometryMix([
+      feat({ type: "LineString", coordinates: [[0, 0], [1, 1]] }),
+      feat({ type: "Polygon", coordinates: [RING] }),
+    ]);
+    expect(mix.lineKm).toBeGreaterThan(0);
+    expect(mix.areaKm2).toBeGreaterThan(0);
+  });
+
+  it("skips malformed geometry without throwing", () => {
+    const mix = computeGeometryMix([
+      feat({ type: "LineString", coordinates: [] }),
+      feat({ type: "Polygon", coordinates: [] }),
+      feat(null),
+    ]);
+    // Types still classified; measures stay finite (0).
+    expect(mix.lines).toBe(1);
+    expect(mix.areas).toBe(1);
+    expect(Number.isFinite(mix.lineKm)).toBe(true);
+    expect(Number.isFinite(mix.areaKm2)).toBe(true);
+  });
+
+  it("returns all zeros for empty input", () => {
+    expect(computeGeometryMix([])).toEqual({
+      total: 0,
+      points: 0,
+      lines: 0,
+      areas: 0,
+      lineKm: 0,
+      areaKm2: 0,
+    });
+  });
+});

--- a/src/lib/__tests__/dataset-snapshot.test.ts
+++ b/src/lib/__tests__/dataset-snapshot.test.ts
@@ -128,6 +128,19 @@ describe("fetchDatasetSnapshot", () => {
     ).toBe(2);
   });
 
+  it("persists geometry mix from the geojson features", async () => {
+    const snapshot = await fetchDatasetSnapshot(1, "query", "tpl-1");
+    // 2 node fixtures -> 2 Point features, no lines/areas.
+    expect(snapshot.stats.geometryMix).toEqual({
+      total: 2,
+      points: 2,
+      lines: 0,
+      areas: 0,
+      lineKm: 0,
+      areaKm2: 0,
+    });
+  });
+
   it("returns bbox as null when no features produced", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/lib/dataset-geometry.ts
+++ b/src/lib/dataset-geometry.ts
@@ -1,0 +1,54 @@
+/**
+ * Geometry mix: how a dataset's features split across point / line / area, with
+ * the total length of lines and total area of polygons. Defined in one place so
+ * the server and the dataset panel classify and measure identically.
+ *
+ * The server precomputes each dataset's mix from its geojson and persists it in
+ * `Dataset.stats` (dataset-snapshot.ts). The panel renders the stored mix,
+ * falling back to computing it here from the geojson for datasets saved before
+ * it was persisted (dataset-panel-stats.tsx). Turf area/length runs once at
+ * snapshot time instead of on every render.
+ */
+import area from "@turf/area";
+import length from "@turf/length";
+import type { Feature } from "geojson";
+
+export interface GeometryMix {
+  total: number; // feature count the mix was computed over (bar denominator)
+  points: number;
+  lines: number;
+  areas: number;
+  lineKm: number;
+  areaKm2: number;
+}
+
+export function computeGeometryMix(features: Feature[]): GeometryMix {
+  let points = 0;
+  let lines = 0;
+  let areas = 0;
+  let lineKm = 0;
+  let areaKm2 = 0;
+
+  for (const f of features) {
+    const geomType = f.geometry?.type;
+    if (geomType === "Point" || geomType === "MultiPoint") {
+      points++;
+    } else if (geomType === "LineString" || geomType === "MultiLineString") {
+      lines++;
+      try {
+        lineKm += length(f);
+      } catch {
+        /* skip malformed geometry */
+      }
+    } else if (geomType === "Polygon" || geomType === "MultiPolygon") {
+      areas++;
+      try {
+        areaKm2 += area(f) / 1_000_000;
+      } catch {
+        /* skip malformed geometry */
+      }
+    }
+  }
+
+  return { total: features.length, points, lines, areas, lineKm, areaKm2 };
+}

--- a/src/lib/dataset-snapshot.ts
+++ b/src/lib/dataset-snapshot.ts
@@ -9,6 +9,7 @@ import {
 import type { OverpassData } from "@/types/overpass";
 import { calculateBbox } from "@/lib/utils";
 import { computeRecencyBands } from "@/lib/dataset-recency";
+import { computeGeometryMix, type GeometryMix } from "@/lib/dataset-geometry";
 import type { Bbox } from "@/types/geojson";
 import { prisma } from "@/lib/db";
 import {
@@ -104,6 +105,7 @@ export interface DatasetStats {
   // Set from the geojson in fetchDatasetSnapshot, not extractDatasetStats.
   editRecencyBands?: number[];
   mapperRecencyBands?: number[];
+  geometryMix?: GeometryMix;
 }
 
 export interface DatasetSnapshot {
@@ -279,6 +281,7 @@ export async function fetchDatasetSnapshot(
   );
   stats.editRecencyBands = editRecencyBands;
   stats.mapperRecencyBands = mapperRecencyBands;
+  stats.geometryMix = computeGeometryMix(geojson.features);
   const bbox = calculateBbox(geojson);
   return {
     geojson,

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -4,6 +4,15 @@ import { RECENCY_BANDS } from "@/lib/dataset-recency";
 
 export const RecencyBandsSchema = z.array(z.number()).length(RECENCY_BANDS.length);
 
+export const GeometryMixSchema = z.object({
+  total: z.number(),
+  points: z.number(),
+  lines: z.number(),
+  areas: z.number(),
+  lineKm: z.number(),
+  areaKm2: z.number(),
+});
+
 export const DatasetStatsSchema = z.object({
   lastEdited: z.coerce.date().nullable().optional(),
   editorsCount: z.number(),
@@ -37,6 +46,10 @@ export const DatasetStatsSchema = z.object({
   // client-side derivation.
   editRecencyBands: RecencyBandsSchema.optional(),
   mapperRecencyBands: RecencyBandsSchema.optional(),
+
+  // Feature geometry split + measures. Optional: older datasets fall back to
+  // client-side derivation.
+  geometryMix: GeometryMixSchema.optional(),
 });
 
 export const CreateDatasetSchema = z.object({


### PR DESCRIPTION
@coderabbitai ignore

## Follow-up to #390: Fast data loading (geometry mix slice)

**Problem:** The dataset side-panel derives its charts client-side from the full geojson on every render. #390 lists persisting those derivations into `Dataset.stats` so the panel can eventually load without shipping/processing geojson. The recency-bands slice already landed (folded into #390); this is the **geometry mix** slice — the heaviest per-render work, since turf `area()`/`length()` runs over every feature.

**Changes:**
- New shared helper `src/lib/dataset-geometry.ts` — `computeGeometryMix(features)` returns `{ total, points, lines, areas, lineKm, areaKm2 }`; owns the turf imports and the point/line/area classification loop.
- `fetchDatasetSnapshot` persists `stats.geometryMix` from the geojson features (same input the panel uses), right after the recency bands.
- `GeometryMixSchema` added to `src/schemas/dataset.ts`; optional `geometryMix` field on `DatasetStatsSchema` (`.parse` strips unknown keys, so the schema field is load-bearing).
- Panel (`dataset-panel-stats.tsx`) drops the inline geometry loop, prefers `dataset.stats?.geometryMix` and falls back to the shared helper over geojson. Bar denominator is the mix's own `total` (= feature count at snapshot = `dataCount`), so stored and derived paths render identically.

**Why groundwork:** geojson is still shipped to the panel today, so no visible change now — this moves turf off the render path and makes the "By type" bar resilient to a future geojson-free load. Additive, optional schema: no migration, no backfill.

**Verification:**
- `pnpm type-check` clean, eslint clean, new `dataset-geometry` tests + extended snapshot test pass (16 unit tests).
- Live-verified on a worktree dev server: created a Munich bus-stops dataset; stored `geometryMix = { total: 2419, points: 470, lines: 1, areas: 1948, lineKm: 0.0046, areaKm2: 0.104 }` renders as 470 / <0.1 km / 0.1 km², matching the DB exactly, no console errors.