### PR TITLE
feat(templates): template-management workflow + demonstrator registry

### DIFF
--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -53,27 +53,21 @@ Lucide `icon` (validated by `pnpm generate-icons`). Add name/description to
 
 A key belongs in the allow-list only if it is **both**:
 
-- **well covered** — a meaningful share of features carry it (read the Critical
-  coverage block), and
-- **multi-valued** — it takes more than one value, so coloring produces a real legend
-  rather than one flat color.
+- **well covered** — a meaningful share of features carry it, and
+- **not the same value on every feature** — or coloring is one flat blob.
 
-Both tests matter. `public_transport` sits near 100% on bus stops but is almost always
-the single value `platform` (PTv2 co-tags `highway=bus_stop` with
-`public_transport=platform`), so it colors as one blob — high coverage, no diversity,
-not a good view. A yes/no key like `shelter`, or a many-valued key like `operator`,
-passes both tests.
+Drop a key only when it is near-absent (`covered` on bus-stops) or truly single-valued
+everywhere (`public_transport=platform`, which PTv2 co-tags on every stop). A *skewed*
+distribution is fine and even valuable: `operator` on `bicycle-rental` is mostly one
+value (a city has one bike-share system), but the stray outliers it surfaces — a second
+operator, a mis-tagged dock — are exactly the data deviations OSM for Cities exists to
+flag. Don't require an even spread.
 
 Tune in both directions, using the dashboard's "Most used tags" list as the menu:
 
-- **Reduce** — drop keys whose coverage is near-zero across the demonstrators. (The
-  `bus-stops` allow-list dropped `covered` for this reason: it is redundant with
-  `shelter` and barely tagged anywhere.)
-- **Widen** — promote a high-usage, multi-valued key into the list. (`operator` was
-  added to `bus-stops`. Note coverage can be regional — some communities tag `operator`
-  on every stop, others almost never — so a widened key may render richly in one
-  demonstrator and mostly "Missing" in another. That is acceptable and itself
-  informative; the legend handles Missing.)
+- **Reduce** — drop keys near-zero across the demonstrators.
+- **Widen** — promote a high-usage, varied key. Coverage can be regional (rich in one
+  demonstrator, mostly "Missing" in another); that is fine — the legend handles Missing.
 
 For every key added, add a `TagLabel` in `messages/en.json`, `es.json`, and
 `pt-BR.json`. Values render from `TagValue` with a raw fallback, so controlled-value
@@ -109,6 +103,16 @@ dataset-page toggle. Keep the total active/featured set bounded.
 Commit `templates.yml`, `templates.i18n.yml`, and any `messages/*.json`. Do not open a
 PR or push until the maintainer says so. On merge, deploy runs `db:sync`; templates
 removed from the YAML soft-deprecate (30 days) then delete.
+
+## Worked examples
+
+- **bus-stops** — tags sit on the node, so `shelter`/`bench`/`lit`/`tactile_paving` are
+  well-covered binaries. Dropped `covered` (near-absent), added `operator`.
+- **bicycle-rental** — `[bicycle_rental, operator, network, capacity]`. Skewed (one
+  bike-share system per city) but kept: the outliers are worth surfacing.
+- **tram-stops — rejected.** `railway=tram_stop` marks the trackside point; amenities
+  live on the separate `public_transport=platform` node, so the queried node has nothing
+  to filter. Check the interesting tags sit on the queried element, not a sibling.
 
 ## Validation the sync enforces
 

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -119,7 +119,9 @@ active/featured set bounded.
 
 ## Validation the sync enforces
 
-`prisma/lib/template-parser.ts` fails `pnpm db:sync`/CI on: unknown parent id, unknown
-template id under `filterableTags`/`demonstrators`, and malformed demonstrator entries
-(missing/non-integer `area`, non-string `note`). Tests:
+`prisma/lib/template-parser.ts` fails `pnpm db:sync`/CI on: unknown parent id, and a
+`demonstrators` section that is malformed (scalar/array root, unknown template id,
+missing/non-integer `area`, non-string `note`). An unknown template id under
+`filterableTags` is a non-blocking **warning**, not an error — a typo there only leaves
+that one template age-view-only, so it never blocks the seed/deploy. Tests:
 `prisma/lib/__tests__/template-parser.test.ts`.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -58,6 +58,11 @@ everywhere (`public_transport=platform`, PTv2-co-tagged on every stop), not
 wiki-relevant, or fragmented across many keys (EV connectors live in count-valued
 `socket:type2`/`socket:type2_combo`/… with no single key to color by).
 
+Coverage never qualifies a key on its own — a well-covered `ref` or `name` is still just
+a unique code, not a filter. Confirm every candidate against the OSM wiki first. If this
+measurement is delegated to a subagent, the subagent must do the wiki cross-check too
+(usability-relevance per key), not report Overpass/dashboard coverage alone.
+
 A *skewed* distribution is fine and valuable: `operator` on `bicycle-rental` is mostly
 one value (a city has one bike-share system), but the stray outliers it surfaces — a
 second operator, a mis-tagged dock — are exactly the deviations OSM for Cities exists to
@@ -104,6 +109,10 @@ active/featured set bounded.
   (classic) and `crossing:markings` (newer split) are kept — communities favor one or the
   other, so coverage is regional. Dropped `kerb` (6-15% in most cities; it belongs on the
   separate sidewalk `barrier=kerb` node, not the crossing — same sibling-node trap).
+- **railway-stations** — `[station, wheelchair, operator, network]`; the mode and
+  accessibility tags sit on the station node itself. Dropped `public_transport` (=station
+  everywhere, single-valued) and the `train`/`subway`/`light_rail` boolean siblings (mode
+  is already in `station=`); excluded `ref`/`name` (unique codes/labels, not categories).
 - **tram-stops — rejected.** `railway=tram_stop` marks the trackside point; amenities
   live on the separate `public_transport=platform` node, so the queried node has nothing
   to filter. Check the interesting tags sit on the queried element, not a sibling.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -3,113 +3,103 @@
 How a template gets proposed, defined, validated against real cities, and shipped.
 Written to be run by a coding agent end to end.
 
-Templates are defined in `prisma/templates.yml` (logic) + `prisma/templates.i18n.yml`
-(translations) and synced to the DB by `prisma/sync-templates.ts` (`pnpm db:sync`).
-There is no admin UI — the YAML is the source of truth, and deploy runs the sync.
+Templates live in `prisma/templates.yml` (logic) + `prisma/templates.i18n.yml`
+(translations), synced to the DB by `prisma/sync-templates.ts` (`pnpm db:sync`). The
+YAML is the source of truth; deploy runs the sync. No admin UI.
 
 ## Definitions
 
-- **Template** — an OSM selector (`highway=bus_stop`) plus a category, icon, optional
-  parent, and an optional `filterableTags` allow-list. Rows in `templates.yml`:
-  `[id, query, category, icon?, parent?]`. Query syntax: `;` = OR, `&` = AND,
-  `*`/empty = wildcard; `{OSM_RELATION_ID}` is substituted per area at fetch time.
-- **Sub-template** — a template with a `parent`. Use it when the query is a strict
-  subset/specialisation of a broader template (e.g. `bicycle-parking` under
-  `bicycle-infrastructure`, `bus-stops` under `public-transit`). If it stands alone
-  conceptually, keep it top-level.
-- **filterableTags** — a curated allow-list of OSM tag *keys* (top-level
-  `filterableTags:` map) that become interactive-legend "Color by" views and the
-  "Critical coverage" stat block on the dataset dashboard. Absent → age view only.
-  Each key needs a `TagLabel` entry in every `messages/*.json`.
-- **Demonstrator** — an OSM relation id (top-level `demonstrators:` map) whose real
-  data shows the template at its best. Curation only: validated by the sync, never
-  written to the DB. The workflow reads it to decide which datasets to inspect/seed.
+- **Template** — an OSM selector (`highway=bus_stop`) plus category, icon, optional
+  parent, and optional `filterableTags`. Row: `[id, query, category, icon?, parent?]`.
+  Query syntax: `;` = OR, `&` = AND, `*`/empty = wildcard; `{OSM_RELATION_ID}` is
+  substituted per area at fetch time.
+- **Sub-template** — a template with a `parent`. Use when the query is a strict subset
+  of a broader template (`bus-stops` under `public-transit`). Standalone → top-level.
+- **filterableTags** — an allow-list of OSM tag *keys* (top-level `filterableTags:` map)
+  that become interactive-legend "Color by" views + the "Critical coverage" stat block.
+  Absent → age view only. Each key needs a `TagLabel` in every `messages/*.json`.
+- **Demonstrator** — an OSM relation id (top-level `demonstrators:` map) whose real data
+  shows the template at its best. Curation only: validated by the sync, never written to
+  the DB. The workflow reads it to decide which datasets to inspect/seed.
 
 ## The dashboard is the validation tool
 
-There is no separate preview. To inspect a template, a **signed-in** agent opens
-`/area/{relationId}/dataset/{templateId}` — the page creates the dataset on view
-(fetches the Overpass snapshot + stats) and renders the real dashboard. Read numbers
-live from the dashboard; do not copy them into the YAML (they drift as OSM changes).
+No separate preview. A **signed-in** agent opens `/area/{relationId}/dataset/{templateId}`
+— the page creates the dataset on view (Overpass snapshot + stats) and renders the real
+dashboard. Read numbers live; never copy them into the YAML (they drift as OSM changes).
 
-Prerequisites: local dev server, signed in (osmforcities-dev-auth), Overpass tunnel up
+Prereqs: local dev server, signed in (osmforcities-dev-auth), Overpass tunnel up
 (infra-overpass-tunnel). Resolve relation ids from Nominatim.
 
 ## Workflow
 
-### 1. Propose
+1. **Propose** — a template is worth adding when it maps a distinct civic need, has a
+   clean wiki-documented selector, and is neither so broad it trips the size cap nor so
+   rare it is empty in most cities.
+2. **Define** — add the row, pick a seeded `category`, decide parent, add a Lucide `icon`
+   (validated by `pnpm generate-icons`), add name/description to `templates.i18n.yml`.
+   `pnpm db:sync`.
+3. **Choose `filterableTags`** — see below.
+4. **Pick demonstrators** — see below.
+5. **Seed / feature** — see Overpass budget below.
+6. **Ship** — commit `templates.yml`, `templates.i18n.yml`, `messages/*.json`. Don't push
+   or open a PR until the maintainer says so. On merge, deploy runs `db:sync`; removed
+   templates soft-deprecate (30 days) then delete.
 
-A template is worth adding when it maps a distinct civic need, has a clean selector
-that is documented on the OSM wiki, and is neither so broad it trips the size cap nor
-so rare it is empty in most cities.
+### Tuning `filterableTags` from the dashboard
 
-### 2. Define in `templates.yml`
+Start from the OSM wiki page for the selector — it names the tags that describe the
+feature's real-world usability (for `amenity=charging_station`: capacity, connector,
+access, operator, fee). Shortlist those, then keep a key only if it is **both** well
+covered on the dashboard (a meaningful share of features carry it) **and** not the same
+value on every feature (or coloring is one flat blob), **and** exists as a single
+colorable key. Drop a key when near-absent (`covered` on bus-stops), truly single-valued
+everywhere (`public_transport=platform`, PTv2-co-tagged on every stop), not
+wiki-relevant, or fragmented across many keys (EV connectors live in count-valued
+`socket:type2`/`socket:type2_combo`/… with no single key to color by).
 
-Add the row, pick a seeded `category`, decide parent (see sub-template above), add a
-Lucide `icon` (validated by `pnpm generate-icons`). Add name/description to
-`templates.i18n.yml`. Run `pnpm db:sync` to apply.
-
-### 3. Choose `filterableTags` — tune from the dashboard
-
-A key belongs in the allow-list only if it is **both**:
-
-- **well covered** — a meaningful share of features carry it, and
-- **not the same value on every feature** — or coloring is one flat blob.
-
-Drop a key only when it is near-absent (`covered` on bus-stops) or truly single-valued
-everywhere (`public_transport=platform`, which PTv2 co-tags on every stop). A *skewed*
-distribution is fine and even valuable: `operator` on `bicycle-rental` is mostly one
-value (a city has one bike-share system), but the stray outliers it surfaces — a second
-operator, a mis-tagged dock — are exactly the data deviations OSM for Cities exists to
+A *skewed* distribution is fine and valuable: `operator` on `bicycle-rental` is mostly
+one value (a city has one bike-share system), but the stray outliers it surfaces — a
+second operator, a mis-tagged dock — are exactly the deviations OSM for Cities exists to
 flag. Don't require an even spread.
 
-Tune in both directions, using the dashboard's "Most used tags" list as the menu:
+Tune both ways, using the dashboard's "Most used tags" as the menu: **reduce**
+near-zero keys; **widen** a high-usage varied key (coverage can be regional — the legend
+handles Missing). For each key added, add a `TagLabel` in en/es/pt-BR; values fall back
+to the raw string, so `TagValue` labels are optional. Re-sync and reload to confirm.
 
-- **Reduce** — drop keys near-zero across the demonstrators.
-- **Widen** — promote a high-usage, varied key. Coverage can be regional (rich in one
-  demonstrator, mostly "Missing" in another); that is fine — the legend handles Missing.
+### Picking demonstrators
 
-For every key added, add a `TagLabel` in `messages/en.json`, `es.json`, and
-`pt-BR.json`. Values render from `TagValue` with a raw fallback, so controlled-value
-labels are optional. Re-run `pnpm db:sync` and reload the dashboard to confirm.
+Up to ~5 cities with strong, well-maintained tagging. Two signals, in order:
 
-### 4. Pick demonstrators
+1. **Community strength** — shortlist cities in active OSM communities. Proxy: current
+   Pascal Neis country stats (`https://osmstats.neis-one.org/?item=countries`).
+2. **Dashboard confirmation** — open each candidate and read the Critical coverage block;
+   keep the ones that actually show the template well.
 
-Aim for a small set (up to ~5 for flagship templates) of cities with strong,
-well-maintained tagging for this template. Two signals, in order:
+Best-tagged cities sometimes cluster in one region — balance best-data against
+geographic diversity. Record each in `demonstrators:` with a short qualitative `note`
+(no percentages — they drift).
 
-1. **Community strength** — shortlist cities in active OSM communities. Use current
-   Pascal Neis country stats (`https://osmstats.neis-one.org/?item=countries`, read for
-   today's date) as the proxy.
-2. **Dashboard confirmation** — open each candidate's dataset and read the Critical
-   coverage block. Keep the ones that actually show the template well.
+### Seed / feature (Overpass budget)
 
-Note the tension: for some templates the best-tagged cities cluster in one region.
-Balance "best data" against geographic/community diversity per template; record the
-choice in `demonstrators:` with a short qualitative `note` (no percentages — they
-drift).
-
-### 5. Seed / feature decision (Overpass budget)
-
-Every persisted dataset is a standing daily-refresh cost: the refresh cron
+Every persisted dataset is a standing daily-refresh cost: the cron
 (`api/tasks/update-datasets`) re-fetches **all active datasets**, featured or not,
-oldest-first at a small batch size. So seeding is deliberate, not automatic —
-demonstrators are recommendations. To showcase one, a signed-in agent/admin opens its
-dataset page (which persists it); an admin may then feature the single best via the
-dataset-page toggle. Keep the total active/featured set bounded.
-
-### 6. Ship
-
-Commit `templates.yml`, `templates.i18n.yml`, and any `messages/*.json`. Do not open a
-PR or push until the maintainer says so. On merge, deploy runs `db:sync`; templates
-removed from the YAML soft-deprecate (30 days) then delete.
+oldest-first at a small batch size. Seeding is deliberate — demonstrators are
+recommendations. To showcase one, a signed-in agent/admin opens its dataset page (which
+persists it); an admin may feature the single best via the dataset-page toggle. Keep the
+active/featured set bounded.
 
 ## Worked examples
 
 - **bus-stops** — tags sit on the node, so `shelter`/`bench`/`lit`/`tactile_paving` are
   well-covered binaries. Dropped `covered` (near-absent), added `operator`.
 - **bicycle-rental** — `[bicycle_rental, operator, network, capacity]`. Skewed (one
-  bike-share system per city) but kept: the outliers are worth surfacing.
+  system per city) but kept: the outliers are worth surfacing.
+- **ev-charging** — `[capacity, operator, access, fee]`: the wiki's usability-critical
+  keys that each exist as one colorable key. Dropped `network` (wiki doesn't emphasize
+  it; ~0% outside Germany). Excluded connectors though the wiki calls them essential —
+  OSM fragments them across count-valued `socket:*` keys, so no single key colors "type".
 - **tram-stops — rejected.** `railway=tram_stop` marks the trackside point; amenities
   live on the separate `public_transport=platform` node, so the queried node has nothing
   to filter. Check the interesting tags sit on the queried element, not a sibling.
@@ -118,5 +108,5 @@ removed from the YAML soft-deprecate (30 days) then delete.
 
 `prisma/lib/template-parser.ts` fails `pnpm db:sync`/CI on: unknown parent id, unknown
 template id under `filterableTags`/`demonstrators`, and malformed demonstrator entries
-(missing/non-integer `area`, non-string `note`). Unit tests:
+(missing/non-integer `area`, non-string `note`). Tests:
 `prisma/lib/__tests__/template-parser.test.ts`.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -120,8 +120,8 @@ active/featured set bounded.
 ## Validation the sync enforces
 
 `prisma/lib/template-parser.ts` fails `pnpm db:sync`/CI on: unknown parent id, and a
-`demonstrators` section that is malformed (scalar/array root, unknown template id,
-missing/non-integer `area`, non-string `note`). An unknown template id under
+`demonstrators` section that is malformed (scalar/array root, unknown template id, an
+`area` that is not a positive integer, non-string `note`). An unknown template id under
 `filterableTags` is a non-blocking **warning**, not an error — a typo there only leaves
 that one template age-view-only, so it never blocks the seed/deploy. Tests:
 `prisma/lib/__tests__/template-parser.test.ts`.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -100,6 +100,10 @@ active/featured set bounded.
   keys that each exist as one colorable key. Dropped `network` (wiki doesn't emphasize
   it; ~0% outside Germany). Excluded connectors though the wiki calls them essential —
   OSM fragments them across count-valued `socket:*` keys, so no single key colors "type".
+- **crossings** — `[crossing, crossing:markings, tactile_paving]`. Both `crossing`
+  (classic) and `crossing:markings` (newer split) are kept — communities favor one or the
+  other, so coverage is regional. Dropped `kerb` (6-15% in most cities; it belongs on the
+  separate sidewalk `barrier=kerb` node, not the crossing — same sibling-node trap).
 - **tram-stops — rejected.** `railway=tram_stop` marks the trackside point; amenities
   live on the separate `public_transport=platform` node, so the queried node has nothing
   to filter. Check the interesting tags sit on the queried element, not a sibling.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -1,0 +1,118 @@
+# Template Management
+
+How a template gets proposed, defined, validated against real cities, and shipped.
+Written to be run by a coding agent end to end.
+
+Templates are defined in `prisma/templates.yml` (logic) + `prisma/templates.i18n.yml`
+(translations) and synced to the DB by `prisma/sync-templates.ts` (`pnpm db:sync`).
+There is no admin UI — the YAML is the source of truth, and deploy runs the sync.
+
+## Definitions
+
+- **Template** — an OSM selector (`highway=bus_stop`) plus a category, icon, optional
+  parent, and an optional `filterableTags` allow-list. Rows in `templates.yml`:
+  `[id, query, category, icon?, parent?]`. Query syntax: `;` = OR, `&` = AND,
+  `*`/empty = wildcard; `{OSM_RELATION_ID}` is substituted per area at fetch time.
+- **Sub-template** — a template with a `parent`. Use it when the query is a strict
+  subset/specialisation of a broader template (e.g. `bicycle-parking` under
+  `bicycle-infrastructure`, `bus-stops` under `public-transit`). If it stands alone
+  conceptually, keep it top-level.
+- **filterableTags** — a curated allow-list of OSM tag *keys* (top-level
+  `filterableTags:` map) that become interactive-legend "Color by" views and the
+  "Critical coverage" stat block on the dataset dashboard. Absent → age view only.
+  Each key needs a `TagLabel` entry in every `messages/*.json`.
+- **Demonstrator** — an OSM relation id (top-level `demonstrators:` map) whose real
+  data shows the template at its best. Curation only: validated by the sync, never
+  written to the DB. The workflow reads it to decide which datasets to inspect/seed.
+
+## The dashboard is the validation tool
+
+There is no separate preview. To inspect a template, a **signed-in** agent opens
+`/area/{relationId}/dataset/{templateId}` — the page creates the dataset on view
+(fetches the Overpass snapshot + stats) and renders the real dashboard. Read numbers
+live from the dashboard; do not copy them into the YAML (they drift as OSM changes).
+
+Prerequisites: local dev server, signed in (osmforcities-dev-auth), Overpass tunnel up
+(infra-overpass-tunnel). Resolve relation ids from Nominatim.
+
+## Workflow
+
+### 1. Propose
+
+A template is worth adding when it maps a distinct civic need, has a clean selector
+that is documented on the OSM wiki, and is neither so broad it trips the size cap nor
+so rare it is empty in most cities.
+
+### 2. Define in `templates.yml`
+
+Add the row, pick a seeded `category`, decide parent (see sub-template above), add a
+Lucide `icon` (validated by `pnpm generate-icons`). Add name/description to
+`templates.i18n.yml`. Run `pnpm db:sync` to apply.
+
+### 3. Choose `filterableTags` — tune from the dashboard
+
+A key belongs in the allow-list only if it is **both**:
+
+- **well covered** — a meaningful share of features carry it (read the Critical
+  coverage block), and
+- **multi-valued** — it takes more than one value, so coloring produces a real legend
+  rather than one flat color.
+
+Both tests matter. `public_transport` sits near 100% on bus stops but is almost always
+the single value `platform` (PTv2 co-tags `highway=bus_stop` with
+`public_transport=platform`), so it colors as one blob — high coverage, no diversity,
+not a good view. A yes/no key like `shelter`, or a many-valued key like `operator`,
+passes both tests.
+
+Tune in both directions, using the dashboard's "Most used tags" list as the menu:
+
+- **Reduce** — drop keys whose coverage is near-zero across the demonstrators. (The
+  `bus-stops` allow-list dropped `covered` for this reason: it is redundant with
+  `shelter` and barely tagged anywhere.)
+- **Widen** — promote a high-usage, multi-valued key into the list. (`operator` was
+  added to `bus-stops`. Note coverage can be regional — some communities tag `operator`
+  on every stop, others almost never — so a widened key may render richly in one
+  demonstrator and mostly "Missing" in another. That is acceptable and itself
+  informative; the legend handles Missing.)
+
+For every key added, add a `TagLabel` in `messages/en.json`, `es.json`, and
+`pt-BR.json`. Values render from `TagValue` with a raw fallback, so controlled-value
+labels are optional. Re-run `pnpm db:sync` and reload the dashboard to confirm.
+
+### 4. Pick demonstrators
+
+Aim for a small set (up to ~5 for flagship templates) of cities with strong,
+well-maintained tagging for this template. Two signals, in order:
+
+1. **Community strength** — shortlist cities in active OSM communities. Use current
+   Pascal Neis country stats (`https://osmstats.neis-one.org/?item=countries`, read for
+   today's date) as the proxy.
+2. **Dashboard confirmation** — open each candidate's dataset and read the Critical
+   coverage block. Keep the ones that actually show the template well.
+
+Note the tension: for some templates the best-tagged cities cluster in one region.
+Balance "best data" against geographic/community diversity per template; record the
+choice in `demonstrators:` with a short qualitative `note` (no percentages — they
+drift).
+
+### 5. Seed / feature decision (Overpass budget)
+
+Every persisted dataset is a standing daily-refresh cost: the refresh cron
+(`api/tasks/update-datasets`) re-fetches **all active datasets**, featured or not,
+oldest-first at a small batch size. So seeding is deliberate, not automatic —
+demonstrators are recommendations. To showcase one, a signed-in agent/admin opens its
+dataset page (which persists it); an admin may then feature the single best via the
+dataset-page toggle. Keep the total active/featured set bounded.
+
+### 6. Ship
+
+Commit `templates.yml`, `templates.i18n.yml`, and any `messages/*.json`. Do not open a
+PR or push until the maintainer says so. On merge, deploy runs `db:sync`; templates
+removed from the YAML soft-deprecate (30 days) then delete.
+
+## Validation the sync enforces
+
+`prisma/lib/template-parser.ts` fails `pnpm db:sync`/CI on: unknown parent id, unknown
+template id under `filterableTags`/`demonstrators`, and malformed demonstrator entries
+(missing/non-integer `area`, non-string `note`). Unit tests:
+`prisma/lib/__tests__/template-parser.test.ts`.

--- a/messages/en.json
+++ b/messages/en.json
@@ -679,7 +679,9 @@
     "access": "Access",
     "fee": "Fee",
     "crossing": "Crossing",
-    "crossing:markings": "Markings"
+    "crossing:markings": "Markings",
+    "station": "Station type",
+    "wheelchair": "Wheelchair access"
   },
   "TagValue": {
     "__common__": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -672,6 +672,8 @@
     "lit": "Lit",
     "tactile_paving": "Tactile paving",
     "operator": "Operator",
+    "network": "Network",
+    "bicycle_rental": "Type",
     "bicycle_parking": "Type",
     "capacity": "Capacity",
     "access": "Access",

--- a/messages/en.json
+++ b/messages/en.json
@@ -671,6 +671,7 @@
     "covered": "Covered",
     "lit": "Lit",
     "tactile_paving": "Tactile paving",
+    "operator": "Operator",
     "bicycle_parking": "Type",
     "capacity": "Capacity",
     "access": "Access",

--- a/messages/en.json
+++ b/messages/en.json
@@ -677,7 +677,9 @@
     "bicycle_parking": "Type",
     "capacity": "Capacity",
     "access": "Access",
-    "fee": "Fee"
+    "fee": "Fee",
+    "crossing": "Crossing",
+    "crossing:markings": "Markings"
   },
   "TagValue": {
     "__common__": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -681,6 +681,8 @@
     "lit": "Iluminado",
     "tactile_paving": "Pavimento táctil",
     "operator": "Operador",
+    "network": "Red",
+    "bicycle_rental": "Tipo",
     "bicycle_parking": "Tipo",
     "capacity": "Capacidad",
     "access": "Acceso",

--- a/messages/es.json
+++ b/messages/es.json
@@ -688,7 +688,9 @@
     "access": "Acceso",
     "fee": "Tarifa",
     "crossing": "Cruce",
-    "crossing:markings": "Marcas viales"
+    "crossing:markings": "Marcas viales",
+    "station": "Tipo de estación",
+    "wheelchair": "Acceso silla de ruedas"
   },
   "TagValue": {
     "__common__": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -680,6 +680,7 @@
     "covered": "Cubierto",
     "lit": "Iluminado",
     "tactile_paving": "Pavimento táctil",
+    "operator": "Operador",
     "bicycle_parking": "Tipo",
     "capacity": "Capacidad",
     "access": "Acceso",

--- a/messages/es.json
+++ b/messages/es.json
@@ -686,7 +686,9 @@
     "bicycle_parking": "Tipo",
     "capacity": "Capacidad",
     "access": "Acceso",
-    "fee": "Tarifa"
+    "fee": "Tarifa",
+    "crossing": "Cruce",
+    "crossing:markings": "Marcas viales"
   },
   "TagValue": {
     "__common__": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -688,7 +688,9 @@
     "access": "Acesso",
     "fee": "Tarifa",
     "crossing": "Travessia",
-    "crossing:markings": "Faixa de pedestres"
+    "crossing:markings": "Faixa de pedestres",
+    "station": "Tipo de estação",
+    "wheelchair": "Acesso para cadeirantes"
   },
   "TagValue": {
     "__common__": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -681,6 +681,8 @@
     "lit": "Iluminado",
     "tactile_paving": "Piso tátil",
     "operator": "Operador",
+    "network": "Rede",
+    "bicycle_rental": "Tipo",
     "bicycle_parking": "Tipo",
     "capacity": "Capacidade",
     "access": "Acesso",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -686,7 +686,9 @@
     "bicycle_parking": "Tipo",
     "capacity": "Capacidade",
     "access": "Acesso",
-    "fee": "Tarifa"
+    "fee": "Tarifa",
+    "crossing": "Travessia",
+    "crossing:markings": "Faixa de pedestres"
   },
   "TagValue": {
     "__common__": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -680,6 +680,7 @@
     "covered": "Coberto",
     "lit": "Iluminado",
     "tactile_paving": "Piso tátil",
+    "operator": "Operador",
     "bicycle_parking": "Tipo",
     "capacity": "Capacidade",
     "access": "Acesso",

--- a/prisma/lib/__tests__/template-parser.test.ts
+++ b/prisma/lib/__tests__/template-parser.test.ts
@@ -21,6 +21,7 @@ import {
   loadTemplatesYaml,
   loadTemplatesLogic,
   loadTemplatesI18n,
+  validateDemonstrators,
 } from "../template-parser";
 
 describe("template-parser", () => {
@@ -311,9 +312,9 @@ describe("template-parser", () => {
       expect(byId.get("bus-stops")?.filterableTags).toEqual([
         "shelter",
         "bench",
-        "covered",
         "lit",
         "tactile_paving",
+        "operator",
       ]);
       // Uncurated templates have no list (age-only in the legend)
       expect(byId.get("hospitals")?.filterableTags).toBeUndefined();
@@ -346,6 +347,89 @@ describe("template-parser", () => {
       expect(first.name).toBeDefined();
       expect(first.description).toBeDefined();
       expect(first.overpassQuery).toContain("area.searchArea");
+    });
+
+    it("exposes the demonstrators section keyed by template id", () => {
+      const config = loadTemplatesYaml("./prisma");
+      expect(config.demonstrators).toBeDefined();
+      const busStops = config.demonstrators?.["bus-stops"];
+      expect(Array.isArray(busStops)).toBe(true);
+      expect((busStops as unknown[]).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("validateDemonstrators", () => {
+    const known = new Set(["bus-stops", "cycleways"]);
+
+    it("returns no errors for a valid section", () => {
+      const errors = validateDemonstrators(
+        {
+          "bus-stops": [
+            { area: 54517, note: "Rennes" },
+            { area: 451516 },
+          ],
+        },
+        known,
+      );
+      expect(errors).toHaveLength(0);
+    });
+
+    it("accepts an empty or absent section", () => {
+      expect(validateDemonstrators(undefined, known)).toHaveLength(0);
+      expect(validateDemonstrators({}, known)).toHaveLength(0);
+    });
+
+    it("errors on an unknown template id", () => {
+      const errors = validateDemonstrators(
+        { "bus-stopz": [{ area: 54517 }] },
+        known,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain("unknown template id");
+    });
+
+    it("errors when the value is not a list", () => {
+      const errors = validateDemonstrators(
+        { "bus-stops": { area: 54517 } as unknown as unknown[] },
+        known,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain("must be a list");
+    });
+
+    it("errors on a non-integer or non-positive area", () => {
+      const errors = validateDemonstrators(
+        {
+          "bus-stops": [
+            { area: 1.5 },
+            { area: -3 },
+            { area: "54517" as unknown as number },
+          ],
+        },
+        known,
+      );
+      expect(errors).toHaveLength(3);
+      for (const e of errors) {
+        expect(e.message).toContain("positive integer");
+      }
+    });
+
+    it("errors when an entry is not an object", () => {
+      const errors = validateDemonstrators(
+        { "bus-stops": [54517 as unknown as object] },
+        known,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('must be an object');
+    });
+
+    it("errors when note is not a string", () => {
+      const errors = validateDemonstrators(
+        { "bus-stops": [{ area: 54517, note: 42 as unknown as string }] },
+        known,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain("note must be a string");
     });
   });
 });

--- a/prisma/lib/__tests__/template-parser.test.ts
+++ b/prisma/lib/__tests__/template-parser.test.ts
@@ -352,7 +352,8 @@ describe("template-parser", () => {
     it("exposes the demonstrators section keyed by template id", () => {
       const config = loadTemplatesYaml("./prisma");
       expect(config.demonstrators).toBeDefined();
-      const busStops = config.demonstrators?.["bus-stops"];
+      const demonstrators = config.demonstrators as Record<string, unknown>;
+      const busStops = demonstrators["bus-stops"];
       expect(Array.isArray(busStops)).toBe(true);
       expect((busStops as unknown[]).length).toBeGreaterThan(0);
     });
@@ -376,7 +377,16 @@ describe("template-parser", () => {
 
     it("accepts an empty or absent section", () => {
       expect(validateDemonstrators(undefined, known)).toHaveLength(0);
+      expect(validateDemonstrators(null, known)).toHaveLength(0);
       expect(validateDemonstrators({}, known)).toHaveLength(0);
+    });
+
+    it("errors on a scalar or array root (hand-edited YAML)", () => {
+      for (const root of [42, true, "bus-stops", [{ area: 54517 }]]) {
+        const errors = validateDemonstrators(root, known);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toContain("map keyed by template id");
+      }
     });
 
     it("errors on an unknown template id", () => {

--- a/prisma/lib/template-parser.ts
+++ b/prisma/lib/template-parser.ts
@@ -33,11 +33,22 @@ export interface TemplateLogic {
 }
 
 /**
+ * A curated demonstrator city for a template: an OSM relation id whose data
+ * shows the template at its best. Validated only, never written to the DB.
+ */
+export interface Demonstrator {
+  area: number;
+  note?: string;
+}
+
+/**
  * Logic-only config from templates.yml (used by parseTemplates and collectIcons)
  */
 export interface LogicConfig {
   templates: Record<string, TemplateLogic>;
   categories?: Record<string, string>;
+  // Raw so validateDemonstrators can report shape errors on hand-edited YAML.
+  demonstrators?: Record<string, unknown>;
 }
 
 /**
@@ -263,6 +274,7 @@ export function buildTemplate(config: TemplateConfig): ParsedTemplate {
 export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
   entries: LogicEntry[];
   categories: Record<string, string>;
+  demonstrators: Record<string, unknown>;
 } {
   const filePath = join(basePath, LOGIC_FILE);
   try {
@@ -271,6 +283,7 @@ export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
       templates?: unknown[];
       categories?: Record<string, string>;
       filterableTags?: Record<string, unknown>;
+      demonstrators?: Record<string, unknown>;
     };
 
     if (!config?.templates || !Array.isArray(config.templates)) {
@@ -334,6 +347,7 @@ export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
     return {
       entries,
       categories: config.categories ?? {},
+      demonstrators: config.demonstrators ?? {},
     };
   } catch (error) {
     if (error instanceof Error) {
@@ -379,7 +393,7 @@ export function loadTemplatesI18n(
 export function loadTemplatesYaml(
   basePath: string = DEFAULT_PRISMA,
 ): LogicConfig {
-  const { entries, categories } = loadTemplatesLogic(basePath);
+  const { entries, categories, demonstrators } = loadTemplatesLogic(basePath);
   const templates: Record<string, TemplateLogic> = {};
   for (const entry of entries) {
     templates[entry.id] = {
@@ -390,7 +404,61 @@ export function loadTemplatesYaml(
       filterableTags: entry.filterableTags,
     };
   }
-  return { templates, categories };
+  return { templates, categories, demonstrators };
+}
+
+/**
+ * Validate the `demonstrators:` section against the set of known template ids.
+ * A typo'd id or malformed relation id fails the sync loudly instead of pointing
+ * the workflow at nothing. One error per problem; an empty/absent section is valid.
+ */
+export function validateDemonstrators(
+  demonstrators: Record<string, unknown> | undefined,
+  knownIds: Set<string>,
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!demonstrators) return errors;
+
+  for (const [templateId, list] of Object.entries(demonstrators)) {
+    if (!knownIds.has(templateId)) {
+      errors.push({
+        field: "demonstrators",
+        message: `demonstrators references unknown template id: "${templateId}"`,
+      });
+      continue;
+    }
+    if (!Array.isArray(list)) {
+      errors.push({
+        field: "demonstrators",
+        message: `demonstrators for "${templateId}" must be a list`,
+      });
+      continue;
+    }
+    list.forEach((entry, i) => {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        errors.push({
+          field: "demonstrators",
+          message: `demonstrators["${templateId}"][${i}] must be an object with an "area"`,
+        });
+        return;
+      }
+      const { area, note } = entry as { area?: unknown; note?: unknown };
+      if (typeof area !== "number" || !Number.isInteger(area) || area <= 0) {
+        errors.push({
+          field: "demonstrators",
+          message: `demonstrators["${templateId}"][${i}].area must be a positive integer OSM relation id`,
+        });
+      }
+      if (note !== undefined && typeof note !== "string") {
+        errors.push({
+          field: "demonstrators",
+          message: `demonstrators["${templateId}"][${i}].note must be a string`,
+        });
+      }
+    });
+  }
+
+  return errors;
 }
 
 /**
@@ -452,6 +520,8 @@ export function parseTemplates(config: LogicConfig): ParseResult {
       });
     }
   }
+
+  errors.push(...validateDemonstrators(config.demonstrators, parsedIds));
 
   return { templates, errors, warnings };
 }

--- a/prisma/lib/template-parser.ts
+++ b/prisma/lib/template-parser.ts
@@ -47,8 +47,9 @@ export interface Demonstrator {
 export interface LogicConfig {
   templates: Record<string, TemplateLogic>;
   categories?: Record<string, string>;
-  // Raw so validateDemonstrators can report shape errors on hand-edited YAML.
-  demonstrators?: Record<string, unknown>;
+  // Raw so validateDemonstrators can report shape errors on hand-edited YAML
+  // (incl. a scalar/array root, not just per-key issues).
+  demonstrators?: unknown;
 }
 
 /**
@@ -274,7 +275,7 @@ export function buildTemplate(config: TemplateConfig): ParsedTemplate {
 export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
   entries: LogicEntry[];
   categories: Record<string, string>;
-  demonstrators: Record<string, unknown>;
+  demonstrators: unknown;
 } {
   const filePath = join(basePath, LOGIC_FILE);
   try {
@@ -283,7 +284,7 @@ export function loadTemplatesLogic(basePath: string = DEFAULT_PRISMA): {
       templates?: unknown[];
       categories?: Record<string, string>;
       filterableTags?: Record<string, unknown>;
-      demonstrators?: Record<string, unknown>;
+      demonstrators?: unknown;
     };
 
     if (!config?.templates || !Array.isArray(config.templates)) {
@@ -413,11 +414,18 @@ export function loadTemplatesYaml(
  * the workflow at nothing. One error per problem; an empty/absent section is valid.
  */
 export function validateDemonstrators(
-  demonstrators: Record<string, unknown> | undefined,
+  demonstrators: unknown,
   knownIds: Set<string>,
 ): ValidationError[] {
   const errors: ValidationError[] = [];
-  if (!demonstrators) return errors;
+  if (demonstrators === undefined || demonstrators === null) return errors;
+  if (typeof demonstrators !== "object" || Array.isArray(demonstrators)) {
+    errors.push({
+      field: "demonstrators",
+      message: "demonstrators must be a map keyed by template id",
+    });
+    return errors;
+  }
 
   for (const [templateId, list] of Object.entries(demonstrators)) {
     if (!knownIds.has(templateId)) {

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -284,6 +284,7 @@ templates:
 filterableTags:
   bus-stops:       [shelter, bench, lit, tactile_paving, operator]
   bicycle-parking: [bicycle_parking, covered, capacity, access, fee]
+  bicycle-rental:  [bicycle_rental, operator, network, capacity]
 
 # Curated demonstrator cities per template (OSM relation ids).
 # Cities whose real data best shows the template in the dashboard. Curation-only:
@@ -296,6 +297,11 @@ demonstrators:
     - { area: 2697338, note: "Rio de Janeiro, BR - best-maintained stop tagging in Latin America" }
     - { area: 79604,   note: "Cape Town, ZA - African representative, active community" }
     - { area: 1293250, note: "Taipei, TW - East Asia representative" }
+  bicycle-rental:
+    - { area: 71525,   note: "Paris, FR - Velib, large and thoroughly tagged dock network" }
+    - { area: 347950,  note: "Barcelona, ES - Bicing, complete operator/network/capacity tagging" }
+    - { area: 1634158, note: "Montreal, CA - Bixi, North American representative" }
+    - { area: 1376330, note: "Mexico City, MX - Ecobici, Latin American representative" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -287,6 +287,7 @@ filterableTags:
   bicycle-rental:  [bicycle_rental, operator, network, capacity]
   ev-charging:     [capacity, operator, access, fee]
   crossings:       [crossing, crossing:markings, tactile_paving]
+  railway-stations: [station, wheelchair, operator, network]
 
 # Curated demonstrator cities per template (OSM relation ids).
 # Cities whose real data best shows the template in the dashboard. Curation-only:
@@ -313,6 +314,11 @@ demonstrators:
     - { area: 54517,   note: "Rennes, FR - meticulous accessibility tagging (crossing/markings/tactile all high)" }
     - { area: 62428,   note: "Munich, DE - dense classic crossing + tactile_paving tagging" }
     - { area: 419203,  note: "Utrecht, NL - near-complete crossing:markings, strong tactile_paving" }
+  railway-stations:
+    - { area: 1293250, note: "Taipei, TW - fully tagged metro, every key present and clean" }
+    - { area: 347950,  note: "Barcelona, ES - near-complete operator/network tagging" }
+    - { area: 71525,   note: "Paris, FR - large set, varied networks/operators, strong accessibility" }
+    - { area: 62428,   note: "Munich, DE - good wheelchair coverage, mixed train/subway modes" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -286,6 +286,7 @@ filterableTags:
   bicycle-parking: [bicycle_parking, covered, capacity, access, fee]
   bicycle-rental:  [bicycle_rental, operator, network, capacity]
   ev-charging:     [capacity, operator, access, fee]
+  crossings:       [crossing, crossing:markings, tactile_paving]
 
 # Curated demonstrator cities per template (OSM relation ids).
 # Cities whose real data best shows the template in the dashboard. Curation-only:
@@ -308,6 +309,10 @@ demonstrators:
     - { area: 62428,   note: "Munich, DE - strong operator/fee tagging, active German community" }
     - { area: 419203,  note: "Utrecht, NL - well-rounded amenity tagging, dense Dutch network" }
     - { area: 1634158, note: "Montreal, CA - North American representative, thorough capacity/operator/access tagging" }
+  crossings:
+    - { area: 54517,   note: "Rennes, FR - meticulous accessibility tagging (crossing/markings/tactile all high)" }
+    - { area: 62428,   note: "Munich, DE - dense classic crossing + tactile_paving tagging" }
+    - { area: 419203,  note: "Utrecht, NL - near-complete crossing:markings, strong tactile_paving" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -280,9 +280,22 @@ templates:
 # Curated OSM tag keys that become interactive-legend views for a template.
 # Templates absent here show the age ("Recent edits") view only.
 # Add tag-key labels to messages/*.json (TagLabel) and controlled values (TagValue).
+# Tuning process (widen/reduce from the dashboard): docs/features/template-management.md.
 filterableTags:
-  bus-stops:       [shelter, bench, covered, lit, tactile_paving]
+  bus-stops:       [shelter, bench, lit, tactile_paving, operator]
   bicycle-parking: [bicycle_parking, covered, capacity, access, fee]
+
+# Curated demonstrator cities per template (OSM relation ids).
+# Cities whose real data best shows the template in the dashboard. Curation-only:
+# validated by sync (template-parser.ts) but never written to the DB. Selection
+# process: docs/features/template-management.md.
+demonstrators:
+  bus-stops:
+    - { area: 54517,   note: "Rennes, FR - Western Europe, near-complete stop amenity tagging" }
+    - { area: 451516,  note: "Wroclaw, PL - Central Europe, thorough public-transport mapping" }
+    - { area: 2697338, note: "Rio de Janeiro, BR - best-maintained stop tagging in Latin America" }
+    - { area: 79604,   note: "Cape Town, ZA - African representative, active community" }
+    - { area: 1293250, note: "Taipei, TW - East Asia representative" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -285,6 +285,7 @@ filterableTags:
   bus-stops:       [shelter, bench, lit, tactile_paving, operator]
   bicycle-parking: [bicycle_parking, covered, capacity, access, fee]
   bicycle-rental:  [bicycle_rental, operator, network, capacity]
+  ev-charging:     [capacity, operator, access, fee]
 
 # Curated demonstrator cities per template (OSM relation ids).
 # Cities whose real data best shows the template in the dashboard. Curation-only:
@@ -302,6 +303,11 @@ demonstrators:
     - { area: 347950,  note: "Barcelona, ES - Bicing, complete operator/network/capacity tagging" }
     - { area: 1634158, note: "Montreal, CA - Bixi, North American representative" }
     - { area: 1376330, note: "Mexico City, MX - Ecobici, Latin American representative" }
+  ev-charging:
+    - { area: 406091,  note: "Oslo, NO - EV-adoption capital, near-complete capacity/access tagging" }
+    - { area: 62428,   note: "Munich, DE - strong operator/fee tagging, active German community" }
+    - { area: 419203,  note: "Utrecht, NL - well-rounded amenity tagging, dense Dutch network" }
+    - { area: 1634158, note: "Montreal, CA - North American representative, thorough capacity/operator/access tagging" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:


### PR DESCRIPTION
## Epic #245: Template Review

**Problem:** Templates are defined in `templates.yml` and synced to the DB, but there is no governance around them: no documented process for how a template is proposed, defined, has its `filterableTags` tuned, gets demonstrator cities, and is decided seed-or-not. Concretely, `bus-stops` listed `covered` in its filterableTags despite near-zero real coverage, and no process existed to catch that.

**Acceptance Criteria:**
- [ ] Documented, repeatable process to audit/rationalize a template
- [ ] Curated per-template legend views (filterableTags) tuned against real data
- [ ] Per-template demonstrator cities recorded and validated

**Changes:**

- **Demonstrator registry:** new `demonstrators:` section in `templates.yml` (template id -> OSM relation ids). Parsed and validated by `template-parser.ts` (curation-only, never written to the DB); `pnpm db:sync`/CI fails on unknown template id or malformed `area`/`note`. Unit tests added.
- **Workflow doc** `docs/features/template-management.md`: agent-operable template lifecycle — propose, define (incl. sub-template decision), tune filterableTags from the dashboard, pick demonstrators (community strength + dashboard confirmation), seed/feature decision (Overpass budget), ship. Two hard tuning rules documented: (1) confirm every candidate key against the OSM wiki for usability-relevance — coverage alone never qualifies a key (drops unique codes/labels like `ref`/`name`); (2) drop keys whose data lives on a sibling node (EV connectors in `socket:*`, `kerb` on `barrier=kerb`, tram amenities on the `public_transport=platform` node).

**Templates tuned (validated on the dashboard against real cities):**

| template | filterableTags | demonstrators |
|---|---|---|
| bus-stops | shelter, bench, lit, tactile_paving, operator | Rennes, Wroclaw, Rio, Cape Town, Taipei |
| bicycle-rental | bicycle_rental, operator, network, capacity | Paris, Barcelona, Montreal, Mexico City |
| ev-charging | capacity, operator, access, fee | Oslo, Munich, Utrecht, Montreal |
| crossings | crossing, crossing:markings, tactile_paving | Rennes, Munich, Utrecht |
| railway-stations | station, wheelchair, operator, network | Taipei, Barcelona, Paris, Munich |

- **bus-stops:** dropped `covered` (near-zero coverage), added `operator`.
- **ev-charging:** dropped `network` (DE-only); excluded connectors (fragmented across count-valued `socket:*`).
- **crossings:** kept both `crossing` and `crossing:markings` (regional community preference); dropped `kerb` (sibling-node trap).
- **railway-stations:** dropped `public_transport` (=station single-valued) and `train`/`subway`/`light_rail` boolean siblings; excluded `ref`/`name`.
- **i18n:** new `TagLabel` keys across en/es/pt-BR: `operator`, `network`, `bicycle_rental`, `crossing`, `crossing:markings`, `station`, `wheelchair`.

Mobility coverage continues in a follow-up PR (parking, subway-entrances, etc.).
Follow-up already filed: #405 (transit-platforms template; `railway=tram_stop` amenities live on separate `public_transport=platform` nodes).

Verified: `pnpm db:sync`, `type-check`, `i18n:check`, 41/41 parser unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded interactive tag filters to additional template categories (including bus stops, bicycle rentals, EV charging, crossings, and railway stations).
  - Added curated “demonstrators” examples per template to support dashboard-driven validation and selection.
  - Added localized `TagLabel` entries for more transport, accessibility, crossing, and network tags (English, Spanish, Portuguese).
- **Documentation**
  - Added an end-to-end “Template Management” guide covering template behavior, validation, propose/define/choose/sync/ship flow, and merging rules.
- **Bug Fixes**
  - Improved template validation by detecting malformed or unknown demonstrator definitions before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->