### PR TITLE
test: reviewer smoke (CodeRabbit vs Claude head-to-head)

### DIFF
--- a/src/lib/review-smoke.ts
+++ b/src/lib/review-smoke.ts
@@ -1,0 +1,12 @@
+// Throwaway smoke test for the automated PR reviewers (CodeRabbit vs Claude).
+// Delete after the trial. Contains a deliberate edge-case bug so we can see
+// which reviewer flags it.
+
+/**
+ * Average dataset feature count across a set of datasets.
+ */
+export function averageFeatureCount(counts: number[]): number {
+  const total = counts.reduce((sum, count) => sum + count, 0);
+  // Bug on purpose: empty input divides by zero -> NaN, no guard.
+  return total / counts.length;
+}


### PR DESCRIPTION
Throwaway PR to run both automated reviewers on the same diff, now that the Claude workflow is on `develop`.

- Base is `develop` (default branch) so both bots review.
- Adds `src/lib/review-smoke.ts` with a **deliberate** empty-array divide-by-zero bug (returns `NaN`, no guard).
- Expect: CodeRabbit + Claude sticky comment. Let's see which flags the bug and how each reads.

Will be closed (not merged).