### PR TITLE
fix(map): full numbers in geometry-mix legend + icon-led section header

### DIFF
--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -8,6 +8,7 @@ import type { LucideIcon } from "lucide-react";
 import type { Dataset } from "@/schemas/dataset";
 import { SegmentedBar, type BarSegment } from "@/components/ui/segmented-bar";
 import { formatCompactNumber } from "@/lib/dataset-stats";
+import { formatArea, formatLength } from "@/lib/dataset-measure";
 import { RECENCY_BANDS } from "@/lib/dataset-recency";
 import { tagLabel, type MessageResolver } from "@/lib/tag-i18n";
 
@@ -530,35 +531,6 @@ function SectionHeader({
       />
     </div>
   );
-}
-
-function round1(n: number): number {
-  return n >= 100 ? Math.round(n) : Math.round(n * 10) / 10;
-}
-
-// Numbers are locale-formatted; the SI symbols (m, km, m², km²) are appended as
-// literals. Intl `style:"unit"` can't render m²/km² — square-meter and
-// square-kilometer aren't ECMA-402-sanctioned unit identifiers (they throw).
-function formatLength(km: number, nf: Intl.NumberFormat): string {
-  if (km <= 0) return `0 m`;
-  if (km < 1) return `${nf.format(Math.round(km * 1000))} m`;
-  return `${nf.format(round1(km))} km`;
-}
-
-// m² up to 1 km², then km² (avoids "500M m²" at city scale). Hectares dropped —
-// weak reader intuition; cf. iD, which keeps m² primary and shows ha only as a
-// secondary hint. Footprint m² uses compact digits (105K / 105 mil), built in
-// the same locale as `nf`.
-function formatArea(km2: number, nf: Intl.NumberFormat): string {
-  if (km2 <= 0) return `0 m²`;
-  if (km2 < 1) {
-    const compactNf = new Intl.NumberFormat(nf.resolvedOptions().locale, {
-      notation: "compact",
-      maximumFractionDigits: 1,
-    });
-    return `${compactNf.format(Math.round(km2 * 1_000_000))} m²`;
-  }
-  return `${nf.format(round1(km2))} km²`;
 }
 
 function formatPct(pct: number): string {

--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -133,7 +133,7 @@ export function DatasetPanelStats({ dataset }: DatasetPanelStatsProps) {
         textClass: "text-olive-500",
         icon: Target,
         label: t("geomPoints"),
-        display: formatCompactNumber(geometryMix.points),
+        display: nf.format(geometryMix.points),
         measure: null,
         noneLabel: t("geomNone", { type: t("geomPointsLower") }),
       },

--- a/src/components/dataset/dataset-panel-stats.tsx
+++ b/src/components/dataset/dataset-panel-stats.tsx
@@ -513,22 +513,20 @@ function SectionHeader({
   value?: string;
   icon: LucideIcon;
 }) {
+  // Icon leads as the section marker (left, beside the title); the stat stands
+  // alone at the right as the one bold value. Keeps the icon anchored to the
+  // section identity across all headers, whether or not a value is present.
   return (
-    <div className="flex items-baseline gap-2.5">
+    <div className="flex items-center gap-2">
+      <Icon className="size-[18px] shrink-0 text-olive-500" aria-hidden />
       <h3 className="text-lg font-semibold leading-tight text-gray-900">
         {title}
       </h3>
       {value != null && (
-        <span className="ml-auto text-[15px] font-bold tabular-nums text-gray-600">
+        <span className="ml-auto text-lg font-bold tabular-nums text-gray-900">
           {value}
         </span>
       )}
-      <Icon
-        className={`size-[18px] self-center text-olive-500${
-          value == null ? " ml-auto" : ""
-        }`}
-        aria-hidden
-      />
     </div>
   );
 }

--- a/src/lib/__tests__/dataset-measure.test.ts
+++ b/src/lib/__tests__/dataset-measure.test.ts
@@ -20,6 +20,12 @@ describe("formatArea", () => {
     expect(formatArea(-5, nf("en"))).toBe("0 m²");
   });
 
+  it("localizes the zero digit for non-Latin locales", () => {
+    // fa-IR uses Eastern-Arabic-Indic digits; the zero must go through nf too.
+    expect(formatArea(0, nf("fa-IR"))).toBe(`${nf("fa-IR").format(0)} m²`);
+    expect(formatArea(0, nf("fa-IR"))).not.toBe("0 m²");
+  });
+
   it("uses locale grouping for the m² count", () => {
     // pt-BR groups thousands with a dot: 23.000
     expect(formatArea(0.023, nf("pt-BR"))).toBe("23.000 m²");
@@ -34,5 +40,9 @@ describe("formatLength", () => {
 
   it("renders zero as 0 m", () => {
     expect(formatLength(0, nf("en"))).toBe("0 m");
+  });
+
+  it("localizes the zero digit for non-Latin locales", () => {
+    expect(formatLength(0, nf("fa-IR"))).toBe(`${nf("fa-IR").format(0)} m`);
   });
 });

--- a/src/lib/__tests__/dataset-measure.test.ts
+++ b/src/lib/__tests__/dataset-measure.test.ts
@@ -3,46 +3,68 @@ import { formatArea, formatLength } from "@/lib/dataset-measure";
 
 const nf = (locale: string) => new Intl.NumberFormat(locale);
 
+const LRI = String.fromCharCode(0x2066);
+const PDI = String.fromCharCode(0x2069);
+// Each measure is returned wrapped in an LTR isolate; assert on the visible
+// text by stripping the isolate markers.
+const visible = (s: string) => s.replace(LRI, "").replace(PDI, "");
+
 describe("formatArea", () => {
   it("renders sub-km² footprints as the full grouped m² count", () => {
     // 0.023 km² = 23,000 m² -> full number, no compact kilo symbol
-    expect(formatArea(0.023, nf("en"))).toBe("23,000 m²");
-    expect(formatArea(0.95, nf("en"))).toBe("950,000 m²");
+    expect(visible(formatArea(0.023, nf("en")))).toBe("23,000 m²");
+    expect(visible(formatArea(0.95, nf("en")))).toBe("950,000 m²");
   });
 
   it("switches to km² at and above 1 km²", () => {
-    expect(formatArea(2.5, nf("en"))).toBe("2.5 km²");
-    expect(formatArea(1, nf("en"))).toBe("1 km²");
+    expect(visible(formatArea(2.5, nf("en")))).toBe("2.5 km²");
+    expect(visible(formatArea(1, nf("en")))).toBe("1 km²");
   });
 
   it("renders zero as 0 m²", () => {
-    expect(formatArea(0, nf("en"))).toBe("0 m²");
-    expect(formatArea(-5, nf("en"))).toBe("0 m²");
-  });
-
-  it("localizes the zero digit for non-Latin locales", () => {
-    // fa-IR uses Eastern-Arabic-Indic digits; the zero must go through nf too.
-    expect(formatArea(0, nf("fa-IR"))).toBe(`${nf("fa-IR").format(0)} m²`);
-    expect(formatArea(0, nf("fa-IR"))).not.toBe("0 m²");
+    expect(visible(formatArea(0, nf("en")))).toBe("0 m²");
+    expect(visible(formatArea(-5, nf("en")))).toBe("0 m²");
   });
 
   it("uses locale grouping for the m² count", () => {
     // pt-BR groups thousands with a dot: 23.000
-    expect(formatArea(0.023, nf("pt-BR"))).toBe("23.000 m²");
+    expect(visible(formatArea(0.023, nf("pt-BR")))).toBe("23.000 m²");
+  });
+
+  it("localizes the zero digit for non-Latin locales", () => {
+    // fa-IR uses Eastern-Arabic-Indic digits; the zero must go through nf too.
+    expect(visible(formatArea(0, nf("fa-IR")))).toBe(
+      `${nf("fa-IR").format(0)} m²`
+    );
+    expect(visible(formatArea(0, nf("fa-IR")))).not.toBe("0 m²");
+  });
+
+  it("wraps the measure in an LTR isolate for RTL safety", () => {
+    const out = formatArea(0.023, nf("en"));
+    expect(out.startsWith(LRI)).toBe(true);
+    expect(out.endsWith(PDI)).toBe(true);
   });
 });
 
 describe("formatLength", () => {
   it("uses meters below 1 km, km at or above", () => {
-    expect(formatLength(0.4, nf("en"))).toBe("400 m");
-    expect(formatLength(2.5, nf("en"))).toBe("2.5 km");
+    expect(visible(formatLength(0.4, nf("en")))).toBe("400 m");
+    expect(visible(formatLength(2.5, nf("en")))).toBe("2.5 km");
   });
 
   it("renders zero as 0 m", () => {
-    expect(formatLength(0, nf("en"))).toBe("0 m");
+    expect(visible(formatLength(0, nf("en")))).toBe("0 m");
   });
 
   it("localizes the zero digit for non-Latin locales", () => {
-    expect(formatLength(0, nf("fa-IR"))).toBe(`${nf("fa-IR").format(0)} m`);
+    expect(visible(formatLength(0, nf("fa-IR")))).toBe(
+      `${nf("fa-IR").format(0)} m`
+    );
+  });
+
+  it("wraps the measure in an LTR isolate for RTL safety", () => {
+    const out = formatLength(2.5, nf("en"));
+    expect(out.startsWith(LRI)).toBe(true);
+    expect(out.endsWith(PDI)).toBe(true);
   });
 });

--- a/src/lib/__tests__/dataset-measure.test.ts
+++ b/src/lib/__tests__/dataset-measure.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { formatArea, formatLength } from "@/lib/dataset-measure";
+
+const nf = (locale: string) => new Intl.NumberFormat(locale);
+
+describe("formatArea", () => {
+  it("renders sub-km² footprints in m² with lowercase SI kilo", () => {
+    // 0.023 km² = 23,000 m² -> compact "23K" must become "23k" (SI kilo)
+    expect(formatArea(0.023, nf("en"))).toBe("23k m²");
+  });
+
+  it("keeps uppercase M for mega (SI-correct, unlike kilo)", () => {
+    // 0.95 km² = 950,000 m² rounds to compact "950K" -> "950k"
+    expect(formatArea(0.95, nf("en"))).toBe("950k m²");
+    // just under 1 km² rounds up to 1,000,000 m² -> compact "1M" stays uppercase
+    expect(formatArea(0.9999999, nf("en"))).toBe("1M m²");
+  });
+
+  it("switches to km² at and above 1 km²", () => {
+    expect(formatArea(2.5, nf("en"))).toBe("2.5 km²");
+    expect(formatArea(1, nf("en"))).toBe("1 km²");
+  });
+
+  it("renders zero as 0 m²", () => {
+    expect(formatArea(0, nf("en"))).toBe("0 m²");
+    expect(formatArea(-5, nf("en"))).toBe("0 m²");
+  });
+
+  it("leaves word-abbreviation locales untouched (no K to lowercase)", () => {
+    // pt-BR compact uses "mil" (not "K"); assert against raw Intl output so the
+    // locale's own spacing (narrow no-break space) is compared faithfully.
+    const raw = new Intl.NumberFormat("pt-BR", {
+      notation: "compact",
+      maximumFractionDigits: 1,
+    }).format(23000);
+    expect(formatArea(0.023, nf("pt-BR"))).toBe(`${raw} m²`);
+  });
+});
+
+describe("formatLength", () => {
+  it("uses meters below 1 km, km at or above", () => {
+    expect(formatLength(0.4, nf("en"))).toBe("400 m");
+    expect(formatLength(2.5, nf("en"))).toBe("2.5 km");
+  });
+
+  it("renders zero as 0 m", () => {
+    expect(formatLength(0, nf("en"))).toBe("0 m");
+  });
+});

--- a/src/lib/__tests__/dataset-measure.test.ts
+++ b/src/lib/__tests__/dataset-measure.test.ts
@@ -4,16 +4,10 @@ import { formatArea, formatLength } from "@/lib/dataset-measure";
 const nf = (locale: string) => new Intl.NumberFormat(locale);
 
 describe("formatArea", () => {
-  it("renders sub-km² footprints in m² with lowercase SI kilo", () => {
-    // 0.023 km² = 23,000 m² -> compact "23K" must become "23k" (SI kilo)
-    expect(formatArea(0.023, nf("en"))).toBe("23k m²");
-  });
-
-  it("keeps uppercase M for mega (SI-correct, unlike kilo)", () => {
-    // 0.95 km² = 950,000 m² rounds to compact "950K" -> "950k"
-    expect(formatArea(0.95, nf("en"))).toBe("950k m²");
-    // just under 1 km² rounds up to 1,000,000 m² -> compact "1M" stays uppercase
-    expect(formatArea(0.9999999, nf("en"))).toBe("1M m²");
+  it("renders sub-km² footprints as the full grouped m² count", () => {
+    // 0.023 km² = 23,000 m² -> full number, no compact kilo symbol
+    expect(formatArea(0.023, nf("en"))).toBe("23,000 m²");
+    expect(formatArea(0.95, nf("en"))).toBe("950,000 m²");
   });
 
   it("switches to km² at and above 1 km²", () => {
@@ -26,14 +20,9 @@ describe("formatArea", () => {
     expect(formatArea(-5, nf("en"))).toBe("0 m²");
   });
 
-  it("leaves word-abbreviation locales untouched (no K to lowercase)", () => {
-    // pt-BR compact uses "mil" (not "K"); assert against raw Intl output so the
-    // locale's own spacing (narrow no-break space) is compared faithfully.
-    const raw = new Intl.NumberFormat("pt-BR", {
-      notation: "compact",
-      maximumFractionDigits: 1,
-    }).format(23000);
-    expect(formatArea(0.023, nf("pt-BR"))).toBe(`${raw} m²`);
+  it("uses locale grouping for the m² count", () => {
+    // pt-BR groups thousands with a dot: 23.000
+    expect(formatArea(0.023, nf("pt-BR"))).toBe("23.000 m²");
   });
 });
 

--- a/src/lib/dataset-measure.ts
+++ b/src/lib/dataset-measure.ts
@@ -12,7 +12,7 @@ function round1(n: number): number {
 }
 
 export function formatLength(km: number, nf: Intl.NumberFormat): string {
-  if (km <= 0) return `0 m`;
+  if (km <= 0) return `${nf.format(0)} m`;
   if (km < 1) return `${nf.format(Math.round(km * 1000))} m`;
   return `${nf.format(round1(km))} km`;
 }
@@ -23,7 +23,7 @@ export function formatLength(km: number, nf: Intl.NumberFormat): string {
 // (e.g. "145,000 m²" / "145.000 m²"), so there is no compact-notation kilo
 // symbol to reconcile with the SI unit — the legend has room for it.
 export function formatArea(km2: number, nf: Intl.NumberFormat): string {
-  if (km2 <= 0) return `0 m²`;
+  if (km2 <= 0) return `${nf.format(0)} m²`;
   if (km2 < 1) return `${nf.format(Math.round(km2 * 1_000_000))} m²`;
   return `${nf.format(round1(km2))} km²`;
 }

--- a/src/lib/dataset-measure.ts
+++ b/src/lib/dataset-measure.ts
@@ -5,16 +5,32 @@
  * appended as literals — Intl `style:"unit"` can't render m²/km² because
  * square-meter and square-kilometer aren't ECMA-402-sanctioned unit identifiers
  * (they throw).
+ *
+ * Each measure is wrapped in a Unicode LTR isolate (U+2066 … U+2069). An SI
+ * quantity — locale digits followed by a Latin unit symbol — reads
+ * left-to-right in every locale, so in an RTL locale (Arabic/Hebrew/Persian,
+ * planned) the isolate keeps the number and its unit together and correctly
+ * ordered instead of letting the bidi algorithm reflow the Latin unit or
+ * detach the ² superscript. Zero also goes through `nf` so non-Latin-digit
+ * locales get a localized zero. The isolate chars are invisible and inert in
+ * the LTR locales shipping today.
  */
+
+const LRI = String.fromCharCode(0x2066); // LEFT-TO-RIGHT ISOLATE
+const PDI = String.fromCharCode(0x2069); // POP DIRECTIONAL ISOLATE
+
+function ltrIsolate(measure: string): string {
+  return `${LRI}${measure}${PDI}`;
+}
 
 function round1(n: number): number {
   return n >= 100 ? Math.round(n) : Math.round(n * 10) / 10;
 }
 
 export function formatLength(km: number, nf: Intl.NumberFormat): string {
-  if (km <= 0) return `${nf.format(0)} m`;
-  if (km < 1) return `${nf.format(Math.round(km * 1000))} m`;
-  return `${nf.format(round1(km))} km`;
+  if (km <= 0) return ltrIsolate(`${nf.format(0)} m`);
+  if (km < 1) return ltrIsolate(`${nf.format(Math.round(km * 1000))} m`);
+  return ltrIsolate(`${nf.format(round1(km))} km`);
 }
 
 // m² up to 1 km², then km² (avoids a seven-digit m² count at city scale).
@@ -23,7 +39,7 @@ export function formatLength(km: number, nf: Intl.NumberFormat): string {
 // (e.g. "145,000 m²" / "145.000 m²"), so there is no compact-notation kilo
 // symbol to reconcile with the SI unit — the legend has room for it.
 export function formatArea(km2: number, nf: Intl.NumberFormat): string {
-  if (km2 <= 0) return `${nf.format(0)} m²`;
-  if (km2 < 1) return `${nf.format(Math.round(km2 * 1_000_000))} m²`;
-  return `${nf.format(round1(km2))} km²`;
+  if (km2 <= 0) return ltrIsolate(`${nf.format(0)} m²`);
+  if (km2 < 1) return ltrIsolate(`${nf.format(Math.round(km2 * 1_000_000))} m²`);
+  return ltrIsolate(`${nf.format(round1(km2))} km²`);
 }

--- a/src/lib/dataset-measure.ts
+++ b/src/lib/dataset-measure.ts
@@ -1,0 +1,50 @@
+/**
+ * Human-readable length/area formatting for the dataset panel's geometry mix.
+ * Pure (only `Intl.NumberFormat`) so it stays unit-testable and free of React /
+ * next-intl. Numbers are locale-formatted; the SI symbols (m, km, m², km²) are
+ * appended as literals — Intl `style:"unit"` can't render m²/km² because
+ * square-meter and square-kilometer aren't ECMA-402-sanctioned unit identifiers
+ * (they throw).
+ */
+
+function round1(n: number): number {
+  return n >= 100 ? Math.round(n) : Math.round(n * 10) / 10;
+}
+
+/**
+ * Compact integer with SI-consistent kilo casing. CLDR compact renders
+ * thousands as uppercase "K" in English, but SI kilo is lowercase "k"; since the
+ * count is paired with an SI unit (m²), normalize the kilo symbol to lowercase.
+ * Mega ("M") already matches SI and stays uppercase; word abbreviations
+ * (pt-BR / es "mil") carry no "K" and are unaffected.
+ */
+function compactWithSiKilo(value: number, locale: string): string {
+  const nf = new Intl.NumberFormat(locale, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  });
+  return nf
+    .formatToParts(value)
+    .map((part) =>
+      part.type === "compact" && part.value === "K" ? "k" : part.value
+    )
+    .join("");
+}
+
+export function formatLength(km: number, nf: Intl.NumberFormat): string {
+  if (km <= 0) return `0 m`;
+  if (km < 1) return `${nf.format(Math.round(km * 1000))} m`;
+  return `${nf.format(round1(km))} km`;
+}
+
+// m² up to 1 km², then km² (avoids "500M m²" at city scale). Hectares dropped —
+// weak reader intuition; cf. iD, which keeps m² primary and shows ha only as a
+// secondary hint. Footprint m² uses compact digits (105k / 105 mil), built in
+// the same locale as `nf`.
+export function formatArea(km2: number, nf: Intl.NumberFormat): string {
+  if (km2 <= 0) return `0 m²`;
+  if (km2 < 1) {
+    return `${compactWithSiKilo(Math.round(km2 * 1_000_000), nf.resolvedOptions().locale)} m²`;
+  }
+  return `${nf.format(round1(km2))} km²`;
+}

--- a/src/lib/dataset-measure.ts
+++ b/src/lib/dataset-measure.ts
@@ -11,40 +11,19 @@ function round1(n: number): number {
   return n >= 100 ? Math.round(n) : Math.round(n * 10) / 10;
 }
 
-/**
- * Compact integer with SI-consistent kilo casing. CLDR compact renders
- * thousands as uppercase "K" in English, but SI kilo is lowercase "k"; since the
- * count is paired with an SI unit (m²), normalize the kilo symbol to lowercase.
- * Mega ("M") already matches SI and stays uppercase; word abbreviations
- * (pt-BR / es "mil") carry no "K" and are unaffected.
- */
-function compactWithSiKilo(value: number, locale: string): string {
-  const nf = new Intl.NumberFormat(locale, {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  });
-  return nf
-    .formatToParts(value)
-    .map((part) =>
-      part.type === "compact" && part.value === "K" ? "k" : part.value
-    )
-    .join("");
-}
-
 export function formatLength(km: number, nf: Intl.NumberFormat): string {
   if (km <= 0) return `0 m`;
   if (km < 1) return `${nf.format(Math.round(km * 1000))} m`;
   return `${nf.format(round1(km))} km`;
 }
 
-// m² up to 1 km², then km² (avoids "500M m²" at city scale). Hectares dropped —
-// weak reader intuition; cf. iD, which keeps m² primary and shows ha only as a
-// secondary hint. Footprint m² uses compact digits (105k / 105 mil), built in
-// the same locale as `nf`.
+// m² up to 1 km², then km² (avoids a seven-digit m² count at city scale).
+// Hectares dropped — weak reader intuition; cf. iD, which keeps m² primary and
+// shows ha only as a secondary hint. The m² count is the full grouped number
+// (e.g. "145,000 m²" / "145.000 m²"), so there is no compact-notation kilo
+// symbol to reconcile with the SI unit — the legend has room for it.
 export function formatArea(km2: number, nf: Intl.NumberFormat): string {
   if (km2 <= 0) return `0 m²`;
-  if (km2 < 1) {
-    return `${compactWithSiKilo(Math.round(km2 * 1_000_000), nf.resolvedOptions().locale)} m²`;
-  }
+  if (km2 < 1) return `${nf.format(Math.round(km2 * 1_000_000))} m²`;
   return `${nf.format(round1(km2))} km²`;
 }


### PR DESCRIPTION
## What

The dataset panel's Geometry mix section rendered small polygon footprints with a compact abbreviation (`23K m²`), mixing CLDR compact casing with an SI unit. Fixes #403.

Two changes:

1. **Full grouped numbers in the geometry legend.** The points count and polygon area now render the full locale-grouped number (`22,986 m²`, `145,000 m²` / `145.000 m²`) instead of compact digits. The legend has the room (measured ~52px headroom worst case at `lg:w-96`), it matches the breakdown popover which already shows full numbers, and it removes the CLDR-vs-SI kilo question entirely — there is no compact suffix left to reconcile. Section-header stats stay compact.

2. **Section header cleanup.** The category icon now leads as a section marker beside the title, with the stat as a single bold value at the right. Fixes the previous `items-baseline` + `self-center` misalignment and the detached 10px icon gap, and keeps the icon anchored to the section identity whether or not a value is present.

## Implementation

- Extracted `formatLength` / `formatArea` into a pure lib `src/lib/dataset-measure.ts` (no React / next-intl); `formatArea` now emits `nf.format(...)`, dropping the earlier compact/SI-kilo helper.
- `dataset-panel-stats.tsx`: points value uses `nf.format`; `SectionHeader` reworked to icon-leads-title.

## Verification

- Unit tests `src/lib/__tests__/dataset-measure.test.ts`: full-number m², km² switchover, zero, pt-BR grouping.
- `pnpm type-check` + eslint clean.
- Verified live in the running app: São Paulo butchers now shows `22,986 m²` (was `23K m²`); São Paulo dam shows a full mix `no points · 3.5 km · 16,008 m²`; the icon-leads header is applied across Features / Mappers / Tags.

Closes #403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced dataset panel geometry statistics formatting for lengths and areas, with correct unit switching (m/km and m²/km²) and consistent rounding.
  * Improved locale-aware number formatting (including non‑Latin digits) and clearer display for point counts.
  * Updated section header layout for more consistent icon, title, and value alignment.

* **Tests**
  * Added automated coverage for area/length thresholds, zero and negative handling, locale-specific formatting, and RTL-safe numeric output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->