### PR TITLE
test: live Claude review + guard check

### DIFF
--- a/src/lib/review-smoke.ts
+++ b/src/lib/review-smoke.ts
@@ -1,0 +1,12 @@
+// Throwaway smoke test for the automated PR reviewers (CodeRabbit + Claude).
+// Delete after the trial. Contains a deliberate edge-case bug so we can see
+// which reviewer flags it and confirm the review workflow's guard step.
+
+/**
+ * Average dataset feature count across a set of datasets.
+ */
+export function averageFeatureCount(counts: number[]): number {
+  const total = counts.reduce((sum, count) => sum + count, 0);
+  // Bug on purpose: empty input divides by zero -> NaN, no guard.
+  return total / counts.length;
+}


### PR DESCRIPTION
Throwaway PR to watch the full Claude review flow in one run, now that the workflow + guard are on `develop`.

- Adds `src/lib/review-smoke.ts` with a deliberate empty-array divide-by-zero (`NaN`, no guard).
- Expect: Claude sticky comment with a verdict + fix, the `Verify review was posted` guard passing green, and CodeRabbit in parallel (if not rate-limited).
- If Claude stubs out, the guard should now turn the check red instead of passing silently.

Will be closed (not merged).