### PR TITLE
feat(templates): education domain filterableTags + 5 new templates

### DIFF
--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -73,6 +73,28 @@ near-zero keys; **widen** a high-usage varied key (coverage can be regional — 
 handles Missing). For each key added, add a `TagLabel` in en/es/pt-BR; values fall back
 to the raw string, so `TagValue` labels are optional. Re-sync and reload to confirm.
 
+### Accessibility as a transversal signal
+
+`wheelchair` is a default shortlist item for **every template whose queried element is
+an enterable building or staffed amenity** (shops, healthcare, education, government,
+culture, tourism, food, transit stops/stations) — the OSM wiki documents it across all
+of these, not just a curated subset. It's still gated by the normal coverage/variance
+rule (drop if near-absent or flat), but skipping the wiki check itself is not an option:
+always shortlist it first.
+
+Reasonable exceptions — skip shortlisting, nothing to "enter": outdoor/natural features
+(`waterfall`, `dam`, `viewpoints`), street furniture (`benches`, `telephones`,
+`emergency-phones`, `recycling`, `waste-disposal`), `parking` (use the more specific
+`capacity:disabled` instead), unstaffed infrastructure (`bicycle-parking`,
+`bicycle-rental`, `taxi-ranks`).
+
+Blind/visually-impaired tags (`tactile_paving`, `kerb`, `traffic_signals:sound`,
+`traffic_signals:vibration`) are a separate track: they live on pedestrian-path
+elements, not POI buildings, so they only apply to pedestrian-infrastructure templates
+(crossings, bus-stops, platforms, subway-entrances) — see `crossings`/`bus-stops` in
+Worked examples. Not every template category has one; don't force it onto a POI
+template just because `wheelchair` is present there.
+
 ### Picking demonstrators
 
 Up to ~5 cities with strong, well-maintained tagging. Two signals, in order:
@@ -113,6 +135,12 @@ active/featured set bounded.
   accessibility tags sit on the station node itself. Dropped `public_transport` (=station
   everywhere, single-valued) and the `train`/`subway`/`light_rail` boolean siblings (mode
   is already in `station=`); excluded `ref`/`name` (unique codes/labels, not categories).
+- **kindergarten / childcare / music-school / language-school / research-institute** —
+  `wheelchair` shortlisted per the transversal rule (all are enterable buildings) but
+  dropped for all five: 0-31% coverage across demonstrator cities, mostly single digits,
+  several on samples under 20 features. Same "regionally near-zero" bar that already
+  dropped `preschool` on kindergarten (17.7% max). The rule says shortlist it — it
+  doesn't say keep it.
 - **tram-stops — rejected.** `railway=tram_stop` marks the trackside point; amenities
   live on the separate `public_transport=platform` node, so the queried node has nothing
   to filter. Check the interesting tags sit on the queried element, not a sibling.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -48,47 +48,54 @@ Prereqs: local dev server, signed in (osmforcities-dev-auth), Overpass tunnel up
 
 ### Tuning `filterableTags` from the dashboard
 
-Start from the OSM wiki page for the selector — it names the tags that describe the
+Shortlist from the OSM wiki page for the selector — it names the tags that describe the
 feature's real-world usability (for `amenity=charging_station`: capacity, connector,
-access, operator, fee). Shortlist those, then keep a key only if it is **both** well
-covered on the dashboard (a meaningful share of features carry it) **and** not the same
-value on every feature (or coloring is one flat blob), **and** exists as a single
-colorable key. Drop a key when near-absent (`covered` on bus-stops), truly single-valued
-everywhere (`public_transport=platform`, PTv2-co-tagged on every stop), not
-wiki-relevant, or fragmented across many keys (EV connectors live in count-valued
-`socket:type2`/`socket:type2_combo`/… with no single key to color by). Exception: a key
-the wiki marks essential to usability or equity (`capacity`, `wheelchair`) stays even
-near-absent — a large Missing share is the signal, not a reason to hide the filter. Use
-wiki-importance and common sense here, not just the coverage number.
+access, operator, fee). Then decide per key:
 
-Coverage never qualifies a key on its own — a well-covered `ref` or `name` is still just
-a unique code, not a filter. Confirm every candidate against the OSM wiki first. If this
-measurement is delegated to a subagent, the subagent must do the wiki cross-check too
-(usability-relevance per key), not report Overpass/dashboard coverage alone.
+**Keep** a key only when all three hold:
 
-A *skewed* distribution is fine and valuable: `operator` on `bicycle-rental` is mostly
-one value (a city has one bike-share system), but the stray outliers it surfaces — a
-second operator, a mis-tagged dock — are exactly the deviations OSM for Cities exists to
-flag. Don't require an even spread.
+- **Wiki-relevant** — describes usability/equity, not identity. Coverage never qualifies
+  a key on its own: a well-covered `ref` or `name` is a unique code, not a filter.
+- **Colorable** — exists as one single key. Not fragmented across siblings (EV connectors
+  live in count-valued `socket:type2`/`socket:type2_combo`/… — no single key to color by).
+- **Well-covered with variance** — a meaningful share of features carry it, and not the
+  same value on every one (or coloring is one flat blob).
 
-Tune both ways, using the dashboard's "Most used tags" as the menu: **reduce**
-near-zero keys; **widen** a high-usage varied key (coverage can be regional — the legend
-handles Missing). For each key added, add a `TagLabel` in en/es/pt-BR; values fall back
-to the raw string, so `TagValue` labels are optional. Re-sync and reload to confirm.
+**Drop** a key when:
+
+- **Near-absent** — `covered` on bus-stops.
+- **Single-valued everywhere** — `public_transport=platform`, PTv2-co-tagged on every stop.
+- **Not wiki-relevant** — `ref`, `name`.
+- **Fragmented** across many keys (see EV connectors above).
+
+**Exceptions to the rules:**
+
+- **Wiki-essential equity/usability keys** (`capacity`, `wheelchair`) stay even when
+  near-absent — a large Missing share is the signal, not a reason to hide the filter.
+  Use wiki-importance and common sense, not the coverage number alone.
+- **Skewed is fine.** `operator` on `bicycle-rental` is mostly one value (one bike-share
+  system per city), but the stray outliers — a second operator, a mis-tagged dock — are
+  exactly the deviations OSM for Cities exists to flag. Don't require an even spread.
+
+Tune both ways off the dashboard's "Most used tags" menu: **reduce** near-zero keys,
+**widen** a high-usage varied key (coverage can be regional — the legend handles Missing).
+For each key added: add a `TagLabel` in en/es/pt-BR (values fall back to the raw string,
+so `TagValue` labels are optional), re-sync, reload to confirm. If measurement is
+delegated to a subagent, it must do the wiki cross-check too — not report coverage alone.
 
 ### Accessibility as a transversal signal
 
-`wheelchair` — always shortlist and keep for any enterable-building/staffed-amenity
-template (shops, healthcare, education, government, culture, tourism, food, transit).
-Low coverage is not a reason to drop it (see the coverage exception above). Skip
-shortlisting only when there's nothing to enter: outdoor/natural features, street
-furniture, `parking` (use `capacity:disabled` instead), unstaffed infra
-(`bicycle-parking`, `bicycle-rental`, `taxi-ranks`).
-
-Blind/visually-impaired tags (`tactile_paving`, `kerb`, `traffic_signals:sound`/
-`:vibration`) are a separate, narrower track — pedestrian-path templates only
-(crossings, bus-stops, platforms, subway-entrances; see Worked examples). Don't add
-them to a POI template just because `wheelchair` applies there.
+- **`wheelchair`** — always shortlist **and keep** for any enterable-building /
+  staffed-amenity template (shops, healthcare, education, government, culture, tourism,
+  food, transit). Low coverage is not a reason to drop it (equity-essential exception
+  above).
+- **Skip `wheelchair`** only when there's nothing to enter: outdoor/natural features,
+  street furniture, `parking` (use `capacity:disabled` instead), unstaffed infra
+  (`bicycle-parking`, `bicycle-rental`, `taxi-ranks`).
+- **Blind/visually-impaired tags** (`tactile_paving`, `kerb`, `traffic_signals:sound`/
+  `:vibration`) are a separate, narrower track — pedestrian-path templates only
+  (crossings, bus-stops, platforms, subway-entrances; see Worked examples). Don't add
+  them to a POI template just because `wheelchair` applies there.
 
 ### Picking demonstrators
 
@@ -140,9 +147,15 @@ active/featured set bounded.
 
 ## Validation the sync enforces
 
-`prisma/lib/template-parser.ts` fails `pnpm db:sync`/CI on: unknown parent id, and a
-`demonstrators` section that is malformed (scalar/array root, unknown template id, an
-`area` that is not a positive integer, non-string `note`). An unknown template id under
-`filterableTags` is a non-blocking **warning**, not an error — a typo there only leaves
-that one template age-view-only, so it never blocks the seed/deploy. Tests:
-`prisma/lib/__tests__/template-parser.test.ts`.
+`prisma/lib/template-parser.ts` (tests: `prisma/lib/__tests__/template-parser.test.ts`).
+
+**Fails** `pnpm db:sync`/CI on:
+
+- Unknown parent id.
+- Malformed `demonstrators` — scalar/array root, unknown template id, `area` that is not
+  a positive integer, non-string `note`.
+
+**Warns** (non-blocking):
+
+- Unknown template id under `filterableTags` — a typo there only leaves that one template
+  age-view-only, so it never blocks the seed/deploy.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -56,7 +56,10 @@ value on every feature (or coloring is one flat blob), **and** exists as a singl
 colorable key. Drop a key when near-absent (`covered` on bus-stops), truly single-valued
 everywhere (`public_transport=platform`, PTv2-co-tagged on every stop), not
 wiki-relevant, or fragmented across many keys (EV connectors live in count-valued
-`socket:type2`/`socket:type2_combo`/… with no single key to color by).
+`socket:type2`/`socket:type2_combo`/… with no single key to color by). Exception: a key
+the wiki marks essential to usability or equity (`capacity`, `wheelchair`) stays even
+near-absent — a large Missing share is the signal, not a reason to hide the filter. Use
+wiki-importance and common sense here, not just the coverage number.
 
 Coverage never qualifies a key on its own — a well-covered `ref` or `name` is still just
 a unique code, not a filter. Confirm every candidate against the OSM wiki first. If this
@@ -75,25 +78,17 @@ to the raw string, so `TagValue` labels are optional. Re-sync and reload to conf
 
 ### Accessibility as a transversal signal
 
-`wheelchair` is a default shortlist item for **every template whose queried element is
-an enterable building or staffed amenity** (shops, healthcare, education, government,
-culture, tourism, food, transit stops/stations) — the OSM wiki documents it across all
-of these, not just a curated subset. It's still gated by the normal coverage/variance
-rule (drop if near-absent or flat), but skipping the wiki check itself is not an option:
-always shortlist it first.
+`wheelchair` — always shortlist and keep for any enterable-building/staffed-amenity
+template (shops, healthcare, education, government, culture, tourism, food, transit).
+Low coverage is not a reason to drop it (see the coverage exception above). Skip
+shortlisting only when there's nothing to enter: outdoor/natural features, street
+furniture, `parking` (use `capacity:disabled` instead), unstaffed infra
+(`bicycle-parking`, `bicycle-rental`, `taxi-ranks`).
 
-Reasonable exceptions — skip shortlisting, nothing to "enter": outdoor/natural features
-(`waterfall`, `dam`, `viewpoints`), street furniture (`benches`, `telephones`,
-`emergency-phones`, `recycling`, `waste-disposal`), `parking` (use the more specific
-`capacity:disabled` instead), unstaffed infrastructure (`bicycle-parking`,
-`bicycle-rental`, `taxi-ranks`).
-
-Blind/visually-impaired tags (`tactile_paving`, `kerb`, `traffic_signals:sound`,
-`traffic_signals:vibration`) are a separate track: they live on pedestrian-path
-elements, not POI buildings, so they only apply to pedestrian-infrastructure templates
-(crossings, bus-stops, platforms, subway-entrances) — see `crossings`/`bus-stops` in
-Worked examples. Not every template category has one; don't force it onto a POI
-template just because `wheelchair` is present there.
+Blind/visually-impaired tags (`tactile_paving`, `kerb`, `traffic_signals:sound`/
+`:vibration`) are a separate, narrower track — pedestrian-path templates only
+(crossings, bus-stops, platforms, subway-entrances; see Worked examples). Don't add
+them to a POI template just because `wheelchair` applies there.
 
 ### Picking demonstrators
 
@@ -136,11 +131,9 @@ active/featured set bounded.
   everywhere, single-valued) and the `train`/`subway`/`light_rail` boolean siblings (mode
   is already in `station=`); excluded `ref`/`name` (unique codes/labels, not categories).
 - **kindergarten / childcare / music-school / language-school / research-institute** —
-  `wheelchair` shortlisted per the transversal rule (all are enterable buildings) but
-  dropped for all five: 0-31% coverage across demonstrator cities, mostly single digits,
-  several on samples under 20 features. Same "regionally near-zero" bar that already
-  dropped `preschool` on kindergarten (17.7% max). The rule says shortlist it — it
-  doesn't say keep it.
+  `wheelchair` added to all five despite low coverage (0-31% across demonstrator
+  cities, several samples under 20 features): it's an equity-essential key per the
+  wiki, so the near-absent rule doesn't apply — the Missing share is itself useful.
 - **tram-stops — rejected.** `railway=tram_stop` marks the trackside point; amenities
   live on the separate `public_transport=platform` node, so the queried node has nothing
   to filter. Check the interesting tags sit on the queried element, not a sibling.

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -83,6 +83,12 @@ For each key added: add a `TagLabel` in en/es/pt-BR (values fall back to the raw
 so `TagValue` labels are optional), re-sync, reload to confirm. If measurement is
 delegated to a subagent, it must do the wiki cross-check too — not report coverage alone.
 
+Don't translate values that are standardized indexes or codes (`isced:level` = ISCED
+levels 0-8, `capacity` counts): leave them raw, no `TagValue` map. The code is the
+canonical form and its ordering is meaningful; a localized word list would only obscure
+it. Only add `TagValue` labels for keys whose values are opaque enum strings (`wlan`,
+`government`).
+
 ### Accessibility as a transversal signal
 
 - **`wheelchair`** — always shortlist **and keep** for any enterable-building /

--- a/messages/en.json
+++ b/messages/en.json
@@ -681,7 +681,10 @@
     "crossing": "Crossing",
     "crossing:markings": "Markings",
     "station": "Station type",
-    "wheelchair": "Wheelchair access"
+    "wheelchair": "Wheelchair access",
+    "operator:type": "Operator type",
+    "isced:level": "Education level",
+    "internet_access": "Internet access"
   },
   "TagValue": {
     "__common__": {
@@ -715,6 +718,19 @@
       "handlebar_holder": "Handlebar holder",
       "crossbar": "Crossbar",
       "informal": "Informal"
+    },
+    "operator:type": {
+      "public": "Public",
+      "private": "Private",
+      "government": "Government",
+      "religious": "Religious",
+      "ngo": "NGO",
+      "community": "Community",
+      "university": "University"
+    },
+    "internet_access": {
+      "wlan": "Wi-Fi",
+      "terminal": "Terminal"
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -690,7 +690,10 @@
     "crossing": "Cruce",
     "crossing:markings": "Marcas viales",
     "station": "Tipo de estación",
-    "wheelchair": "Acceso silla de ruedas"
+    "wheelchair": "Acceso silla de ruedas",
+    "operator:type": "Tipo de operador",
+    "isced:level": "Nivel educativo",
+    "internet_access": "Acceso a internet"
   },
   "TagValue": {
     "__common__": {
@@ -724,6 +727,19 @@
       "handlebar_holder": "Soporte de manillar",
       "crossbar": "Barra",
       "informal": "Informal"
+    },
+    "operator:type": {
+      "public": "Público",
+      "private": "Privado",
+      "government": "Gobierno",
+      "religious": "Religioso",
+      "ngo": "ONG",
+      "community": "Comunidad",
+      "university": "Universidad"
+    },
+    "internet_access": {
+      "wlan": "Wi-Fi",
+      "terminal": "Terminal"
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -690,7 +690,7 @@
     "crossing": "Cruce",
     "crossing:markings": "Marcas viales",
     "station": "Tipo de estación",
-    "wheelchair": "Acceso silla de ruedas",
+    "wheelchair": "Acceso para silla de ruedas",
     "operator:type": "Tipo de operador",
     "isced:level": "Nivel educativo",
     "internet_access": "Acceso a internet"

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -690,7 +690,10 @@
     "crossing": "Travessia",
     "crossing:markings": "Faixa de pedestres",
     "station": "Tipo de estação",
-    "wheelchair": "Acesso para cadeirantes"
+    "wheelchair": "Acesso para cadeirantes",
+    "operator:type": "Tipo de operador",
+    "isced:level": "Nível educacional",
+    "internet_access": "Acesso à internet"
   },
   "TagValue": {
     "__common__": {
@@ -724,6 +727,19 @@
       "handlebar_holder": "Suporte de guidão",
       "crossbar": "Barra",
       "informal": "Informal"
+    },
+    "operator:type": {
+      "public": "Público",
+      "private": "Privado",
+      "government": "Governo",
+      "religious": "Religioso",
+      "ngo": "ONG",
+      "community": "Comunidade",
+      "university": "Universidade"
+    },
+    "internet_access": {
+      "wlan": "Wi-Fi",
+      "terminal": "Terminal"
     }
   }
 }

--- a/prisma/templates.i18n.yml
+++ b/prisma/templates.i18n.yml
@@ -270,6 +270,51 @@ templates:
       en: College
       pt: Faculdades
       es: Facultades
+  childcare:
+    name:
+      en: Childcare
+      pt: Creches
+      es: Guarderías
+    desc:
+      en: Childcare
+      pt: Creches
+      es: Guarderías
+  driving-school:
+    name:
+      en: Driving Schools
+      pt: Autoescolas
+      es: Autoescuelas
+    desc:
+      en: Driving Schools
+      pt: Autoescolas
+      es: Autoescuelas
+  music-school:
+    name:
+      en: Music Schools
+      pt: Escolas de música
+      es: Escuelas de música
+    desc:
+      en: Music Schools
+      pt: Escolas de música
+      es: Escuelas de música
+  language-school:
+    name:
+      en: Language Schools
+      pt: Escolas de idiomas
+      es: Escuelas de idiomas
+    desc:
+      en: Language Schools
+      pt: Escolas de idiomas
+      es: Escuelas de idiomas
+  research-institute:
+    name:
+      en: Research Institutes
+      pt: Institutos de pesquisa
+      es: Institutos de investigación
+    desc:
+      en: Research Institutes
+      pt: Institutos de pesquisa
+      es: Institutos de investigación
   hotels:
     name:
       en: Hotels

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -347,7 +347,8 @@ demonstrators:
     - { area: 62428,   note: "Munich, DE - best wheelchair coverage of the sample" }
     - { area: 1293250, note: "Taipei, TW - East Asia representative" }
   libraries:
-    - { area: 62428,   note: "Munich, DE - all four keys well covered (operator, type, wheelchair, internet_access)" }
+    - { area: 175905,  note: "New York, US - exemplary operator/operator:type tagging, North America representative" }
+    - { area: 62422,   note: "Berlin, DE - large sample, strong wheelchair and internet_access coverage" }
     - { area: 451516,  note: "Wroclaw, PL - near-complete operator tagging" }
     - { area: 71525,   note: "Paris, FR - strong internet_access and wheelchair coverage" }
     - { area: 1293250, note: "Taipei, TW - all four keys represented, East Asia diversity" }

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -296,13 +296,13 @@ filterableTags:
   schools:          [operator, operator:type, wheelchair, isced:level]
   universities:     [operator, operator:type, wheelchair]
   libraries:        [operator, operator:type, wheelchair, internet_access]
-  kindergarten:     [operator, operator:type]
+  kindergarten:     [operator, operator:type, wheelchair]
   college:          [operator, operator:type, wheelchair]
-  childcare:          [operator, operator:type]
+  childcare:          [operator, operator:type, wheelchair]
   driving-school:     [operator, wheelchair]
-  music-school:       [operator, operator:type]
-  language-school:    [operator, operator:type]
-  research-institute: [operator, operator:type]
+  music-school:       [operator, operator:type, wheelchair]
+  language-school:    [operator, operator:type, wheelchair]
+  research-institute: [operator, operator:type, wheelchair]
 
 # Curated demonstrator cities per template (OSM relation ids).
 # Cities whose real data best shows the template in the dashboard. Curation-only:

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -44,6 +44,11 @@ templates:
   - ["libraries","amenity=library","education","LibraryBig"]
   - ["kindergarten","amenity=kindergarten","education","Baby"]
   - ["college","amenity=college","education","GraduationCap"]
+  - ["childcare","amenity=childcare","education","Backpack"]
+  - ["driving-school","amenity=driving_school","education","Car"]
+  - ["music-school","amenity=music_school","education","Music"]
+  - ["language-school","amenity=language_school","education","Languages"]
+  - ["research-institute","amenity=research_institute","education","Microscope"]
 # Tourism
   - ["hotels","tourism=hotel","tourism","Hotel"]
   - ["attractions","tourism=attraction","tourism","Star"]
@@ -288,6 +293,16 @@ filterableTags:
   ev-charging:     [capacity, operator, access, fee]
   crossings:       [crossing, crossing:markings, tactile_paving]
   railway-stations: [station, wheelchair, operator, network]
+  schools:          [operator, operator:type, wheelchair, isced:level]
+  universities:     [operator, operator:type, wheelchair]
+  libraries:        [operator, operator:type, wheelchair, internet_access]
+  kindergarten:     [operator, operator:type]
+  college:          [operator, operator:type, wheelchair]
+  childcare:          [operator, operator:type]
+  driving-school:     [operator, wheelchair]
+  music-school:       [operator, operator:type]
+  language-school:    [operator, operator:type]
+  research-institute: [operator, operator:type]
 
 # Curated demonstrator cities per template (OSM relation ids).
 # Cities whose real data best shows the template in the dashboard. Curation-only:
@@ -319,6 +334,54 @@ demonstrators:
     - { area: 347950,  note: "Barcelona, ES - near-complete operator/network tagging" }
     - { area: 71525,   note: "Paris, FR - large set, varied networks/operators, strong accessibility" }
     - { area: 62428,   note: "Munich, DE - good wheelchair coverage, mixed train/subway modes" }
+  schools:
+    - { area: 451516,  note: "Wroclaw, PL - near-complete operator/operator:type/isced:level tagging" }
+    - { area: 419203,  note: "Utrecht, NL - strong isced:level, operator, wheelchair coverage" }
+    - { area: 71525,   note: "Paris, FR - operator:type near-universal (public/private split)" }
+    - { area: 62428,   note: "Munich, DE - solid wheelchair and operator coverage" }
+    - { area: 1293250, note: "Taipei, TW - East Asia representative" }
+  universities:
+    - { area: 451516,  note: "Wroclaw, PL - operator well-covered across campuses" }
+    - { area: 419203,  note: "Utrecht, NL - strong operator and wheelchair tagging" }
+    - { area: 71525,   note: "Paris, FR - operator:type public/private split clearly tagged" }
+    - { area: 62428,   note: "Munich, DE - best wheelchair coverage of the sample" }
+    - { area: 1293250, note: "Taipei, TW - East Asia representative" }
+  libraries:
+    - { area: 62428,   note: "Munich, DE - all four keys well covered (operator, type, wheelchair, internet_access)" }
+    - { area: 451516,  note: "Wroclaw, PL - near-complete operator tagging" }
+    - { area: 71525,   note: "Paris, FR - strong internet_access and wheelchair coverage" }
+    - { area: 1293250, note: "Taipei, TW - all four keys represented, East Asia diversity" }
+  kindergarten:
+    - { area: 451516,  note: "Wroclaw, PL - near-complete operator/operator:type tagging" }
+    - { area: 62428,   note: "Munich, DE - large sample, solid operator coverage" }
+    - { area: 71525,   note: "Paris, FR - decent operator/operator:type split" }
+    - { area: 419203,  note: "Utrecht, NL - regional diversity" }
+  college:
+    - { area: 451516,  note: "Wroclaw, PL - near-complete operator/operator:type tagging" }
+    - { area: 71525,   note: "Paris, FR - operator:type near half coverage" }
+    - { area: 419203,  note: "Utrecht, NL - best wheelchair coverage of the sample" }
+    - { area: 62428,   note: "Munich, DE - balanced operator/wheelchair tagging" }
+    - { area: 1293250, note: "Taipei, TW - East Asia representative" }
+  childcare:
+    - { area: 419203,  note: "Utrecht, NL - best operator coverage of the sample" }
+    - { area: 71525,   note: "Paris, FR - operator:type near a third coverage" }
+    - { area: 62428,   note: "Munich, DE - large sample, solid operator/operator:type split" }
+  driving-school:
+    - { area: 62428,   note: "Munich, DE - best wheelchair and operator coverage" }
+    - { area: 71525,   note: "Paris, FR - large sample, moderate wheelchair coverage" }
+    - { area: 451516,  note: "Wroclaw, PL - decent operator tagging" }
+  music-school:
+    - { area: 451516,  note: "Wroclaw, PL - near-complete operator/operator:type tagging (small sample)" }
+    - { area: 62428,   note: "Munich, DE - largest sample, moderate operator coverage" }
+    - { area: 71525,   note: "Paris, FR - moderate operator:type coverage" }
+  language-school:
+    - { area: 62428,   note: "Munich, DE - best operator/operator:type coverage" }
+    - { area: 451516,  note: "Wroclaw, PL - decent operator/operator:type split" }
+    - { area: 71525,   note: "Paris, FR - largest sample, moderate operator:type coverage" }
+  research-institute:
+    - { area: 62428,   note: "Munich, DE - best operator/operator:type coverage (small sample)" }
+    - { area: 451516,  note: "Wroclaw, PL - consistent operator/operator:type pairing (small sample)" }
+    - { area: 71525,   note: "Paris, FR - largest sample among candidates" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:

--- a/src/lib/category-icons.tsx
+++ b/src/lib/category-icons.tsx
@@ -4,6 +4,7 @@ import {
   Antenna,
   Apple,
   Baby,
+  Backpack,
   Banknote,
   BedDouble,
   Beef,
@@ -60,6 +61,7 @@ import {
   Info,
   LandPlot,
   Landmark,
+  Languages,
   Leaf,
   LibraryBig,
   Lightbulb,
@@ -67,10 +69,12 @@ import {
   MapPin,
   Martini,
   Medal,
+  Microscope,
   Milk,
   MoonStar,
   Mountain,
   MountainSnow,
+  Music,
   Package,
   Palette,
   PawPrint,
@@ -138,7 +142,7 @@ import {
  * Icon lookups for dataset templates and categories
  *
  * AUTO-GENERATED from prisma/templates.yml - DO NOT EDIT DIRECTLY
- * Generated: 2026-07-15T16:48:47.042Z
+ * Generated: 2026-07-28T15:12:01.922Z
  * Regenerate with: pnpm generate-icons
  */
 
@@ -282,6 +286,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Home className="w-5 h-5" />;
     case "chemist":
       return <Pill className="w-5 h-5" />;
+    case "childcare":
+      return <Backpack className="w-5 h-5" />;
     case "chimney":
       return <Factory className="w-5 h-5" />;
     case "church":
@@ -334,6 +340,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Building className="w-5 h-5" />;
     case "drinking-water":
       return <Droplet className="w-5 h-5" />;
+    case "driving-school":
+      return <Car className="w-5 h-5" />;
     case "electronics":
       return <Tv className="w-5 h-5" />;
     case "emergency-phones":
@@ -436,6 +444,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Gem className="w-5 h-5" />;
     case "kindergarten":
       return <Baby className="w-5 h-5" />;
+    case "language-school":
+      return <Languages className="w-5 h-5" />;
     case "libraries":
       return <LibraryBig className="w-5 h-5" />;
     case "livestock-buildings":
@@ -468,6 +478,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Trophy className="w-5 h-5" />;
     case "museums":
       return <Landmark className="w-5 h-5" />;
+    case "music-school":
+      return <Music className="w-5 h-5" />;
     case "natural-surfaces":
       return <Mountain className="w-5 h-5" />;
     case "natural-vegetation":
@@ -522,6 +534,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Train className="w-5 h-5" />;
     case "recycling":
       return <Recycle className="w-5 h-5" />;
+    case "research-institute":
+      return <Microscope className="w-5 h-5" />;
     case "residential":
       return <Building2 className="w-5 h-5" />;
     case "restaurants":


### PR DESCRIPTION
## Epic #245: Education domain batch

Builds on #406 (merged — workflow doc + filterableTags/demonstrators infra), rebased onto `develop`.

### Tuned filterableTags (5 existing templates)

Validated against dashboard coverage on Munich/Paris/Utrecht/Wroclaw/Taipei:

| template | filterableTags |
|---|---|
| schools | operator, operator:type, wheelchair, isced:level |
| universities | operator, operator:type, wheelchair |
| libraries | operator, operator:type, wheelchair, internet_access |
| kindergarten | operator, operator:type, wheelchair |
| college | operator, operator:type, wheelchair |

`operator:type` (public/private/government/ngo/religious/community) is the consistent civic-relevant classifier across the domain.

**Dropped** (failed the keep bar):
- `religion`/`denomination` — near-absent everywhere (0.5-17%).
- `internet_access` on universities — flat "yes" blob.
- `language:*` on language-school — fragmented across many boolean keys (same issue as EV connectors).
- `preschool=yes/no` on kindergarten — 17.7% in Munich, 0-3.4% elsewhere; near-zero-outside-one-country pattern that also dropped `network` from `ev-charging`. (It's the wiki's own tag for the kindergarten-vs-childcare distinction — see below.)

### Added 5 new templates

Amenities documented under OSM's `Key:amenity` Education section but missing from `templates.yml`, confirmed present via Overpass counts (Munich/Paris/Wroclaw) before adding:

| template | amenity | filterableTags |
|---|---|---|
| childcare | `amenity=childcare` | operator, operator:type, wheelchair |
| driving-school | `amenity=driving_school` | operator, wheelchair |
| music-school | `amenity=music_school` | operator, operator:type, wheelchair |
| language-school | `amenity=language_school` | operator, operator:type, wheelchair |
| research-institute | `amenity=research_institute` | operator, operator:type, wheelchair |

`childcare` is the notable gap fix: ~10% of Munich's under-school-age facilities were missed entirely by `kindergarten` alone. Per the OSM wiki the two are genuinely separate tags — `kindergarten` is education-focused (early-years teaching), `childcare` is supervision-focused (nurseries + after-school care) — so it's a sibling template, not a widened `kindergarten` query and not a parent/child pair (that pattern, `bicycle-parking` under `bicycle-infrastructure`, is for strict subset queries). Caveat for future audits: the wiki notes mappers sometimes still tag pure-supervision facilities as `kindergarten`, so this pair carries some existing tagging ambiguity we can't fix template-side.

### Accessibility guidance (docs)

Added to `docs/features/template-management.md`, restructured into keep/drop/exception lists:

- **`wheelchair` is a default shortlist candidate** for any enterable-POI template (shops, healthcare, education, government, culture, tourism, food, transit) — with a named skip list (outdoor/natural features, street furniture, `parking` → use `capacity:disabled`, unstaffed infra).
- **Blind/visual-impairment tags** (`tactile_paving`, `kerb`, `traffic_signals:sound`/`:vibration`) stay scoped to pedestrian-infra templates, per the existing `crossings`/`bus-stops` pattern.
- **Coverage alone never drops a wiki-essential equity/usability key** (`wheelchair`, `capacity`) — a large Missing share is itself the signal. Applied to `wheelchair` on the 5 templates above with low real-world coverage (0-31%, mostly single digits): kept, not dropped.
- **Don't translate index/code values** — standardized indexes/codes (`isced:level` = ISCED 0-8, `capacity` counts) stay raw with no `TagValue` map; only opaque enum strings (`wlan`, `government`) get value labels. The code is canonical and its ordering is meaningful.

### Category placement (reviewed, no change)

Confirmed the domain's category assignments — `libraries` stays in `education` (public libraries are civic learning infrastructure). Deliberately did **not** move the culture/tourism items (`museums`, `galleries`, `arts-centre`, `theatres`, `cinemas`) into education: they have educational value but their primary civic function and OSM tagging is cultural-destination, and "education coverage" should read as schools/childcare/etc., not museums.

**Demonstrators** picked per template from the same city pool, balancing best-data with geographic diversity (added Taipei for East Asia representation on several).

Verified: `pnpm db:sync`, `type-check`, `i18n:check`, `generate-icons`, 42/42 parser unit tests. Spot-checked legend rendering live (schools/operator:type on Wroclaw, childcare on Paris). Rebased cleanly onto `develop` after #406 merged (`git rebase --onto origin/develop`).

## Test plan
- [ ] `pnpm db:sync`, `pnpm type-check`, `pnpm i18n:check`
- [ ] `pnpm vitest run prisma/lib/__tests__/template-parser.test.ts`
- [ ] Spot-check a few dataset pages under `/area/{relation}/dataset/{template}` for the new templates and confirm legend/Color-by render



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new education location categories for childcare, driving schools, music schools, language schools, and research institutes.
  * Added dedicated icons and localized names and descriptions for the new categories.
  * Expanded education filters with operator, accessibility, and internet access details.
  * Added curated example locations to improve category discovery and validation.
  * Added translations for operator types, education levels, internet access, and accessibility tags in English, Spanish, and Portuguese.

* **Documentation**
  * Clarified accessibility-focused filtering guidance and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->