### PR TITLE
feat(dataset): persist tag counts + show coverage and most-used together

### DIFF
--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -17,20 +17,6 @@ type DatasetPanelStatsProps = {
   dataset: Dataset;
 };
 
-// Property keys carried by osmtogeojson output that are NOT real OSM tags — the
-// combined id, the "@"-prefixed internals, per-element metadata, and app-added
-// fields. Mirrors the filters in feature-detail-panel.tsx so the tag list counts
-// only genuine tags.
-const NON_TAG_KEYS = new Set([
-  "id",
-  "user",
-  "timestamp",
-  "version",
-  "changeset",
-  "ageCategory",
-  "uid",
-]);
-
 type GeomItem = {
   count: number;
   pct: number;
@@ -67,33 +53,6 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
     const features = gj.features;
     const now = Date.now();
 
-    // Keys used by the template's Overpass query (e.g. "highway=bus_stop" ->
-    // "highway"). They match ~100% of features by definition, so exclude them
-    // from the Most-used-tags list where they'd only crowd out real signal.
-    const queryKeys = new Set<string>();
-    for (const kv of dataset.template.tags ?? []) {
-      for (const cond of kv.split(/[;&]/)) {
-        const key = cond.split("=")[0]?.trim();
-        if (key) queryKeys.add(key);
-      }
-    }
-
-    const tagCounts = new Map<string, number>();
-    for (const f of features) {
-      const props = (f.properties ?? {}) as Record<string, unknown>;
-      for (const key in props) {
-        if (key.startsWith("@") || NON_TAG_KEYS.has(key) || queryKeys.has(key))
-          continue;
-        tagCounts.set(key, (tagCounts.get(key) ?? 0) + 1);
-      }
-    }
-
-    const total = features.length;
-
-    const sortedTags = [...tagCounts.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .map(([key, count]) => ({ key, pct: (count / total) * 100 }));
-
     // Same helpers the server uses, so these match the stored values.
     const { editRecencyBands, mapperRecencyBands } = computeRecencyBands(
       features,
@@ -102,22 +61,46 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
     const geometryMix = computeGeometryMix(features);
 
     return {
-      sortedTags,
       editRecencyBands,
       mapperRecencyBands,
       geometryMix,
     };
-  }, [dataset.geojson, dataset.template.tags]);
+  }, [dataset.geojson]);
+
+  // Stored counts only — no client fallback (see dataset-tags).
+  const tagCounts = dataset.stats?.tagCounts ?? null;
+
+  // Keys used by the template's Overpass query (e.g. "highway=bus_stop" ->
+  // "highway"). They match ~100% of features by definition, so exclude them from
+  // the Most-used list where they'd only crowd out real signal.
+  const queryKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const kv of dataset.template.tags ?? []) {
+      for (const cond of kv.split(/[;&]/)) {
+        const key = cond.split("=")[0]?.trim();
+        if (key) keys.add(key);
+      }
+    }
+    return keys;
+  }, [dataset.template.tags]);
+
+  // Non-query tags, each with its share of features (count / dataCount).
+  const sortedTags = useMemo(() => {
+    if (!tagCounts) return [];
+    const total = dataset.dataCount;
+    return tagCounts
+      .filter((tc) => !queryKeys.has(tc.key))
+      .map((tc) => ({ key: tc.key, pct: (tc.count / total) * 100 }));
+  }, [tagCounts, queryKeys, dataset.dataCount]);
 
   // Group tags that share the same displayed percentage onto one line, capped
   // at five lines, so the section stays dense but shows more than five tags.
   const tagGroups = useMemo(() => {
-    if (!derived) return [];
     const MAX_LINES = 5;
     const MAX_KEYS = 4;
     const groups: { label: string; keys: string[]; pct: number; extra: number }[] =
       [];
-    for (const { key, pct } of derived.sortedTags) {
+    for (const { key, pct } of sortedTags) {
       const label = formatPct(pct);
       let g = groups[groups.length - 1];
       if (!g || g.label !== label) {
@@ -129,15 +112,18 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       else g.extra++;
     }
     return groups;
-  }, [derived]);
+  }, [sortedTags]);
 
   // Critical-tag coverage: for each of the template's filterable (curated) tags,
   // the share of features that carry it. Absent tags read 0% — that gap is the
-  // signal. Replaces the Most-used list for templates that curate a list.
+  // signal. Shown above the Most-used list for templates that curate a list.
   const coverageItems = useMemo(() => {
     const filterable = dataset.template.filterableTags ?? [];
-    if (!derived || filterable.length === 0) return [];
-    const pctByKey = new Map(derived.sortedTags.map((s) => [s.key, s.pct]));
+    if (!tagCounts || filterable.length === 0) return [];
+    const total = dataset.dataCount;
+    const pctByKey = new Map(
+      tagCounts.map((tc) => [tc.key, (tc.count / total) * 100])
+    );
     return filterable
       .map((key) => ({
         key,
@@ -145,7 +131,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
         pct: pctByKey.get(key) ?? 0,
       }))
       .sort((a, b) => b.pct - a.pct);
-  }, [derived, dataset.template.filterableTags, tTagLabel]);
+  }, [tagCounts, dataset.dataCount, dataset.template.filterableTags, tTagLabel]);
 
   const recencyLabels = RECENCY_BANDS.map((band) => t(band.labelKey));
 
@@ -309,12 +295,12 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
         )}
       </Section>
 
-      {/* Tags — its own section: a leading tag icon + title, then the ranked
-          key-presence list. */}
+      {/* Tags — its own section. Curated templates show Critical coverage first;
+          the Most-used list (all non-query tags) follows, so both stories show. */}
       {(coverageItems.length > 0 || tagGroups.length > 0) && (
         <Section>
           <SectionHeader title={t("titleTags")} icon={Tag} />
-          {coverageItems.length > 0 ? (
+          {coverageItems.length > 0 && (
             <SubBlock eyebrow={t("tagCoverage")}>
               <div className="flex flex-col gap-1.5">
                 {coverageItems.map((c) => (
@@ -331,8 +317,12 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
                 ))}
               </div>
             </SubBlock>
-          ) : (
-            <SubBlock eyebrow={t("mostUsedTags")}>
+          )}
+          {tagGroups.length > 0 && (
+            <SubBlock
+              eyebrow={t("mostUsedTags")}
+              spaced={coverageItems.length > 0}
+            >
               <div className="flex flex-col gap-1.5">
                 {tagGroups.map((g) => (
                   <StatRow

--- a/src/lib/__tests__/dataset-snapshot.test.ts
+++ b/src/lib/__tests__/dataset-snapshot.test.ts
@@ -141,6 +141,12 @@ describe("fetchDatasetSnapshot", () => {
     });
   });
 
+  it("persists tag counts from the geojson features", async () => {
+    const snapshot = await fetchDatasetSnapshot(1, "query", "tpl-1");
+    // Both node fixtures carry a `name` tag -> one entry, count 2.
+    expect(snapshot.stats.tagCounts).toEqual([{ key: "name", count: 2 }]);
+  });
+
   it("returns bbox as null when no features produced", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/lib/__tests__/dataset-tags.test.ts
+++ b/src/lib/__tests__/dataset-tags.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { Feature, Point } from "geojson";
+import { computeTagCounts } from "@/lib/dataset-tags";
+
+function feat(properties: Record<string, unknown>): Feature<Point> {
+  return {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties,
+  };
+}
+
+describe("computeTagCounts", () => {
+  it("counts key presence across features, sorted most-used first", () => {
+    const counts = computeTagCounts([
+      feat({ name: "A", shelter: "yes" }),
+      feat({ name: "B", shelter: "no", bench: "yes" }),
+      feat({ name: "C" }),
+    ]);
+    expect(counts).toEqual([
+      { key: "name", count: 3 },
+      { key: "shelter", count: 2 },
+      { key: "bench", count: 1 },
+    ]);
+  });
+
+  it("skips @-prefixed internals and NON_TAG_KEYS", () => {
+    const counts = computeTagCounts([
+      feat({
+        highway: "bus_stop",
+        id: "node/1",
+        user: "mapper",
+        timestamp: "2025-01-01T00:00:00Z",
+        version: 3,
+        changeset: 9,
+        uid: 42,
+        ageCategory: "recent",
+        "@relations": [],
+      }),
+    ]);
+    expect(counts).toEqual([{ key: "highway", count: 1 }]);
+  });
+
+  it("keeps query and filterable keys (helper is template-agnostic)", () => {
+    // highway is a query key, shelter a filterable key — both counted here; the
+    // panel applies those filters, not this helper.
+    const counts = computeTagCounts([feat({ highway: "bus_stop", shelter: "yes" })]);
+    expect(counts.map((c) => c.key).sort()).toEqual(["highway", "shelter"]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(computeTagCounts([])).toEqual([]);
+  });
+});

--- a/src/lib/dataset-snapshot.ts
+++ b/src/lib/dataset-snapshot.ts
@@ -10,6 +10,7 @@ import type { OverpassData } from "@/types/overpass";
 import { calculateBbox } from "@/lib/utils";
 import { computeRecencyBands } from "@/lib/dataset-recency";
 import { computeGeometryMix, type GeometryMix } from "@/lib/dataset-geometry";
+import { computeTagCounts, type TagCount } from "@/lib/dataset-tags";
 import type { Bbox } from "@/types/geojson";
 import { prisma } from "@/lib/db";
 import {
@@ -106,6 +107,7 @@ export interface DatasetStats {
   editRecencyBands?: number[];
   mapperRecencyBands?: number[];
   geometryMix?: GeometryMix;
+  tagCounts?: TagCount[];
 }
 
 export interface DatasetSnapshot {
@@ -282,6 +284,7 @@ export async function fetchDatasetSnapshot(
   stats.editRecencyBands = editRecencyBands;
   stats.mapperRecencyBands = mapperRecencyBands;
   stats.geometryMix = computeGeometryMix(geojson.features);
+  stats.tagCounts = computeTagCounts(geojson.features);
   const bbox = calculateBbox(geojson);
   return {
     geojson,

--- a/src/lib/dataset-tags.ts
+++ b/src/lib/dataset-tags.ts
@@ -1,0 +1,47 @@
+/**
+ * Tag counts: how many features carry each OSM tag key (presence, not value).
+ *
+ * Computed once server-side from a dataset's geojson and persisted in
+ * `Dataset.stats` (dataset-snapshot.ts); the panel renders the stored counts (the
+ * Critical-coverage and Most-used-tags lists) and never recomputes them, so the
+ * Tags section stays hidden until a dataset is (re)snapshotted.
+ *
+ * Counts are template-agnostic: the template's query keys and its curated
+ * filterable set are applied by the panel, not baked in here, so the stored data
+ * stays correct if the template changes.
+ */
+import type { Feature } from "geojson";
+
+// Property keys carried by osmtogeojson output that are NOT real OSM tags — the
+// combined id, the "@"-prefixed internals, per-element metadata, and app-added
+// fields. Mirrors the filters in feature-detail-panel.tsx so the counts cover
+// only genuine tags.
+const NON_TAG_KEYS = new Set([
+  "id",
+  "user",
+  "timestamp",
+  "version",
+  "changeset",
+  "ageCategory",
+  "uid",
+]);
+
+export interface TagCount {
+  key: string;
+  count: number;
+}
+
+// Feature-presence count per tag key, sorted most-used first.
+export function computeTagCounts(features: Feature[]): TagCount[] {
+  const counts = new Map<string, number>();
+  for (const f of features) {
+    const props = (f.properties ?? {}) as Record<string, unknown>;
+    for (const key in props) {
+      if (key.startsWith("@") || NON_TAG_KEYS.has(key)) continue;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([key, count]) => ({ key, count }));
+}

--- a/src/schemas/dataset.ts
+++ b/src/schemas/dataset.ts
@@ -13,6 +13,11 @@ export const GeometryMixSchema = z.object({
   areaKm2: z.number(),
 });
 
+export const TagCountSchema = z.object({
+  key: z.string(),
+  count: z.number(),
+});
+
 export const DatasetStatsSchema = z.object({
   lastEdited: z.coerce.date().nullable().optional(),
   editorsCount: z.number(),
@@ -50,6 +55,10 @@ export const DatasetStatsSchema = z.object({
   // Feature geometry split + measures. Optional: older datasets fall back to
   // client-side derivation.
   geometryMix: GeometryMixSchema.optional(),
+
+  // Per-key tag presence counts, sorted desc. Optional: absent until a dataset is
+  // (re)snapshotted — the panel reads these stored counts only, no client fallback.
+  tagCounts: z.array(TagCountSchema).optional(),
 });
 
 export const CreateDatasetSchema = z.object({


### PR DESCRIPTION
@coderabbitai ignore

## Follow-up to #390: Fast data loading (tag counts slice)

**Problem:** The dataset side-panel derives its charts client-side from the full geojson on every render. #390's "Fast data loading" follow-up persists those derivations into `Dataset.stats` so the panel can eventually load without geojson. Recency bands (#388) and geometry mix (#392) already landed; this is the **last slice — tag counts**. After it, a follow-up can drop `geojson` from the panel query.

**Also (brainstorm decision):** the Tags section was **either/or** — "Critical coverage" (curated `filterableTags`) for curated templates, else "Most used tags". It now shows **both, stacked** for curated templates (coverage first, then the descending most-used list of all non-query tags, overlap allowed). Uncurated templates keep most-used only. Stays key-presence; tag combinations deferred.

**Changes:**
- New shared helper `src/lib/dataset-tags.ts` — `computeTagCounts(features)` returns per-key presence counts `[{key, count}]` sorted desc; owns `NON_TAG_KEYS`. Template-agnostic: query-key and filterable filtering stay client-side, so stored data is correct if the template changes.
- `fetchDatasetSnapshot` persists `stats.tagCounts` (after geometry mix).
- `TagCountSchema` + optional `tagCounts` on `DatasetStatsSchema` (`.parse` strips unknown keys, so the field is load-bearing).
- Panel (`dataset-panel-stats.tsx`): reads `dataset.stats?.tagCounts` **only — no client fallback** (the Tags section stays hidden until a dataset is (re)snapshotted); builds most-used (query keys excluded) and coverage from it, denominator `dataCount`; renders both `SubBlock`s stacked.

**Note:** stored-only (no geojson fallback) is the direction for all three persisted stats — it's what lets a later slice drop `geojson` from the panel query. Recency/geometry still fall back (already merged); those get aligned when geojson is dropped.

**Verification:**
- `pnpm type-check` + eslint clean; new `dataset-tags` tests + extended snapshot test pass (17 unit tests).
- Live (isolated chrome, Munich bus-stops): Tags card shows Critical coverage (Shelter 95%, Bench 94%, Tactile paving 93%, Lit 89%, Covered 1%) AND Most used tags (public_transport 99.8%, name 99.7%, bus 98%, shelter 95%, bench 94%), rendered from stored counts. The query key `highway` (2419) is persisted but excluded from most-used. No console errors from the change.