### PR TITLE
feat(templates): tune civic + remaining domains, add markets/hydrants/defibrillators (#245)

### DIFF
--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -56,48 +56,39 @@ Prereqs: local dev server, signed in (osmforcities-dev-auth), Overpass tunnel up
 
 ### Tuning `filterableTags` from the dashboard
 
-Shortlist from the OSM wiki page for the selector — it names the tags that describe the
-feature's real-world usability (for `amenity=charging_station`: capacity, connector,
-access, operator, fee). Then decide per key:
+**Candidates come from the selector's OSM wiki page only.** It names the usability tags
+(for `amenity=charging_station`: capacity, connector, access, operator, fee). Never invent
+a key, and never add a regional-convention key — the AWWA hydrant `colour` scheme, US
+`drive_through` — even where locally common. Within the wiki set, decide per key:
 
-**Keep** a key only when all three hold:
+**Keep** when all three hold:
 
-- **Wiki-relevant** — describes usability/equity, not identity. Coverage never qualifies
-  a key on its own: a well-covered `ref` or `name` is a unique code, not a filter.
-- **Colorable** — exists as one single key. Not fragmented across siblings (EV connectors
-  live in count-valued `socket:type2`/`socket:type2_combo`/… — no single key to color by).
-- **Well-covered with variance** — a meaningful share of features carry it, and not the
-  same value on every one (or coloring is one flat blob).
+- **Wiki-relevant** — describes usability/equity, not identity. `ref`/`name` are codes,
+  never filters, no matter how well covered.
+- **Colorable** — one single key, not fragmented across siblings (EV connectors live in
+  count-valued `socket:type2`/`socket:type2_combo`/… — no single key to color by).
+- **Well-covered with variance** — a meaningful share carry it, with more than one value.
 
-**Drop** a key when:
+**Drop** when: near-absent (`covered` on bus-stops); single-valued everywhere
+(`public_transport=platform`); identity (`ref`, `name`); fragmented across keys; or a
+**sibling-node** tag — the data sits on a different element than the queried one (`kerb` on
+the sidewalk node, not the crossing).
 
-- **Near-absent** — `covered` on bus-stops.
-- **Single-valued everywhere** — `public_transport=platform`, PTv2-co-tagged on every stop.
-- **Not wiki-relevant** — `ref`, `name`.
-- **Fragmented** across many keys (see EV connectors above).
-- **Sibling-node** — the data lives on a different element than the queried one (`kerb`
-  on the sidewalk node, not the crossing).
+**Exceptions:**
 
-**Exceptions to the rules:**
+- **Equity/usability keys** (`capacity`, `wheelchair`) stay even when near-absent — the
+  Missing share *is* the signal. Wiki-importance and common sense over the coverage number.
+- **Skewed is fine** — `operator` on `bicycle-rental` is one value per city, but the stray
+  outlier (a second operator, a mis-tagged dock) is exactly what we exist to flag.
 
-- **Wiki-essential equity/usability keys** (`capacity`, `wheelchair`) stay even when
-  near-absent — a large Missing share is the signal, not a reason to hide the filter.
-  Use wiki-importance and common sense, not the coverage number alone.
-- **Skewed is fine.** `operator` on `bicycle-rental` is mostly one value (one bike-share
-  system per city), but the stray outliers — a second operator, a mis-tagged dock — are
-  exactly the deviations OSM for Cities exists to flag. Don't require an even spread.
+Tune both ways off the dashboard's "Most used tags": drop near-zero keys, widen a
+high-usage varied one (coverage may be regional — the legend handles Missing). Per key
+added: `TagLabel` in en/es/pt-BR, re-sync, reload to confirm. A subagent that measures
+must do the wiki cross-check too, not report coverage alone.
 
-Tune both ways off the dashboard's "Most used tags" menu: **reduce** near-zero keys,
-**widen** a high-usage varied key (coverage can be regional — the legend handles Missing).
-For each key added: add a `TagLabel` in en/es/pt-BR (values fall back to the raw string,
-so `TagValue` labels are optional), re-sync, reload to confirm. If measurement is
-delegated to a subagent, it must do the wiki cross-check too — not report coverage alone.
-
-Don't translate values that are standardized indexes or codes (`isced:level` = ISCED
-levels 0-8, `capacity` counts): leave them raw, no `TagValue` map. The code is the
-canonical form and its ordering is meaningful; a localized word list would only obscure
-it. Only add `TagValue` labels for keys whose values are opaque enum strings (`wlan`,
-`government`, `parking`, `surface`).
+Leave standardized codes/indexes raw — no `TagValue` map (`isced:level` 0-8, `admin_level`,
+`capacity` counts): the code's ordering is canonical, a word list obscures it. Add
+`TagValue` labels only for opaque enum strings (`wlan`, `government`, `parking`, `surface`).
 
 ### Accessibility as a transversal signal
 
@@ -252,57 +243,51 @@ public-amenity batches: financial, culture, government, emergency, retail shops,
 green leisure, barriers, religion — plus the age-view screen-and-skip blocks (nature,
 agriculture, infrastructure, housing, environment).
 
-- **places-of-worship — religion consolidation.** Replaced the five value-templates
-  `church`/`mosque`/`synagogue`/`temple`/`shrine` (each a loose `religion=christian`/`=islam`/…
-  selector that also matches cemeteries, schools and other `religion`-tagged features) with the
-  single `amenity=place_of_worship` template colored by `religion`. `[religion, denomination,
-  wheelchair]` — `religion` is the textbook single-key color-by (christian/muslim/jewish/buddhist/…),
-  near-universal on worship sites. The old templates soft-deprecate on merge.
-- **atms** — `[operator, brand, cash_in, wheelchair]`. `cash_in` (yes/no deposit-capability) is
-  the real usability split; `network`/`fee` dropped as near-absent. **`wheelchair` kept** despite
-  the "skip wheelchair for unstaffed infra" rule: the wiki doesn't formally document `wheelchair`
-  for ATMs (its ATM a11y key is `speech_output:*` for blind/VI users), but `speech_output` is
-  globally unpopulated, while `wheelchair` is the only a11y signal with real coverage —
-  well-split (yes/no/limited) in Germany, sparse elsewhere, so the Missing share is the a11y-gap
-  signal. An ATM's machine interface (screen/slot height, step-free approach) is closer to a
-  service point than street furniture, which is why it earns the exception that
-  bicycle-parking/taxi-ranks do not.
-- **banks** — `[brand, operator, atm, wheelchair]`. Staffed/enterable, so `wheelchair` stays;
-  `atm=yes/no` (does the branch have an ATM) is a useful binary.
-- **museums** — `[museum, operator, fee, wheelchair]`. `museum=*` (art/history/local/…) is the
-  defining categorical attribute — kept even at moderate coverage, its Missing share is
-  informative. `memorials` keeps only `[memorial]` (plaque/statue/war_memorial — the type is the
-  color-by; outdoor, so no `wheelchair`); `monuments` stays age-view.
-- **fire-hydrants** (new, `emergency=fire_hydrant`) — `[fire_hydrant:type, fire_hydrant:position,
-  fire_hydrant:diameter]`. `fire_hydrant:type`/`:position` are near-universal. **`fire_hydrant:diameter`**
-  (nominal pipe diameter, mm) is the capacity descriptor — numeric but a small standardized value set;
-  the legend's `TOP_VALUES_COUNT` cap folds the long tail into Other, same as `maxspeed`. Coverage is
-  regional (strong in DE/UK, sparse elsewhere) — the Missing share is the signal, demonstrate in DE.
-  Dropped `colour` (the AWWA bonnet-colour scheme is a US-regional practice barely tagged elsewhere).
-  Surveyed `couplings:type` (Storz/UNI/Barcelona/Guillemin) and `water_source` across several
-  countries and dropped both: `couplings:type` is **globally unpopulated** — mappers don't use it even
-  where the coupling genuinely varies — and `water_source` is single-valued `main` wherever present.
-  **Lesson reinforced:** a regionally-standardized key can look empty in one country (Germany Storz is
-  universal → untagged) — check across countries before dropping, but here the survey confirmed it's
-  dead everywhere, not a German artifact.
-- **defibrillators** (new, `emergency=defibrillator`) — `[access, indoor]`. `indoor` (mounted inside
-  vs outside) is the main split; `access` adds the public-vs-restricted dimension. Dropped `locked`
-  (near-absent). A life-safety dataset worth surfacing even where thin.
-- **markets** (new, `amenity=marketplace`) — **age-view only.** A valuable civic dataset (municipal
-  markets, street feiras), but its wiki keys (`operator`, `organic`) are near-absent in well-mapped
-  cities — no viable color-by, so age-view is the correct outcome. Distinct multi-vendor tag
-  vocabulary keeps it out of the single-vendor `shops` tuning even though it shares the `shops`
-  category.
-- **shops** — `wheelchair` (transversal equity-keep) on every enterable storefront, plus `brand`
-  for chain-vs-independent. `supermarkets` adds `[operator, organic]`, `greengrocers` adds
-  `[organic]`, `clothes` adds `[clothes]` (men/women/children subtype), `fuel` is `[brand,
-  operator]` (unstaffed forecourt — no wheelchair; fuel-type keys are fragmented `fuel:*` booleans).
-- **government / emergency stations** — `government-office` `[government, operator, wheelchair]`,
-  `courts`/`police-stations` `[operator, wheelchair]`, `fire-stations` `[operator, wheelchair]`,
-  `ambulance-stations` `[operator]`. `prisons` and `emergency-phones` stay age-view.
-- **green leisure** (not covered by the sport batch) — `parks` `[access]`, `gardens` `[garden:type,
-  access]`, `marinas` `[access, fee, operator]`, `golf-courses` `[access]`, `fitness-centers`
-  `[wheelchair]`. `gates` (barriers) `[access]` — locked/public is the useful split.
+- **places-of-worship — religion consolidation.** `[religion, denomination, wheelchair]`. Replaced
+  the five value-templates `church`/`mosque`/`synagogue`/`temple`/`shrine` (each a loose
+  `religion=*` selector that also caught cemeteries/schools) with one `amenity=place_of_worship`
+  colored by `religion` (the textbook single-key color-by, near-universal). Old ones soft-deprecate.
+- **atms** — `[operator, brand, cash_in, wheelchair]`. `cash_in` (deposit y/n) is the usability
+  split; `network`/`fee` dropped as near-absent. `wheelchair` kept via the equity exception even
+  though the ATM wiki's a11y key is the (globally-empty) `speech_output:*` — an ATM's interface is a
+  service point, not street furniture, unlike bicycle-parking/taxi-ranks.
+- **banks** — `[brand, operator, atm, wheelchair]`. Enterable → `wheelchair`; `atm=y/n` is a useful
+  binary.
+- **museums** — `[museum, operator, fee, wheelchair]`. `museum=*` (art/history/local) is the
+  defining categorical, kept at moderate coverage. `memorials` `[memorial]` (type is the color-by;
+  outdoor → no `wheelchair`); `monuments` age-view.
+- **fire-hydrants** (new) — `[fire_hydrant:type, fire_hydrant:position, fire_hydrant:diameter,
+  fire_hydrant:pressure]`. type/position near-universal; `diameter` (mm, small value set) and
+  `pressure` (bar) are wiki-foundational capacity descriptors — regional coverage, Missing is the
+  signal, demonstrate in DE. Dropped `colour` (US AWWA regional), `couplings:type` (globally empty),
+  `water_source` (single-valued `main`). **Lesson:** check a regionally-standardized key across
+  countries before dropping — but these were dead everywhere, not a German artifact.
+- **defibrillators** (new) — `[access, indoor]`. `indoor` is the main split, `access` the
+  public-vs-restricted one. Dropped `locked` (0%). Life-safety data worth surfacing even thin.
+- **markets** (new) — **age-view only.** Wiki keys (`operator`, `organic`) near-absent in
+  well-mapped cities → no viable color-by. Multi-vendor vocabulary keeps it out of `shops` tuning.
+- **shops** — `wheelchair` (equity-keep) on every storefront + `brand` (chain-vs-independent).
+  `supermarkets` +`[operator, organic]`, `greengrocers` +`[organic]`, `clothes` +`[clothes]`
+  (men/women/children), `fuel` `[brand, operator]` (unstaffed forecourt → no wheelchair; fuel-type
+  keys are fragmented `fuel:*` booleans).
+- **government / emergency stations** — `government-office` `[government, operator, admin_level,
+  wheelchair]` (`admin_level` = national/state/municipal, wiki-recommended but thin ~5%; `operator`
+  kept — live coverage shows it's the richer dimension), `courts`/`police-stations`/`fire-stations`
+  `[operator, wheelchair]`, `ambulance-stations` `[operator]`. `prisons`/`emergency-phones` age-view.
+  **Selector fixes (live-validation catch, same lesson as speed-cameras):** `courts` queried the
+  non-existent `amenity=court` → fixed to `amenity=courthouse`; `ambulance-stations` queried
+  `amenity=ambulance_station` (24 objects worldwide) → `emergency=ambulance_station` (16k);
+  `fitness-centers` queried US-spelled `leisure=fitness_center` (0 worldwide) → `leisure=fitness_centre`.
+  All three returned empty everywhere until fixed — confirm a selector matches real features before tuning.
+- **green leisure** — `parks` `[access]`, `gardens` `[garden:type, access]`, `marinas` `[fee,
+  operator]` (dropped `access` — near-zero + not on the marina wiki page), `golf-courses` age-view
+  (dropped `access` — 0-8% and not wiki-listed; operator/fee equally thin, so no filter),
+  `fitness-centers` `[sport, wheelchair]` (`sport` is the best-covered, best-varied key here —
+  yoga/fitness/pilates/cycling, ~51% Berlin — and the de-facto type dimension mappers use; added
+  despite not being on the wiki's recommended-combination list, a data-over-wiki exception), `gates`
+  `[access]` (locked/public split). `shopping-malls`
+  `[operator]` (wiki tags the mall building not inner shops, so `wheelchair` reads low; operator is
+  the wiki-endorsed key though also thin).
 - **Screen-and-skip (age-view only):** nature (trees, water, forests, natural surfaces),
   agriculture (already observable-infrastructure only), man_made infrastructure (towers, tanks,
   lamps), housing (apartments/houses/residential — `building:levels` is numeric), environment

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -256,43 +256,45 @@ agriculture, infrastructure, housing, environment).
   `church`/`mosque`/`synagogue`/`temple`/`shrine` (each a loose `religion=christian`/`=islam`/…
   selector that also matches cemeteries, schools and other `religion`-tagged features) with the
   single `amenity=place_of_worship` template colored by `religion`. `[religion, denomination,
-  wheelchair]` — Berlin 751 sites, religion 99%, denomination 80%, wheelchair 51%; `religion` is
-  the textbook single-key color-by (christian/muslim/jewish/buddhist/…). The old templates
-  soft-deprecate on merge.
-- **atms** — `[operator, brand, cash_in]`. Munich: operator 86%, brand 41%. Dropped `network`
-  (8%) and `fee` (2%) as near-absent; added **`cash_in`** (80%, well-varied yes/no) — the
-  deposit-capability split is the real usability distinction. Unstaffed machine → no `wheelchair`.
+  wheelchair]` — `religion` is the textbook single-key color-by (christian/muslim/jewish/buddhist/…),
+  near-universal on worship sites. The old templates soft-deprecate on merge.
+- **atms** — `[operator, brand, cash_in, wheelchair]`. `cash_in` (yes/no deposit-capability) is
+  the real usability split; `network`/`fee` dropped as near-absent. **`wheelchair` kept** despite
+  the "skip wheelchair for unstaffed infra" rule: the wiki doesn't formally document `wheelchair`
+  for ATMs (its ATM a11y key is `speech_output:*` for blind/VI users), but `speech_output` is
+  globally unpopulated, while `wheelchair` is the only a11y signal with real coverage —
+  well-split (yes/no/limited) in Germany, sparse elsewhere, so the Missing share is the a11y-gap
+  signal. An ATM's machine interface (screen/slot height, step-free approach) is closer to a
+  service point than street furniture, which is why it earns the exception that
+  bicycle-parking/taxi-ranks do not.
 - **banks** — `[brand, operator, atm, wheelchair]`. Staffed/enterable, so `wheelchair` stays;
   `atm=yes/no` (does the branch have an ATM) is a useful binary.
-- **museums** — `[museum, operator, fee, wheelchair]`. Paris 165 museums: fee 62%, wheelchair 46%,
-  museum-type 21%, operator 18%. `museum=*` (art/history/local/…) is the defining categorical
-  attribute — kept despite moderate coverage, its Missing share is informative. `memorials` keeps
-  only `[memorial]` (plaque/statue/war_memorial — the type is the color-by; outdoor, so no
-  `wheelchair`); `monuments` stays age-view.
+- **museums** — `[museum, operator, fee, wheelchair]`. `museum=*` (art/history/local/…) is the
+  defining categorical attribute — kept even at moderate coverage, its Missing share is
+  informative. `memorials` keeps only `[memorial]` (plaque/statue/war_memorial — the type is the
+  color-by; outdoor, so no `wheelchair`); `monuments` stays age-view.
 - **fire-hydrants** (new, `emergency=fire_hydrant`) — `[fire_hydrant:type, fire_hydrant:position,
-  fire_hydrant:diameter]`. Munich 12k hydrants: type 99%, position 97%. **`fire_hydrant:diameter`**
-  (nominal pipe diameter, mm) is the capacity descriptor — numeric but a small standardized value set
-  (100/150/200/300/400/80… the legend's `TOP_VALUES_COUNT` cap folds the long tail into Other, same as
-  `maxspeed`). Regional: 90% Munich / 73% Berlin / 38% London with real variance; sparse elsewhere
-  (Paris 8%, São Paulo 1%) — the Missing share is the coverage signal, demonstrate in DE/UK. Dropped
-  `colour` (<1% globally — the AWWA bonnet-colour scheme is a US-regional practice barely tagged
-  elsewhere). Surveyed `couplings:type` (Storz/UNI/Barcelona/Guillemin) and `water_source` across 8
-  countries and dropped both: `couplings:type` is **globally unpopulated** (Paris 0/9,440, Barcelona
-  1/1,004 — mappers don't use it even where the coupling genuinely varies), and `water_source` is
-  single-valued `main` wherever present. **Lesson reinforced:** a regionally-standardized key can look
-  empty in one country (Germany Storz is universal → untagged) — check across countries before dropping,
-  but here the cross-country survey confirmed it's dead everywhere, not a German artifact.
-- **defibrillators** (new, `emergency=defibrillator`) — `[access, indoor]`. Munich 292 AEDs:
-  indoor 89%, access 27%. Dropped `locked` (0% — the legend auto-omits an empty color-by anyway).
-  A life-safety dataset worth surfacing even where thin.
-- **markets** (new, `amenity=marketplace`) — **age-view only.** The template is a valuable civic
-  dataset (Barcelona 49 municipal markets, São Paulo 88 incl. street feiras), but its wiki keys are
-  near-absent in both well-mapped cities (operator 6%/13%, organic 2%/1%) — no viable color-by, so
-  age-view is the correct outcome. Distinct multi-vendor tag vocabulary keeps it out of the
-  single-vendor `shops` tuning even though it shares the `shops` category.
+  fire_hydrant:diameter]`. `fire_hydrant:type`/`:position` are near-universal. **`fire_hydrant:diameter`**
+  (nominal pipe diameter, mm) is the capacity descriptor — numeric but a small standardized value set;
+  the legend's `TOP_VALUES_COUNT` cap folds the long tail into Other, same as `maxspeed`. Coverage is
+  regional (strong in DE/UK, sparse elsewhere) — the Missing share is the signal, demonstrate in DE.
+  Dropped `colour` (the AWWA bonnet-colour scheme is a US-regional practice barely tagged elsewhere).
+  Surveyed `couplings:type` (Storz/UNI/Barcelona/Guillemin) and `water_source` across several
+  countries and dropped both: `couplings:type` is **globally unpopulated** — mappers don't use it even
+  where the coupling genuinely varies — and `water_source` is single-valued `main` wherever present.
+  **Lesson reinforced:** a regionally-standardized key can look empty in one country (Germany Storz is
+  universal → untagged) — check across countries before dropping, but here the survey confirmed it's
+  dead everywhere, not a German artifact.
+- **defibrillators** (new, `emergency=defibrillator`) — `[access, indoor]`. `indoor` (mounted inside
+  vs outside) is the main split; `access` adds the public-vs-restricted dimension. Dropped `locked`
+  (near-absent). A life-safety dataset worth surfacing even where thin.
+- **markets** (new, `amenity=marketplace`) — **age-view only.** A valuable civic dataset (municipal
+  markets, street feiras), but its wiki keys (`operator`, `organic`) are near-absent in well-mapped
+  cities — no viable color-by, so age-view is the correct outcome. Distinct multi-vendor tag
+  vocabulary keeps it out of the single-vendor `shops` tuning even though it shares the `shops`
+  category.
 - **shops** — `wheelchair` (transversal equity-keep) on every enterable storefront, plus `brand`
-  for chain-vs-independent. Spot-checked on supermarkets (Munich: wheelchair 86%, brand 77%,
-  operator 25%, organic 20%); `supermarkets` adds `[operator, organic]`, `greengrocers` adds
+  for chain-vs-independent. `supermarkets` adds `[operator, organic]`, `greengrocers` adds
   `[organic]`, `clothes` adds `[clothes]` (men/women/children subtype), `fuel` is `[brand,
   operator]` (unstaffed forecourt — no wheelchair; fuel-type keys are fragmented `fuel:*` booleans).
 - **government / emergency stations** — `government-office` `[government, operator, wheelchair]`,

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -245,6 +245,58 @@ sit on the sibling road or crossing node, not the queried element.
 > `categories:` map). Merging categories is YAML-only; emptied categories drop out of the browse
 > UI, which lists only categories that have templates.
 
+### Civic, retail & remaining domains (batch)
+
+Covers the domains left after the mobility/education/food/sport/tourism/social/healthcare/
+public-amenity batches: financial, culture, government, emergency, retail shops, markets,
+green leisure, barriers, religion — plus the age-view screen-and-skip blocks (nature,
+agriculture, infrastructure, housing, environment).
+
+- **places-of-worship — religion consolidation.** Replaced the five value-templates
+  `church`/`mosque`/`synagogue`/`temple`/`shrine` (each a loose `religion=christian`/`=islam`/…
+  selector that also matches cemeteries, schools and other `religion`-tagged features) with the
+  single `amenity=place_of_worship` template colored by `religion`. `[religion, denomination,
+  wheelchair]` — Berlin 751 sites, religion 99%, denomination 80%, wheelchair 51%; `religion` is
+  the textbook single-key color-by (christian/muslim/jewish/buddhist/…). The old templates
+  soft-deprecate on merge.
+- **atms** — `[operator, brand, cash_in]`. Munich: operator 86%, brand 41%. Dropped `network`
+  (8%) and `fee` (2%) as near-absent; added **`cash_in`** (80%, well-varied yes/no) — the
+  deposit-capability split is the real usability distinction. Unstaffed machine → no `wheelchair`.
+- **banks** — `[brand, operator, atm, wheelchair]`. Staffed/enterable, so `wheelchair` stays;
+  `atm=yes/no` (does the branch have an ATM) is a useful binary.
+- **museums** — `[museum, operator, fee, wheelchair]`. Paris 165 museums: fee 62%, wheelchair 46%,
+  museum-type 21%, operator 18%. `museum=*` (art/history/local/…) is the defining categorical
+  attribute — kept despite moderate coverage, its Missing share is informative. `memorials` keeps
+  only `[memorial]` (plaque/statue/war_memorial — the type is the color-by; outdoor, so no
+  `wheelchair`); `monuments` stays age-view.
+- **fire-hydrants** (new, `emergency=fire_hydrant`) — `[fire_hydrant:type, fire_hydrant:position]`.
+  Munich 12k hydrants: type 99%, position 97%. Dropped `colour` (<1% — the AWWA colour scheme is a
+  US-regional practice barely tagged elsewhere) and `fire_hydrant:diameter` (numeric, poor color-by).
+- **defibrillators** (new, `emergency=defibrillator`) — `[access, indoor]`. Munich 292 AEDs:
+  indoor 89%, access 27%. Dropped `locked` (0% — the legend auto-omits an empty color-by anyway).
+  A life-safety dataset worth surfacing even where thin.
+- **markets** (new, `amenity=marketplace`) — **age-view only.** The template is a valuable civic
+  dataset (Barcelona 49 municipal markets, São Paulo 88 incl. street feiras), but its wiki keys are
+  near-absent in both well-mapped cities (operator 6%/13%, organic 2%/1%) — no viable color-by, so
+  age-view is the correct outcome. Distinct multi-vendor tag vocabulary keeps it out of the
+  single-vendor `shops` tuning even though it shares the `shops` category.
+- **shops** — `wheelchair` (transversal equity-keep) on every enterable storefront, plus `brand`
+  for chain-vs-independent. Spot-checked on supermarkets (Munich: wheelchair 86%, brand 77%,
+  operator 25%, organic 20%); `supermarkets` adds `[operator, organic]`, `greengrocers` adds
+  `[organic]`, `clothes` adds `[clothes]` (men/women/children subtype), `fuel` is `[brand,
+  operator]` (unstaffed forecourt — no wheelchair; fuel-type keys are fragmented `fuel:*` booleans).
+- **government / emergency stations** — `government-office` `[government, operator, wheelchair]`,
+  `courts`/`police-stations` `[operator, wheelchair]`, `fire-stations` `[operator, wheelchair]`,
+  `ambulance-stations` `[operator]`. `prisons` and `emergency-phones` stay age-view.
+- **green leisure** (not covered by the sport batch) — `parks` `[access]`, `gardens` `[garden:type,
+  access]`, `marinas` `[access, fee, operator]`, `golf-courses` `[access]`, `fitness-centers`
+  `[wheelchair]`. `gates` (barriers) `[access]` — locked/public is the useful split.
+- **Screen-and-skip (age-view only):** nature (trees, water, forests, natural surfaces),
+  agriculture (already observable-infrastructure only), man_made infrastructure (towers, tanks,
+  lamps), housing (apartments/houses/residential — `building:levels` is numeric), environment
+  (waterfall/dam), and the remaining outdoor barriers (walls/fences/hedges). Natural and
+  structural features carry no single well-covered usability key to color by.
+
 ## Validation the sync enforces
 
 `prisma/lib/template-parser.ts` (tests: `prisma/lib/__tests__/template-parser.test.ts`).

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -269,9 +269,19 @@ agriculture, infrastructure, housing, environment).
   attribute — kept despite moderate coverage, its Missing share is informative. `memorials` keeps
   only `[memorial]` (plaque/statue/war_memorial — the type is the color-by; outdoor, so no
   `wheelchair`); `monuments` stays age-view.
-- **fire-hydrants** (new, `emergency=fire_hydrant`) — `[fire_hydrant:type, fire_hydrant:position]`.
-  Munich 12k hydrants: type 99%, position 97%. Dropped `colour` (<1% — the AWWA colour scheme is a
-  US-regional practice barely tagged elsewhere) and `fire_hydrant:diameter` (numeric, poor color-by).
+- **fire-hydrants** (new, `emergency=fire_hydrant`) — `[fire_hydrant:type, fire_hydrant:position,
+  fire_hydrant:diameter]`. Munich 12k hydrants: type 99%, position 97%. **`fire_hydrant:diameter`**
+  (nominal pipe diameter, mm) is the capacity descriptor — numeric but a small standardized value set
+  (100/150/200/300/400/80… the legend's `TOP_VALUES_COUNT` cap folds the long tail into Other, same as
+  `maxspeed`). Regional: 90% Munich / 73% Berlin / 38% London with real variance; sparse elsewhere
+  (Paris 8%, São Paulo 1%) — the Missing share is the coverage signal, demonstrate in DE/UK. Dropped
+  `colour` (<1% globally — the AWWA bonnet-colour scheme is a US-regional practice barely tagged
+  elsewhere). Surveyed `couplings:type` (Storz/UNI/Barcelona/Guillemin) and `water_source` across 8
+  countries and dropped both: `couplings:type` is **globally unpopulated** (Paris 0/9,440, Barcelona
+  1/1,004 — mappers don't use it even where the coupling genuinely varies), and `water_source` is
+  single-valued `main` wherever present. **Lesson reinforced:** a regionally-standardized key can look
+  empty in one country (Germany Storz is universal → untagged) — check across countries before dropping,
+  but here the cross-country survey confirmed it's dead everywhere, not a German artifact.
 - **defibrillators** (new, `emergency=defibrillator`) — `[access, indoor]`. Munich 292 AEDs:
   indoor 89%, access 27%. Dropped `locked` (0% — the legend auto-omits an empty color-by anyway).
   A life-safety dataset worth surfacing even where thin.

--- a/messages/en.json
+++ b/messages/en.json
@@ -709,6 +709,7 @@
     "garden:type": "Garden type",
     "fire_hydrant:type": "Hydrant type",
     "fire_hydrant:position": "Position",
+    "fire_hydrant:diameter": "Pipe diameter",
     "cash_in": "Cash deposit",
     "indoor": "Indoor"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -702,6 +702,7 @@
     "museum": "Museum type",
     "memorial": "Memorial type",
     "government": "Office type",
+    "admin_level": "Government level",
     "religion": "Religion",
     "denomination": "Denomination",
     "organic": "Organic",
@@ -710,8 +711,10 @@
     "fire_hydrant:type": "Hydrant type",
     "fire_hydrant:position": "Position",
     "fire_hydrant:diameter": "Pipe diameter",
+    "fire_hydrant:pressure": "Pressure",
     "cash_in": "Cash deposit",
-    "indoor": "Indoor"
+    "indoor": "Indoor",
+    "sport": "Activity"
   },
   "TagValue": {
     "__common__": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -696,13 +696,54 @@
     "traffic_calming": "Type",
     "operator:type": "Operator type",
     "isced:level": "Education level",
-    "internet_access": "Internet access"
+    "internet_access": "Internet access",
+    "brand": "Brand",
+    "atm": "ATM",
+    "museum": "Museum type",
+    "memorial": "Memorial type",
+    "government": "Office type",
+    "religion": "Religion",
+    "denomination": "Denomination",
+    "organic": "Organic",
+    "clothes": "Clothing type",
+    "garden:type": "Garden type",
+    "fire_hydrant:type": "Hydrant type",
+    "fire_hydrant:position": "Position",
+    "cash_in": "Cash deposit",
+    "indoor": "Indoor"
   },
   "TagValue": {
     "__common__": {
       "yes": "Yes",
       "no": "No",
       "limited": "Limited"
+    },
+    "religion": {
+      "christian": "Christian",
+      "muslim": "Muslim",
+      "jewish": "Jewish",
+      "buddhist": "Buddhist",
+      "hindu": "Hindu",
+      "sikh": "Sikh",
+      "taoist": "Taoist",
+      "shinto": "Shinto",
+      "bahai": "Bahá'í",
+      "jain": "Jain"
+    },
+    "fire_hydrant:type": {
+      "pillar": "Pillar",
+      "underground": "Underground",
+      "wall": "Wall",
+      "pipe": "Pipe"
+    },
+    "memorial": {
+      "plaque": "Plaque",
+      "statue": "Statue",
+      "war_memorial": "War memorial",
+      "bust": "Bust",
+      "stone": "Stone",
+      "sculpture": "Sculpture",
+      "stele": "Stele"
     },
     "access": {
       "private": "Private",

--- a/messages/es.json
+++ b/messages/es.json
@@ -718,6 +718,7 @@
     "garden:type": "Tipo de jardín",
     "fire_hydrant:type": "Tipo de hidrante",
     "fire_hydrant:position": "Posición",
+    "fire_hydrant:diameter": "Diámetro de tubería",
     "cash_in": "Depósito de efectivo",
     "indoor": "Interior"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -711,6 +711,7 @@
     "museum": "Tipo de museo",
     "memorial": "Tipo de monumento",
     "government": "Tipo de oficina",
+    "admin_level": "Nivel de gobierno",
     "religion": "Religión",
     "denomination": "Confesión",
     "organic": "Orgánico",
@@ -719,8 +720,10 @@
     "fire_hydrant:type": "Tipo de hidrante",
     "fire_hydrant:position": "Posición",
     "fire_hydrant:diameter": "Diámetro de tubería",
+    "fire_hydrant:pressure": "Presión",
     "cash_in": "Depósito de efectivo",
-    "indoor": "Interior"
+    "indoor": "Interior",
+    "sport": "Actividad"
   },
   "TagValue": {
     "__common__": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -705,13 +705,54 @@
     "traffic_calming": "Tipo",
     "operator:type": "Tipo de operador",
     "isced:level": "Nivel educativo",
-    "internet_access": "Acceso a internet"
+    "internet_access": "Acceso a internet",
+    "brand": "Marca",
+    "atm": "Cajero automático",
+    "museum": "Tipo de museo",
+    "memorial": "Tipo de monumento",
+    "government": "Tipo de oficina",
+    "religion": "Religión",
+    "denomination": "Confesión",
+    "organic": "Orgánico",
+    "clothes": "Tipo de ropa",
+    "garden:type": "Tipo de jardín",
+    "fire_hydrant:type": "Tipo de hidrante",
+    "fire_hydrant:position": "Posición",
+    "cash_in": "Depósito de efectivo",
+    "indoor": "Interior"
   },
   "TagValue": {
     "__common__": {
       "yes": "Sí",
       "no": "No",
       "limited": "Limitado"
+    },
+    "religion": {
+      "christian": "Cristiana",
+      "muslim": "Musulmana",
+      "jewish": "Judía",
+      "buddhist": "Budista",
+      "hindu": "Hinduista",
+      "sikh": "Sij",
+      "taoist": "Taoísta",
+      "shinto": "Sintoísta",
+      "bahai": "Bahá'í",
+      "jain": "Jainista"
+    },
+    "fire_hydrant:type": {
+      "pillar": "De columna",
+      "underground": "Subterráneo",
+      "wall": "De pared",
+      "pipe": "De tubo"
+    },
+    "memorial": {
+      "plaque": "Placa",
+      "statue": "Estatua",
+      "war_memorial": "Monumento de guerra",
+      "bust": "Busto",
+      "stone": "Piedra",
+      "sculpture": "Escultura",
+      "stele": "Estela"
     },
     "access": {
       "private": "Privado",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -718,6 +718,7 @@
     "garden:type": "Tipo de jardim",
     "fire_hydrant:type": "Tipo de hidrante",
     "fire_hydrant:position": "Posição",
+    "fire_hydrant:diameter": "Diâmetro da tubulação",
     "cash_in": "Depósito em dinheiro",
     "indoor": "Interno"
   },

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -711,6 +711,7 @@
     "museum": "Tipo de museu",
     "memorial": "Tipo de memorial",
     "government": "Tipo de repartição",
+    "admin_level": "Nível de governo",
     "religion": "Religião",
     "denomination": "Denominação",
     "organic": "Orgânico",
@@ -719,8 +720,10 @@
     "fire_hydrant:type": "Tipo de hidrante",
     "fire_hydrant:position": "Posição",
     "fire_hydrant:diameter": "Diâmetro da tubulação",
+    "fire_hydrant:pressure": "Pressão",
     "cash_in": "Depósito em dinheiro",
-    "indoor": "Interno"
+    "indoor": "Interno",
+    "sport": "Atividade"
   },
   "TagValue": {
     "__common__": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -705,13 +705,54 @@
     "traffic_calming": "Tipo",
     "operator:type": "Tipo de operador",
     "isced:level": "Nível educacional",
-    "internet_access": "Acesso à internet"
+    "internet_access": "Acesso à internet",
+    "brand": "Marca",
+    "atm": "Caixa eletrônico",
+    "museum": "Tipo de museu",
+    "memorial": "Tipo de memorial",
+    "government": "Tipo de repartição",
+    "religion": "Religião",
+    "denomination": "Denominação",
+    "organic": "Orgânico",
+    "clothes": "Tipo de roupa",
+    "garden:type": "Tipo de jardim",
+    "fire_hydrant:type": "Tipo de hidrante",
+    "fire_hydrant:position": "Posição",
+    "cash_in": "Depósito em dinheiro",
+    "indoor": "Interno"
   },
   "TagValue": {
     "__common__": {
       "yes": "Sim",
       "no": "Não",
       "limited": "Limitado"
+    },
+    "religion": {
+      "christian": "Cristã",
+      "muslim": "Muçulmana",
+      "jewish": "Judaica",
+      "buddhist": "Budista",
+      "hindu": "Hindu",
+      "sikh": "Sikh",
+      "taoist": "Taoista",
+      "shinto": "Xintoísta",
+      "bahai": "Bahá'í",
+      "jain": "Jainista"
+    },
+    "fire_hydrant:type": {
+      "pillar": "De coluna",
+      "underground": "Subterrâneo",
+      "wall": "De parede",
+      "pipe": "De tubo"
+    },
+    "memorial": {
+      "plaque": "Placa",
+      "statue": "Estátua",
+      "war_memorial": "Memorial de guerra",
+      "bust": "Busto",
+      "stone": "Pedra",
+      "sculpture": "Escultura",
+      "stele": "Estela"
     },
     "access": {
       "private": "Privado",

--- a/prisma/templates.i18n.yml
+++ b/prisma/templates.i18n.yml
@@ -27,6 +27,15 @@ templates:
       en: Bicycle Shop
       pt: Loja de bicicletas
       es: Tienda de bicicletas
+  markets:
+    name:
+      en: Markets
+      pt: Mercados e feiras
+      es: Mercados
+    desc:
+      en: Public marketplaces
+      pt: Mercados e feiras públicas
+      es: Mercados públicos
   bus-stops:
     name:
       en: Bus Stops
@@ -585,6 +594,24 @@ templates:
       en: Emergency Phones
       pt: Telefones de emergência
       es: Teléfonos de emergencia
+  fire-hydrants:
+    name:
+      en: Fire Hydrants
+      pt: Hidrantes
+      es: Hidrantes
+    desc:
+      en: Fire Hydrants
+      pt: Hidrantes
+      es: Hidrantes
+  defibrillators:
+    name:
+      en: Defibrillators
+      pt: Desfibriladores
+      es: Desfibriladores
+    desc:
+      en: Public access defibrillators (AEDs)
+      pt: Desfibriladores de acesso público (DEAs)
+      es: Desfibriladores de acceso público (DEA)
   waterfall:
     name:
       en: Waterfall
@@ -1692,51 +1719,6 @@ templates:
       en: Places Of Worship
       pt: Locais de culto
       es: Lugares de culto
-  church:
-    name:
-      en: Church
-      pt: Igrejas
-      es: Iglesias
-    desc:
-      en: Church
-      pt: Igrejas
-      es: Iglesias
-  mosque:
-    name:
-      en: Mosque
-      pt: Mesquitas
-      es: Mezquitas
-    desc:
-      en: Mosque
-      pt: Mesquitas
-      es: Mezquitas
-  synagogue:
-    name:
-      en: Synagogue
-      pt: Sinagogas
-      es: Sinagogas
-    desc:
-      en: Synagogue
-      pt: Sinagogas
-      es: Sinagogas
-  temple:
-    name:
-      en: Temple
-      pt: Templos
-      es: Templos
-    desc:
-      en: Temple
-      pt: Templos
-      es: Templos
-  shrine:
-    name:
-      en: Shrine
-      pt: Santuários
-      es: Santuarios
-    desc:
-      en: Shrine
-      pt: Santuários
-      es: Santuarios
   walls:
     name:
       en: Walls

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -83,6 +83,8 @@ templates:
   - ["fire-stations","amenity=fire_station","emergency","FireExtinguisher"]
   - ["ambulance-stations","amenity=ambulance_station","emergency","Ambulance"]
   - ["emergency-phones","emergency=phone","emergency","Phone"]
+  - ["fire-hydrants","emergency=fire_hydrant","emergency","Flame"]
+  - ["defibrillators","emergency=defibrillator","emergency","HeartPulse"]
 # Environment
   - ["waterfall","waterway=waterfall","environment","Waves"]
   - ["dam","waterway=dam","environment","Construction"]
@@ -112,6 +114,9 @@ templates:
   - ["shoes","shop=shoes","shops","Footprints"]
   - ["jewelry","shop=jewelry","shops","Gem"]
   - ["bicycle-shop","shop=bicycle","shops","Store"]
+# Markets
+  # Multi-vendor public markets (distinct from single-vendor shops)
+  - ["markets","amenity=marketplace","shops","ShoppingBasket"]
 # Food
   - ["restaurants","amenity=restaurant","food","UtensilsCrossed"]
   - ["cafes","amenity=cafe","food","Coffee"]
@@ -224,12 +229,10 @@ templates:
   - ["information-boards","tourism=information","public","Info"]
   - ["markers","tourism=information;tourism=guidepost","public","MapPin"]
 # Religion
+  # Single worship template; the former church/mosque/synagogue/temple/shrine
+  # value-templates queried loose religion=* selectors (matching cemeteries,
+  # schools, etc.) and are replaced by the `religion` color-by filter below.
   - ["places-of-worship","amenity=place_of_worship","religion","Landmark"]
-  - ["church","religion=christian","religion","Church"]
-  - ["mosque","religion=islam","religion","MoonStar"]
-  - ["synagogue","religion=jewish","religion","Star"]
-  - ["temple","religion=buddhist;religion=hindu;religion=sikh;religion=taoist","religion","Landmark"]
-  - ["shrine","religion=shinto","religion","Landmark"]
 # Barriers
   - ["walls","barrier=wall","barriers","BrickWall"]
   - ["fences","barrier=fence","barriers","Fence"]
@@ -319,6 +322,55 @@ filterableTags:
   music-school:       [operator, operator:type, wheelchair]
   language-school:    [operator, operator:type, wheelchair]
   research-institute: [operator, operator:type, wheelchair]
+  # Financial
+  atms:             [operator, brand, cash_in]
+  banks:            [brand, operator, atm, wheelchair]
+  # Culture (wheelchair = transversal equity signal on enterable venues)
+  museums:          [museum, operator, fee, wheelchair]
+  theatres:         [operator, wheelchair]
+  cinemas:          [brand, operator, wheelchair]
+  arts-centre:      [operator, wheelchair]
+  gallery:          [operator, fee, wheelchair]
+  memorials:        [memorial]
+  # Government
+  government-office: [government, operator, wheelchair]
+  courts:           [operator, wheelchair]
+  police-stations:  [operator, wheelchair]
+  # Emergency
+  fire-stations:    [operator, wheelchair]
+  ambulance-stations: [operator]
+  fire-hydrants:    [fire_hydrant:type, fire_hydrant:position]
+  defibrillators:   [access, indoor]
+  # Religion (replaces the deprecated per-religion value templates)
+  places-of-worship: [religion, denomination, wheelchair]
+  # Markets: age-view only — operator/organic near-absent (Barcelona 6%/2%, Sao Paulo 13%/1%)
+  # Shops (wheelchair = transversal equity signal; brand/operator = chain vs independent)
+  supermarkets:     [brand, operator, organic, wheelchair]
+  bakeries:         [brand, wheelchair]
+  convenience:      [brand, wheelchair]
+  butchers:         [wheelchair]
+  greengrocers:     [organic, wheelchair]
+  department-stores: [brand, wheelchair]
+  shopping-malls:   [wheelchair]
+  clothes:          [clothes, brand, wheelchair]
+  chemist:          [brand, wheelchair]
+  fuel:             [brand, operator]
+  hardware:         [brand, wheelchair]
+  diy:              [brand, wheelchair]
+  furniture:        [brand, wheelchair]
+  electronics:      [brand, wheelchair]
+  mobile-phone:     [brand, wheelchair]
+  optician:         [brand, wheelchair]
+  shoes:            [brand, wheelchair]
+  jewelry:          [wheelchair]
+  # Leisure (green spaces not covered by the recreation/sport batch)
+  parks:            [access]
+  gardens:          [garden:type, access]
+  marinas:          [access, fee, operator]
+  golf-courses:     [access]
+  fitness-centers:  [wheelchair]
+  # Barriers
+  gates:            [access]
 
 # Curated demonstrator cities per template (OSM relation ids).
 # Cities whose real data best shows the template in the dashboard. Curation-only:
@@ -447,6 +499,33 @@ demonstrators:
     - { area: 62428,   note: "Munich, DE - best operator/operator:type coverage (small sample)" }
     - { area: 451516,  note: "Wroclaw, PL - consistent operator/operator:type pairing (small sample)" }
     - { area: 71525,   note: "Paris, FR - largest sample among candidates" }
+  places-of-worship:
+    - { area: 62422,   note: "Berlin, DE - religion 99%, denomination 80%, wheelchair 51% across 751 sites" }
+    - { area: 71525,   note: "Paris, FR - broad religion mix, strong denomination tagging" }
+    - { area: 298285,  note: "Sao Paulo, BR - Latin American representative, dense christian denomination variety" }
+  atms:
+    - { area: 62428,   note: "Munich, DE - operator 86%, brand 41%, cash_in 80% (deposit-capability split)" }
+    - { area: 71525,   note: "Paris, FR - strong operator/brand tagging" }
+  banks:
+    - { area: 62428,   note: "Munich, DE - strong brand/operator, wheelchair well covered" }
+    - { area: 71525,   note: "Paris, FR - good brand and atm=yes/no tagging" }
+  museums:
+    - { area: 71525,   note: "Paris, FR - fee 62%, wheelchair 46%, museum-type variety across 165 museums" }
+    - { area: 62422,   note: "Berlin, DE - large museum set, strong fee/wheelchair tagging" }
+    - { area: 175905,  note: "New York, US - North American representative, rich museum=* typing" }
+  fire-hydrants:
+    - { area: 62428,   note: "Munich, DE - 12k hydrants, fire_hydrant:type 99%, position 97%" }
+    - { area: 62422,   note: "Berlin, DE - extensive hydrant network, near-complete type tagging" }
+  defibrillators:
+    - { area: 62428,   note: "Munich, DE - indoor 89%, access 27% across 292 AEDs" }
+    - { area: 175342,  note: "London, GB - large public-access AED set, strong access tagging" }
+  supermarkets:
+    - { area: 62428,   note: "Munich, DE - wheelchair 86%, brand 77%, operator 25%, organic 20%" }
+    - { area: 71525,   note: "Paris, FR - strong brand/wheelchair tagging" }
+    - { area: 298285,  note: "Sao Paulo, BR - Latin American representative, brand-chain heavy" }
+  markets:
+    - { area: 347950,  note: "Barcelona, ES - 49 municipal markets, mostly building-mapped (age-view dataset)" }
+    - { area: 298285,  note: "Sao Paulo, BR - 88 marketplaces incl. street feiras" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -339,7 +339,7 @@ filterableTags:
   # Emergency
   fire-stations:    [operator, wheelchair]
   ambulance-stations: [operator]
-  fire-hydrants:    [fire_hydrant:type, fire_hydrant:position]
+  fire-hydrants:    [fire_hydrant:type, fire_hydrant:position, fire_hydrant:diameter]
   defibrillators:   [access, indoor]
   # Religion (replaces the deprecated per-religion value templates)
   places-of-worship: [religion, denomination, wheelchair]

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -76,12 +76,12 @@ templates:
   - ["senior-centers","amenity=senior centre","social","Users"]
 # Government
   - ["government-office","office=government","government","Landmark"]
-  - ["courts","amenity=court","government","Scale"]
+  - ["courts","amenity=courthouse","government","Scale"]
   - ["police-stations","amenity=police","government","Siren"]
   - ["prisons","amenity=prison","government","Fence"]
 # Emergency
   - ["fire-stations","amenity=fire_station","emergency","FireExtinguisher"]
-  - ["ambulance-stations","amenity=ambulance_station","emergency","Ambulance"]
+  - ["ambulance-stations","emergency=ambulance_station","emergency","Ambulance"]
   - ["emergency-phones","emergency=phone","emergency","Phone"]
   - ["fire-hydrants","emergency=fire_hydrant","emergency","Flame"]
   - ["defibrillators","emergency=defibrillator","emergency","HeartPulse"]
@@ -128,7 +128,7 @@ templates:
   - ["parks","leisure=park","leisure","TreePine"]
   - ["playgrounds","leisure=playground","leisure","ToyBrick"]
   - ["gardens","leisure=garden","leisure","Flower2"]
-  - ["fitness-centers","leisure=fitness_center","leisure","Dumbbell"]
+  - ["fitness-centers","leisure=fitness_centre","leisure","Dumbbell"]
   - ["swimming-pools","leisure=swimming_pool","leisure","Waves"]
   - ["sports-centres","leisure=sports_centre","leisure","Dumbbell"]
   - ["stadiums","leisure=stadium","leisure","Trophy"]
@@ -333,13 +333,13 @@ filterableTags:
   gallery:          [operator, fee, wheelchair]
   memorials:        [memorial]
   # Government
-  government-office: [government, operator, wheelchair]
+  government-office: [government, operator, admin_level, wheelchair]
   courts:           [operator, wheelchair]
   police-stations:  [operator, wheelchair]
   # Emergency
   fire-stations:    [operator, wheelchair]
   ambulance-stations: [operator]
-  fire-hydrants:    [fire_hydrant:type, fire_hydrant:position, fire_hydrant:diameter]
+  fire-hydrants:    [fire_hydrant:type, fire_hydrant:position, fire_hydrant:diameter, fire_hydrant:pressure]
   defibrillators:   [access, indoor]
   # Religion (replaces the deprecated per-religion value templates)
   places-of-worship: [religion, denomination, wheelchair]
@@ -351,7 +351,7 @@ filterableTags:
   butchers:         [wheelchair]
   greengrocers:     [organic, wheelchair]
   department-stores: [brand, wheelchair]
-  shopping-malls:   [wheelchair]
+  shopping-malls:   [operator]
   clothes:          [clothes, brand, wheelchair]
   chemist:          [brand, wheelchair]
   fuel:             [brand, operator]
@@ -366,9 +366,8 @@ filterableTags:
   # Leisure (green spaces not covered by the recreation/sport batch)
   parks:            [access]
   gardens:          [garden:type, access]
-  marinas:          [access, fee, operator]
-  golf-courses:     [access]
-  fitness-centers:  [wheelchair]
+  marinas:          [fee, operator]
+  fitness-centers:  [sport, wheelchair]
   # Barriers
   gates:            [access]
 
@@ -500,29 +499,159 @@ demonstrators:
     - { area: 451516,  note: "Wroclaw, PL - consistent operator/operator:type pairing (small sample)" }
     - { area: 71525,   note: "Paris, FR - largest sample among candidates" }
   places-of-worship:
-    - { area: 62422,   note: "Berlin, DE - near-universal religion/denomination, wheelchair well covered" }
-    - { area: 71525,   note: "Paris, FR - broad religion mix, strong denomination tagging" }
-    - { area: 298285,  note: "Sao Paulo, BR - Latin American representative, dense christian denomination variety" }
+    - { area: 298285,  note: "Sao Paulo, BR - best religion coverage, strong Catholic/Evangelical/Pentecostal denomination spread" }
+    - { area: 1293250, note: "Taipei, TW - best religion variance (Taoist/Buddhist/Chinese-folk/Christian mix), non-Western" }
+    - { area: 79604,   note: "Cape Town, ZA - highest religion coverage, African multi-faith spread" }
   atms:
-    - { area: 62428,   note: "Munich, DE - strong operator/brand, well-split cash_in, Germany-strong wheelchair" }
-    - { area: 71525,   note: "Paris, FR - strong operator/brand tagging" }
+    - { area: 62422,   note: "Berlin, DE - strongest across all four keys, large sample, well-split cash_in/wheelchair" }
+    - { area: 1293250, note: "Taipei, TW - Asian spread, strong operator/brand" }
+    - { area: 1376330, note: "Mexico City, MX - Latin American spread, good operator/brand" }
   banks:
-    - { area: 62428,   note: "Munich, DE - strong brand/operator, wheelchair well covered" }
-    - { area: 71525,   note: "Paris, FR - good brand and atm=yes/no tagging" }
+    - { area: 62428,   note: "Munich, DE - operator/atm/wheelchair leader, only region where operator beats brand" }
+    - { area: 175342,  note: "London, GB - brand leader, large sample, good per-bank spread" }
+    - { area: 298285,  note: "Sao Paulo, BR - Latin American spread, brand-heavy on largest sample" }
   museums:
-    - { area: 71525,   note: "Paris, FR - varied museum=* typing, good fee/wheelchair coverage" }
-    - { area: 62422,   note: "Berlin, DE - large museum set, strong fee/wheelchair tagging" }
-    - { area: 175905,  note: "New York, US - North American representative, rich museum=* typing" }
+    - { area: 71525,   note: "Paris, FR - fee/wheelchair leader, well-rounded sample" }
+    - { area: 175905,  note: "New York, US - museum-type leader, rich category spread" }
+    - { area: 1376330, note: "Mexico City, MX - operator leader, Latin American spread" }
+  theatres:
+    - { area: 62422,   note: "Berlin, DE - best on operator and wheelchair, largest reliable sample" }
+    - { area: 71525,   note: "Paris, FR - largest raw sample, usable wheelchair spread" }
+  cinemas:
+    - { area: 175342,  note: "London, GB - brand leader, largest sample" }
+    - { area: 71525,   note: "Paris, FR - best balance of brand/operator/wheelchair" }
+    - { area: 175905,  note: "New York, US - third reliable sample, moderate coverage across keys" }
+  arts-centre:
+    - { area: 62422,   note: "Berlin, DE - best volume and coverage, well-varied operator names" }
+    - { area: 62428,   note: "Munich, DE - mid-size alternative, strong wheelchair" }
+    - { area: 71525,   note: "Paris, FR - largest raw volume, geographic spread" }
+  gallery:
+    - { area: 62422,   note: "Berlin, DE - best coverage across operator/fee/wheelchair, large volume" }
+    - { area: 71525,   note: "Paris, FR - largest raw volume, FR spread" }
+    - { area: 175342,  note: "London, GB - solid volume, anglophone spread" }
+  memorials:
+    - { area: 62422,   note: "Berlin, DE - huge volume, near-universal memorial= (Stolperstein-dense, a real local pattern)" }
+    - { area: 175342,  note: "London, GB - best-balanced memorial= variance (plaque/blue_plaque/war_memorial/statue)" }
+    - { area: 451516,  note: "Wroclaw, PL - cleanest proportional spread, Central/Eastern Europe diversity" }
+  government-office:
+    - { area: 62422,   note: "Berlin, DE - best across government/operator/admin_level/wheelchair, well-spread government= values" }
+    - { area: 71525,   note: "Paris, FR - second-largest volume, best admin_level coverage, FR spread" }
+    - { area: 419203,  note: "Utrecht, NL - smaller but strong wheelchair, Benelux spread" }
+  courts:
+    - { area: 62422,   note: "Berlin, DE - best wheelchair signal with real yes/no/limited spread" }
+    - { area: 175905,  note: "New York, US - best operator signal, several distinct court-system agencies (EU cities collapse to one state entity)" }
+    - { area: 71525,   note: "Paris, FR - geographic diversity, modest wheelchair spread" }
+  police-stations:
+    - { area: 62422,   note: "Berlin, DE - best operator/wheelchair coverage and variance (federal/state/local forces)" }
+    - { area: 71525,   note: "Paris, FR - high operator coverage, distinct national/municipal values" }
+    - { area: 62428,   note: "Munich, DE - secondary EU anchor, some operator variance" }
+  fire-stations:
+    - { area: 62428,   note: "Munich, DE - best operator variance (professional + several volunteer brigades)" }
+    - { area: 62422,   note: "Berlin, DE - highest volume, operator near single-valued" }
+    - { area: 419203,  note: "Utrecht, NL - small NL sample for regional spread" }
+  ambulance-stations:
+    - { area: 62428,   note: "Munich, DE - best signal, spread across many public+private ambulance operators" }
+    - { area: 175342,  note: "London, GB - largest sample, operator present if org-skewed" }
+    - { area: 298285,  note: "Sao Paulo, BR - geographic diversity, public SAMU-dominated (itself a BR signal)" }
   fire-hydrants:
-    - { area: 62428,   note: "Munich, DE - dense hydrant network, near-complete type/position, diameter well covered" }
-    - { area: 62422,   note: "Berlin, DE - extensive hydrant network, near-complete type tagging" }
+    - { area: 62422,   note: "Berlin, DE - best all-around type/position/diameter coverage and variance" }
+    - { area: 62428,   note: "Munich, DE - near-identical strength, best diameter coverage" }
+    - { area: 54517,   note: "Rennes, FR - geographic spread, good type coverage (pillar-dominated), weak diameter/pressure" }
   defibrillators:
-    - { area: 62428,   note: "Munich, DE - clear indoor/access split across a solid AED set" }
-    - { area: 175342,  note: "London, GB - large public-access AED set, strong access tagging" }
+    - { area: 71525,   note: "Paris, FR - highest volume, strong access variance" }
+    - { area: 62422,   note: "Berlin, DE - best access coverage, high indoor coverage" }
+    - { area: 62428,   note: "Munich, DE - solid secondary EU sample, good access/indoor spread" }
   supermarkets:
-    - { area: 62428,   note: "Munich, DE - strong brand/operator, wheelchair + organic well covered" }
-    - { area: 71525,   note: "Paris, FR - strong brand/wheelchair tagging" }
-    - { area: 298285,  note: "Sao Paulo, BR - Latin American representative, brand-chain heavy" }
+    - { area: 62422,   note: "Berlin, DE - best across all four keys, many chains, real wheelchair spread" }
+    - { area: 347950,  note: "Barcelona, ES - Iberian brand mix, Southern-Europe spread" }
+    - { area: 62428,   note: "Munich, DE - alternate DE demonstrator, strong wheelchair/brand" }
+  bakeries:
+    - { area: 62428,   note: "Munich, DE - best overall: brand across several regional chains + strong wheelchair spread" }
+    - { area: 451516,  note: "Wroclaw, PL - highest brand coverage, distinct Polish chains" }
+    - { area: 71525,   note: "Paris, FR - largest raw sample, France spread" }
+  convenience:
+    - { area: 1293250, note: "Taipei, TW - dominant demonstrator: brand across 7-Eleven/FamilyMart/Hi-Life/OK Mart" }
+    - { area: 175342,  note: "London, GB - largest sample, western-chain brand spread" }
+    - { area: 298285,  note: "Sao Paulo, BR - regional spread, moderate brand coverage" }
+  butchers:
+    - { area: 62428,   note: "Munich, DE - best wheelchair coverage and spread" }
+    - { area: 62422,   note: "Berlin, DE - solid coverage, larger urban market" }
+  greengrocers:
+    - { area: 71525,   note: "Paris, FR - best organic variance on largest reliable sample, decent wheelchair" }
+    - { area: 347950,  note: "Barcelona, ES - largest raw count, Iberian spread" }
+    - { area: 62422,   note: "Berlin, DE - best wheelchair, small sample; backup DE demonstrator" }
+  department-stores:
+    - { area: 62422,   note: "Berlin, DE - best balanced brand/wheelchair, real chain spread" }
+    - { area: 175342,  note: "London, GB - best brand coverage, largest strong sample" }
+    - { area: 175905,  note: "New York, US - largest volume, strong brand, market spread (weak wheelchair)" }
+  shopping-malls:
+    - { area: 1293250, note: "Taipei, TW - best operator coverage among candidates, Asian spread" }
+    - { area: 175342,  note: "London, GB - decent operator coverage on a good sample" }
+    - { area: 298285,  note: "Sao Paulo, BR - largest raw mall count, Latin American spread (operator thin but present)" }
+  clothes:
+    - { area: 62428,   note: "Munich, DE - best all-around: clothes-type spread + best wheelchair" }
+    - { area: 71525,   note: "Paris, FR - largest volume, deep brand variety" }
+    - { area: 298285,  note: "Sao Paulo, BR - Latin America spread (wheelchair near-absent regionally)" }
+  chemist:
+    - { area: 62422,   note: "Berlin, DE - largest DE volume, excellent brand and wheelchair" }
+    - { area: 62428,   note: "Munich, DE - best brand coverage, clean drugstore-chain spread" }
+    - { area: 175342,  note: "London, GB - largest raw volume, confirms genuine UK-native usage" }
+  fuel:
+    - { area: 298285,  note: "Sao Paulo, BR - huge volume, best brand variance (Ipiranga/Shell/BR)" }
+    - { area: 419203,  note: "Utrecht, NL - best operator coverage/variance, clean dataset" }
+    - { area: 62428,   note: "Munich, DE - balanced brand and operator, European chain diversity" }
+  hardware:
+    - { area: 62422,   note: "Berlin, DE - best wheelchair coverage and largest sample, some brand signal" }
+    - { area: 62428,   note: "Munich, DE - second-best brand/wheelchair, independent+chain mix" }
+  diy:
+    - { area: 62422,   note: "Berlin, DE - largest sample, excellent brand variance (7 chains) and wheelchair" }
+    - { area: 62428,   note: "Munich, DE - best wheelchair and brand coverage rates" }
+    - { area: 419203,  note: "Utrecht, NL - non-DE demonstrator, high brand coverage" }
+  furniture:
+    - { area: 71525,   note: "Paris, FR - largest sample, best brand variance (designer/chain brands)" }
+    - { area: 62428,   note: "Munich, DE - best wheelchair coverage, reasonable brand presence" }
+  electronics:
+    - { area: 1293250, note: "Taipei, TW - largest sample, best brand variance, non-Western regional chains" }
+    - { area: 71525,   note: "Paris, FR - balanced brand and wheelchair, recognizable Euro chains" }
+    - { area: 62428,   note: "Munich, DE - best wheelchair coverage" }
+  mobile-phone:
+    - { area: 62422,   note: "Berlin, DE - best overall brand/wheelchair, wide carrier-brand spread" }
+    - { area: 298285,  note: "Sao Paulo, BR - regional diversity, distinct Brazilian carriers" }
+    - { area: 71525,   note: "Paris, FR - large sample, good brand variance" }
+  optician:
+    - { area: 62422,   note: "Berlin, DE - best wheelchair + strong brand variety across chains" }
+    - { area: 175342,  note: "London, GB - best brand coverage, large sample, international chains" }
+    - { area: 71525,   note: "Paris, FR - largest sample, balanced brand/wheelchair" }
+  shoes:
+    - { area: 62422,   note: "Berlin, DE - best overall brand/wheelchair, strong chain variance" }
+    - { area: 71525,   note: "Paris, FR - large sample, good brand variance" }
+    - { area: 347950,  note: "Barcelona, ES - Iberian regional spread" }
+  jewelry:
+    - { area: 62422,   note: "Berlin, DE - best wheelchair coverage and spread" }
+    - { area: 71525,   note: "Paris, FR - large sample, moderate coverage" }
+    - { area: 347950,  note: "Barcelona, ES - regional spread" }
+  parks:
+    - { area: 62428,   note: "Munich, DE - largest well-tagged sample, clean access variance" }
+    - { area: 406091,  note: "Oslo, NO - best access coverage, Nordic spread" }
+    - { area: 298285,  note: "Sao Paulo, BR - Latin American spread, largest raw count (access thin, as expected)" }
+  gardens:
+    - { area: 62428,   note: "Munich, DE - best on garden:type and access, rich variance on both" }
+    - { area: 71525,   note: "Paris, FR - large sample, strong access coverage" }
+    - { area: 298285,  note: "Sao Paulo, BR - Latin American spread, largest raw counts" }
+  marinas:
+    - { area: 175905,  note: "New York, US - largest sample, only city with usable operator signal" }
+    - { area: 406091,  note: "Oslo, NO - best fee coverage, Nordic spread" }
+  golf-courses:
+    - { area: 79604,   note: "Cape Town, ZA - largest raw count of courses" }
+    - { area: 175905,  note: "New York, US - second-largest, only city with any access signal" }
+  fitness-centers:
+    - { area: 62422,   note: "Berlin, DE - best sport-type coverage and variety (yoga/fitness/pilates/cycling), large sample" }
+    - { area: 71525,   note: "Paris, FR - large sample, good sport-type and wheelchair spread" }
+    - { area: 1634158, note: "Montreal, CA - non-European diversity, real sport/wheelchair spread" }
+  gates:
+    - { area: 54517,   note: "Rennes, FR - best access coverage, clean variance" }
+    - { area: 451516,  note: "Wroclaw, PL - largest sample, excellent access variance" }
+    - { area: 419203,  note: "Utrecht, NL - strong access coverage, regional spread" }
   markets:
     - { area: 347950,  note: "Barcelona, ES - municipal markets, mostly building-mapped (age-view dataset)" }
     - { area: 298285,  note: "Sao Paulo, BR - marketplaces incl. street feiras" }

--- a/prisma/templates.yml
+++ b/prisma/templates.yml
@@ -323,7 +323,7 @@ filterableTags:
   language-school:    [operator, operator:type, wheelchair]
   research-institute: [operator, operator:type, wheelchair]
   # Financial
-  atms:             [operator, brand, cash_in]
+  atms:             [operator, brand, cash_in, wheelchair]
   banks:            [brand, operator, atm, wheelchair]
   # Culture (wheelchair = transversal equity signal on enterable venues)
   museums:          [museum, operator, fee, wheelchair]
@@ -500,32 +500,32 @@ demonstrators:
     - { area: 451516,  note: "Wroclaw, PL - consistent operator/operator:type pairing (small sample)" }
     - { area: 71525,   note: "Paris, FR - largest sample among candidates" }
   places-of-worship:
-    - { area: 62422,   note: "Berlin, DE - religion 99%, denomination 80%, wheelchair 51% across 751 sites" }
+    - { area: 62422,   note: "Berlin, DE - near-universal religion/denomination, wheelchair well covered" }
     - { area: 71525,   note: "Paris, FR - broad religion mix, strong denomination tagging" }
     - { area: 298285,  note: "Sao Paulo, BR - Latin American representative, dense christian denomination variety" }
   atms:
-    - { area: 62428,   note: "Munich, DE - operator 86%, brand 41%, cash_in 80% (deposit-capability split)" }
+    - { area: 62428,   note: "Munich, DE - strong operator/brand, well-split cash_in, Germany-strong wheelchair" }
     - { area: 71525,   note: "Paris, FR - strong operator/brand tagging" }
   banks:
     - { area: 62428,   note: "Munich, DE - strong brand/operator, wheelchair well covered" }
     - { area: 71525,   note: "Paris, FR - good brand and atm=yes/no tagging" }
   museums:
-    - { area: 71525,   note: "Paris, FR - fee 62%, wheelchair 46%, museum-type variety across 165 museums" }
+    - { area: 71525,   note: "Paris, FR - varied museum=* typing, good fee/wheelchair coverage" }
     - { area: 62422,   note: "Berlin, DE - large museum set, strong fee/wheelchair tagging" }
     - { area: 175905,  note: "New York, US - North American representative, rich museum=* typing" }
   fire-hydrants:
-    - { area: 62428,   note: "Munich, DE - 12k hydrants, fire_hydrant:type 99%, position 97%" }
+    - { area: 62428,   note: "Munich, DE - dense hydrant network, near-complete type/position, diameter well covered" }
     - { area: 62422,   note: "Berlin, DE - extensive hydrant network, near-complete type tagging" }
   defibrillators:
-    - { area: 62428,   note: "Munich, DE - indoor 89%, access 27% across 292 AEDs" }
+    - { area: 62428,   note: "Munich, DE - clear indoor/access split across a solid AED set" }
     - { area: 175342,  note: "London, GB - large public-access AED set, strong access tagging" }
   supermarkets:
-    - { area: 62428,   note: "Munich, DE - wheelchair 86%, brand 77%, operator 25%, organic 20%" }
+    - { area: 62428,   note: "Munich, DE - strong brand/operator, wheelchair + organic well covered" }
     - { area: 71525,   note: "Paris, FR - strong brand/wheelchair tagging" }
     - { area: 298285,  note: "Sao Paulo, BR - Latin American representative, brand-chain heavy" }
   markets:
-    - { area: 347950,  note: "Barcelona, ES - 49 municipal markets, mostly building-mapped (age-view dataset)" }
-    - { area: 298285,  note: "Sao Paulo, BR - 88 marketplaces incl. street feiras" }
+    - { area: 347950,  note: "Barcelona, ES - municipal markets, mostly building-mapped (age-view dataset)" }
+    - { area: 298285,  note: "Sao Paulo, BR - marketplaces incl. street feiras" }
 
 # Category to icon mapping (fallback for templates without icon)
 categories:

--- a/src/lib/area-templates.ts
+++ b/src/lib/area-templates.ts
@@ -124,7 +124,10 @@ export async function getAreaDataTypes(
 async function fetchActiveTemplates(locale: string): Promise<AreaTemplate[]> {
   const dbLocale = mapAppLocaleToDb(locale);
   const rows = await prisma.template.findMany({
-    where: { isActive: true },
+    // Hide soft-deprecated templates: isActive stays true during the 30-day
+    // window so existing dataset pages keep rendering, but a template that can
+    // no longer be opened should not appear as available to browse/create.
+    where: { isActive: true, deprecatesAt: null },
     select: {
       id: true,
       name: true,

--- a/src/lib/category-icons.tsx
+++ b/src/lib/category-icons.tsx
@@ -23,7 +23,6 @@ import {
   Caravan,
   Carrot,
   Cctv,
-  Church,
   Clock,
   Coffee,
   Construction,
@@ -43,6 +42,7 @@ import {
   Fence,
   Film,
   FireExtinguisher,
+  Flame,
   Flower2,
   Footprints,
   Fuel,
@@ -54,6 +54,7 @@ import {
   Hammer,
   Heart,
   HeartHandshake,
+  HeartPulse,
   Home,
   Hospital,
   Hotel,
@@ -73,7 +74,6 @@ import {
   Microscope,
   Milestone,
   Milk,
-  MoonStar,
   Mountain,
   MountainSnow,
   Music,
@@ -95,6 +95,7 @@ import {
   Ship,
   Shirt,
   ShoppingBag,
+  ShoppingBasket,
   ShoppingCart,
   Shrub,
   Signpost,
@@ -146,7 +147,7 @@ import {
  * Icon lookups for dataset templates and categories
  *
  * AUTO-GENERATED from prisma/templates.yml - DO NOT EDIT DIRECTLY
- * Generated: 2026-07-28T22:40:43.772Z
+ * Generated: 2026-07-29T06:59:02.806Z
  * Regenerate with: pnpm generate-icons
  */
 
@@ -290,8 +291,6 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Backpack className="w-5 h-5" />;
     case "chimney":
       return <Factory className="w-5 h-5" />;
-    case "church":
-      return <Church className="w-5 h-5" />;
     case "cinemas":
       return <Film className="w-5 h-5" />;
     case "cliffs":
@@ -326,6 +325,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Milk className="w-5 h-5" />;
     case "dam":
       return <Construction className="w-5 h-5" />;
+    case "defibrillators":
+      return <HeartPulse className="w-5 h-5" />;
     case "dentists":
       return <Smile className="w-5 h-5" />;
     case "department-stores":
@@ -366,6 +367,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Fence className="w-5 h-5" />;
     case "ferry-terminals":
       return <Ship className="w-5 h-5" />;
+    case "fire-hydrants":
+      return <Flame className="w-5 h-5" />;
     case "fire-stations":
       return <FireExtinguisher className="w-5 h-5" />;
     case "fitness-centers":
@@ -458,6 +461,8 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Anchor className="w-5 h-5" />;
     case "markers":
       return <MapPin className="w-5 h-5" />;
+    case "markets":
+      return <ShoppingBasket className="w-5 h-5" />;
     case "mast":
       return <RadioTower className="w-5 h-5" />;
     case "meadows":
@@ -470,8 +475,6 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Landmark className="w-5 h-5" />;
     case "moor":
       return <Leaf className="w-5 h-5" />;
-    case "mosque":
-      return <MoonStar className="w-5 h-5" />;
     case "mud":
       return <Droplets className="w-5 h-5" />;
     case "multi-sport":
@@ -562,8 +565,6 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Target className="w-5 h-5" />;
     case "shopping-malls":
       return <ShoppingBag className="w-5 h-5" />;
-    case "shrine":
-      return <Landmark className="w-5 h-5" />;
     case "silos":
       return <Warehouse className="w-5 h-5" />;
     case "skiing":
@@ -604,16 +605,12 @@ export function getTemplateIcon(templateId: string, category: string) {
       return <Waves className="w-5 h-5" />;
     case "swimming-pools":
       return <Waves className="w-5 h-5" />;
-    case "synagogue":
-      return <Star className="w-5 h-5" />;
     case "tailings-pond":
       return <Factory className="w-5 h-5" />;
     case "taxi-ranks":
       return <CarTaxiFront className="w-5 h-5" />;
     case "telephones":
       return <Phone className="w-5 h-5" />;
-    case "temple":
-      return <Landmark className="w-5 h-5" />;
     case "tennis":
       return <Trophy className="w-5 h-5" />;
     case "theatres":


### PR DESCRIPTION
## Issue #245: epic: Template Review

**Problem:** Audit and rationalize the template structure — curated map themes per template, catch bad filterableTags. Tuning is tracked in per-domain batches. This is the "megazord" batch closing out every domain not covered by the other in-flight batch PRs (#409 food, #410 sport, #411 public amenities, #412 tourism, #413 social, #414 healthcare; #408 education + #415 mobility already merged): financial, culture, government, emergency, retail shops, markets, green leisure, barriers, religion — plus the age-view screen-and-skip blocks (nature, agriculture, infrastructure, housing, environment).

**Acceptance Criteria (from #245, applied to these domains):**
- [x] Review whether current templates make sense (deprecate loose selectors; add missing civic datasets)
- [x] Curated per-template legend views (filterableTags) tuned against wiki + live dashboard
- [x] Per-template demonstrator cities recorded for every validated template

**Method:** filterableTags are wiki-shortlisted (only keys the OSM wiki documents; no regional-convention tags), then validated against live OSM data — every touched template created against real cities via `POST /api/datasets`, coverage + value-variance measured in psql. A final data-driven sweep scanned all property keys (not just the wiki-blessed ones) for any high-coverage categorical missed on a wiki technicality.

**Selector bug fixes (were returning 0 features everywhere):**
- courts `amenity=court` → `amenity=courthouse`
- ambulance-stations `amenity=ambulance_station` → `emergency=ambulance_station`
- fitness-centers `leisure=fitness_center` → `leisure=fitness_centre`

**filterableTags (final):**
- financial — atms `[operator, brand, cash_in, wheelchair]`, banks `[brand, operator, atm, wheelchair]`
- culture — museums `[museum, operator, fee, wheelchair]`, theatres, cinemas, arts-centre, gallery, memorials `[memorial]`; monuments age-view
- government — government-office `[government, operator, admin_level, wheelchair]`, courts, police-stations
- emergency — fire-stations, ambulance-stations `[operator]`, fire-hydrants `[fire_hydrant:type, fire_hydrant:position, fire_hydrant:diameter, fire_hydrant:pressure]`, defibrillators `[access, indoor]`
- retail — `wheelchair` (equity-keep) + `brand` across shops; supermarkets/greengrocers/clothes/fuel tuned; shopping-malls `[operator]`
- green leisure (untouched by the sport batch) — parks, gardens, marinas `[fee, operator]`, golf-courses age-view, fitness-centers `[sport, wheelchair]`; barriers — gates `[access]`
- religion — places-of-worship `[religion, denomination, wheelchair]`

`fitness-centers` uses `sport` as its primary dimension — a deliberate data-over-wiki exception: `sport` splits centres into meaningful activity groups (yoga/fitness/pilates/…) at higher coverage than wheelchair, even though the wiki doesn't list it as a recommended combination. The validation sweep confirmed this was the *only* such case; every other template already carries its best available categorical.

**New templates (critical missing):**
- markets — `amenity=marketplace` (epic's flagged Markets domain); **age-view only**, operator/organic near-absent
- fire-hydrants — `emergency=fire_hydrant`
- defibrillators — `emergency=defibrillator` (AED life-safety)

**Deprecated (soft, 30-day):** church / mosque / synagogue / temple / shrine — loose `religion=christian`/`=islam`/… value selectors that also match cemeteries, schools, etc. Folded into places-of-worship colored by `religion`.

**Screen-and-skip (age-view only, documented):** nature, agriculture, man_made infrastructure, housing, environment, outdoor barriers.

**Demonstrators:** 2-3 geographically diverse curated cities recorded for every touched template (was 8; now the full set). Curation-only — validated by sync, never written to the DB, zero refresh cost. Notes are qualitative (no percentages, which drift).

**i18n:** new TagLabels (incl. fire_hydrant:pressure, admin_level, sport) + religion / fire_hydrant:type / memorial TagValues (en/es/pt-BR). Worked examples + selector-fix lesson added to the template-management doc.

**Verified:** `pnpm db:sync`, `type-check`, `i18n:check`, parser tests, lint. Live dashboard spot-checks via chrome-devtools MCP; live-data coverage/variance validation across all touched templates.

Note: based on current `develop`; touches only rows/keys the sibling batch PRs (#409–414) don't, so parallel merges stay localized to the shared filterableTags/demonstrators blocks.
