### PR TITLE
ci: fail Claude review when it stubs out

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -159,3 +159,34 @@ jobs:
               -F body=@"$RUNNER_TEMP/body.md" > /dev/null; then
             echo "::warning::cost footer skipped: could not update comment $id"
           fi
+
+      # Guard against the action's known sticky-comment flakiness: the model
+      # occasionally replies with a plain message and exits (2 turns, no error)
+      # WITHOUT calling update_claude_comment, so the initial "I'll analyze
+      # this..." placeholder is left standing as the "review". The action
+      # exits success either way, so without this the stub passes silently.
+      # Detect a missing verdict marker and fail the check instead, making the
+      # stub visible so the job can be re-run. Find the comment the same way
+      # the cost step does (latest comment by a claude bot).
+      - name: Verify review was posted
+        if: always() && steps.claude.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.user.type == "Bot" and (.user.login | ascii_downcase | contains("claude"))) | .id' \
+            | tail -1) || true
+          if ! [[ "$id" =~ ^[0-9]+$ ]]; then
+            echo "::error::no Claude review comment found on PR #$PR_NUMBER"
+            exit 1
+          fi
+          body=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body) || true
+          # The prompt requires the review to open with one of these verdict
+          # lines; their absence means the model never posted a real review.
+          if printf '%s' "$body" | grep -qF -e '✅ No blocking issues' -e '❌ Changes requested'; then
+            echo "Review posted (verdict marker present)."
+            exit 0
+          fi
+          echo "::error::Claude posted no review — the sticky comment still shows the placeholder (known action flakiness). Re-run this job."
+          exit 1


### PR DESCRIPTION
## What

Adds a guard step to the Claude PR review workflow that fails the check when Claude produces no real review.

## Why

Investigated a stub run on the trial: the action's sticky-comment flow occasionally exits `success` at **2 turns** without calling `update_claude_comment`, leaving the initial `I'll analyze this...` placeholder standing as the "review" (`is_error: false`, `permission_denials_count: 0` — confirmed model non-determinism, not our config). The action's own system prompt warns about this 5+ times. Because the action exits success either way, the stub otherwise **passes silently**.

## How

New `Verify review was posted` step (runs after the review + cost footer): finds the sticky comment the same way the cost step does, checks the body for a verdict marker (`✅ No blocking issues` / `❌ Changes requested`), and exits non-zero when absent. A stub now shows a red check that can be re-run, rather than a silent no-op.

Note: this makes stubs **visible**, not automatic — a conditional auto-retry is the follow-up if stubs prove frequent during the trial. CodeRabbit still covers the gap in parallel.