### PR TITLE
feat(dataset-panel): category pill links to filtered area grid

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -132,6 +132,8 @@
     "backToArea": "← Back to {area}",
     "backToAreaLabel": "Back to {area}",
     "allDatasetsInArea": "All datasets in this area",
+    "categoryFacetLabel": "Category: {category}. View all {category} datasets in {area}.",
+    "categoryUncategorized": "Other",
     "back": "Back",
     "datasetStats": "Dataset Stats",
     "features": "Features",

--- a/messages/es.json
+++ b/messages/es.json
@@ -131,6 +131,8 @@
     "backToArea": "← Volver a {area}",
     "backToAreaLabel": "Volver a {area}",
     "allDatasetsInArea": "Todos los conjuntos de datos en esta área",
+    "categoryFacetLabel": "Categoría: {category}. Ver todos los conjuntos de datos de {category} en {area}.",
+    "categoryUncategorized": "Otros",
     "back": "Volver",
     "datasetStats": "Estadísticas del Conjunto de Datos",
     "features": "Elementos",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -131,6 +131,8 @@
     "backToArea": "← Voltar para {area}",
     "backToAreaLabel": "Voltar para {area}",
     "allDatasetsInArea": "Todos os conjuntos de dados nesta área",
+    "categoryFacetLabel": "Categoria: {category}. Ver todos os conjuntos de dados de {category} em {area}.",
+    "categoryUncategorized": "Outros",
     "back": "Voltar",
     "datasetStats": "Estatísticas do Conjunto de Dados",
     "features": "Feições",

--- a/src/components/dataset/category-facet.tsx
+++ b/src/components/dataset/category-facet.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { Dataset } from "@/schemas/dataset";
+import { Link } from "@/i18n/navigation";
+
+type CategoryFacetProps = {
+  dataset: Dataset;
+  areaName: string;
+};
+
+const chipClasses =
+  "inline-flex flex-none items-center rounded-full border border-olive-100 bg-olive-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-olive-700";
+
+/**
+ * The dataset's category as an olive chip. When the template has a category it
+ * links to the area's browse grid pre-filtered to that category
+ * (`/area/<id>?category=<slug>`), with an accessible label. Uncategorized
+ * templates fall back to a static "Other" chip (no link).
+ */
+export function CategoryFacet({ dataset, areaName }: CategoryFacetProps) {
+  const t = useTranslations("DatasetPage");
+  const category = dataset.template.category;
+
+  if (!category) {
+    return <span className={chipClasses}>{t("categoryUncategorized")}</span>;
+  }
+
+  return (
+    <Link
+      href={`/area/${dataset.area.id}?category=${category.slug}`}
+      aria-label={t("categoryFacetLabel", {
+        category: category.name,
+        area: areaName,
+      })}
+      className={`${chipClasses} transition-colors hover:border-olive-200 hover:bg-olive-100 hover:text-olive-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-olive-500`}
+    >
+      {category.name}
+    </Link>
+  );
+}

--- a/src/components/dataset/dataset-interactive-section.tsx
+++ b/src/components/dataset/dataset-interactive-section.tsx
@@ -8,6 +8,7 @@ import type { Dataset } from "@/schemas/dataset";
 import { Link } from "@/i18n/navigation";
 import { resolveAreaName } from "@/lib/area-name";
 import { DatasetMapWrapper, type DatasetFullMapHandle } from "@/components/dataset/map-wrapper";
+import { CategoryFacet } from "@/components/dataset/category-facet";
 import { DatasetInfoPanel } from "@/components/dataset/dataset-info-panel";
 import { DatasetPanelStats } from "@/components/dataset/dataset-panel-stats";
 import { DatasetTimestamps } from "@/components/dataset/dataset-timestamps";
@@ -81,9 +82,7 @@ export function DatasetInteractiveSection({
               {/* Metadata chip row: category facet (olive) + freshness chips
                   (edited, fetched) sharing one line below the title. */}
               <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                <span className="inline-flex flex-none items-center rounded-full border border-olive-100 bg-olive-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-olive-700">
-                  {dataset.template.category?.name ?? "other"}
-                </span>
+                <CategoryFacet dataset={dataset} areaName={areaName} />
                 <DatasetTimestamps dataset={dataset} lastChecked={lastChecked} />
               </div>
             </div>


### PR DESCRIPTION
@coderabbitai ignore

Sub-PR of #390 (dataset side-panel redesign). Targets the integration branch `feature/simplify-dataset-panel-rebased`, not develop.

**Problem:** The dataset panel's category chip was a static olive label — dead text, no way to see the category's siblings.

**Change:** Turn it into a link to `/area/<id>?category=<slug>`, which the area browse grid already pre-filters on via its existing `?category=` URL state. Extracted as `CategoryFacet`:
- Categorized template -> olive chip links to the pre-filtered grid, with an accessible label ("Category: {category}. View all {category} datasets in {area}.").
- Uncategorized template -> static "Other" chip, no link.
- Kept olive (facet) vs gray (freshness) chip coding; olive doubles as the link affordance (no icon/arrow, per review).

**i18n:** `categoryFacetLabel` + `categoryUncategorized` across en/es/pt-BR.

**Out of scope:** localizing category names (raw English today, unchanged); pushing grid sidebar clicks into the URL.

**Verify:** type-check, lint (0 errors), i18n:check clean. Live on Munich bus-stops: pill links to `?category=transportation`, click lands the grid pre-filtered to the 13 Transportation datasets.