### PR TITLE
refactor(dataset-panel): drop client geojson fallback for panel stats

### DIFF
--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -2,15 +2,13 @@
 
 import { useMemo } from "react";
 import type { ReactNode } from "react";
-import type { Feature } from "geojson";
 import { useTranslations, useLocale } from "next-intl";
 import { MapPin, Users, Target, Spline, Pentagon, Tag } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { Dataset } from "@/schemas/dataset";
 import { SegmentedBar, type BarSegment } from "@/components/ui/segmented-bar";
 import { formatCompactNumber } from "@/lib/dataset-stats";
-import { computeRecencyBands, RECENCY_BANDS } from "@/lib/dataset-recency";
-import { computeGeometryMix } from "@/lib/dataset-geometry";
+import { RECENCY_BANDS } from "@/lib/dataset-recency";
 import { tagLabel, type MessageResolver } from "@/lib/tag-i18n";
 
 type DatasetPanelStatsProps = {
@@ -43,29 +41,6 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   const tTagLabel = useTranslations("TagLabel") as unknown as MessageResolver;
   const locale = useLocale();
   const nf = useMemo(() => new Intl.NumberFormat(locale), [locale]);
-
-  // Panel bars derived from the geojson; null when none is shipped.
-  const derived = useMemo(() => {
-    const gj = dataset.geojson as { features?: Feature[] } | null;
-    if (!gj || !Array.isArray(gj.features) || gj.features.length === 0) {
-      return null;
-    }
-    const features = gj.features;
-    const now = Date.now();
-
-    // Same helpers the server uses, so these match the stored values.
-    const { editRecencyBands, mapperRecencyBands } = computeRecencyBands(
-      features,
-      now
-    );
-    const geometryMix = computeGeometryMix(features);
-
-    return {
-      editRecencyBands,
-      mapperRecencyBands,
-      geometryMix,
-    };
-  }, [dataset.geojson]);
 
   // Stored counts only — no client fallback (see dataset-tags).
   const tagCounts = dataset.stats?.tagCounts ?? null;
@@ -142,9 +117,9 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   // only needs to separate the slices. The legend always lists all three types:
   // points show their count, lines their total length, areas their total area;
   // absent types read "no lines" etc.
-  // Persisted mix if present, else derived from geojson; its own total is the
-  // bar denominator, so the section is self-contained.
-  const geometryMix = dataset.stats?.geometryMix ?? derived?.geometryMix ?? null;
+  // Persisted mix only; its own total is the bar denominator, so the section is
+  // self-contained.
+  const geometryMix = dataset.stats?.geometryMix ?? null;
   const geomTotal = geometryMix?.total ?? 0;
   const geomItems: GeomItem[] | null = geometryMix
     ? [
@@ -197,10 +172,8 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
       : null;
 
   // --- Freshness (recency of each feature's last edit) --------------------
-  // Priority: persisted bands -> geojson-derived -> legacy 3-band qualityMetrics.
-  const editBands =
-    bandsIfPopulated(dataset.stats?.editRecencyBands) ??
-    bandsIfPopulated(derived?.editRecencyBands);
+  // Priority: persisted bands -> legacy 3-band qualityMetrics.
+  const editBands = bandsIfPopulated(dataset.stats?.editRecencyBands);
   const stale = dataset.stats?.qualityMetrics?.staleElementsPercentage;
   const within1y = dataset.stats?.qualityMetrics?.recentlyUpdatedElementsPercentage;
   let freshnessSegments: BarSegment[] | null = null;
@@ -231,9 +204,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   }
 
   // --- Mappers (recency of each mapper's latest edit) --------------------
-  const mapperBands =
-    bandsIfPopulated(dataset.stats?.mapperRecencyBands) ??
-    bandsIfPopulated(derived?.mapperRecencyBands);
+  const mapperBands = bandsIfPopulated(dataset.stats?.mapperRecencyBands);
   const mappersSegments: BarSegment[] | null = mapperBands
     ? recencyBandSegments(mapperBands, recencyLabels, (_pct, count) =>
         nf.format(count)

--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -42,7 +42,6 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   const locale = useLocale();
   const nf = useMemo(() => new Intl.NumberFormat(locale), [locale]);
 
-  // Stored counts only — no client fallback (see dataset-tags).
   const tagCounts = dataset.stats?.tagCounts ?? null;
 
   // Keys used by the template's Overpass query (e.g. "highway=bus_stop" ->
@@ -116,9 +115,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
   // (500/400/300); the legend icons carry the point/line/area meaning, so color
   // only needs to separate the slices. The legend always lists all three types:
   // points show their count, lines their total length, areas their total area;
-  // absent types read "no lines" etc.
-  // Persisted mix only; its own total is the bar denominator, so the section is
-  // self-contained.
+  // absent types read "no lines" etc. The mix's own total is the bar denominator.
   const geometryMix = dataset.stats?.geometryMix ?? null;
   const geomTotal = geometryMix?.total ?? 0;
   const geomItems: GeomItem[] | null = geometryMix


### PR DESCRIPTION
## What

Stacked on #390. Removes the panel stats' client geojson `derived` fallback. Freshness/mappers recency bands and geometry mix now resolve from persisted `Dataset.stats` only.

## Why

The fallback existed for datasets saved before stat persistence (#388/#392/#394, all on the #390 branch). The daily update job recomputes and stores every stat slice, so legacy datasets self-heal within 24h. The fallback is now effectively dead code.

## Scope

- Panel no longer reads `dataset.geojson` (removes the `derived` memo + now-unused imports).
- Legacy 3-band `qualityMetrics` fallback for freshness kept as-is.
- geojson still ships in the page: the map reads it directly. Cutting it from the shared select + lazy-loading the map is a separate follow-up (real payload win).

## Exposure

< 24h window after deploy: legacy datasets not yet updated show empty freshness/geometry charts instead of geojson-derived ones. Transient, self-healing, cosmetic.

## Verification

- `pnpm type-check` clean
- `pnpm eslint` on changed file clean
- helper unit tests (recency/geometry/tags) pass
