### PR TITLE
ci: revert Claude review args to DS baseline (isolate stub cause)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -107,19 +107,15 @@ jobs:
               citing `path:line` and, where a concrete fix exists, a fenced
               code block with the fix.
             - If nothing is blocking, say so briefly; do not pad.
-          # allowedTools only auto-approves; it does NOT restrict what the
-          # agent can reach. Explicitly deny the file-mutation tools so the
-          # review stays read-only. We do NOT blanket-deny Bash: deny rules
-          # take precedence, so it would also kill the allowed gh read
-          # commands below (arbitrary Bash is already blocked in CI, since
-          # non-allowlisted tools can't be interactively approved).
-          # Model intentionally unset — uses the Claude Code default. We are
-          # measuring whether the default stubs out (posts no review) less
-          # often than a pinned claude-opus-4-8. The guard step below catches
-          # any stub regardless.
+          # Reverted to the developmentseed baseline args to isolate the stub
+          # cause: no --model pin (uses the Claude Code default) and no
+          # --disallowedTools. Both were additions the original workflow lacked.
+          # Dropping the tool blocks is safe: the file-mutation tools aren't in
+          # the action's allowlist, so CI already blocks them without an
+          # explicit deny (non-allowlisted tools can't be interactively
+          # approved). The guard step below catches any stub regardless.
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --disallowedTools "Edit,Write,MultiEdit,NotebookEdit"
 
       # The action has no built-in cost display, but its execution log's
       # final result record carries the run metrics — append them to the

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -113,10 +113,13 @@ jobs:
           # take precedence, so it would also kill the allowed gh read
           # commands below (arbitrary Bash is already blocked in CI, since
           # non-allowlisted tools can't be interactively approved).
+          # Model intentionally unset — uses the Claude Code default. We are
+          # measuring whether the default stubs out (posts no review) less
+          # often than a pinned claude-opus-4-8. The guard step below catches
+          # any stub regardless.
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
             --disallowedTools "Edit,Write,MultiEdit,NotebookEdit"
-            --model claude-opus-4-8
 
       # The action has no built-in cost display, but its execution log's
       # final result record carries the run metrics — append them to the


### PR DESCRIPTION
## What

Reverts the Claude review `claude_args` to the exact developmentseed baseline:
- drops `--model claude-opus-4-8` (uses the Claude Code default)
- drops `--disallowedTools "Edit,Write,MultiEdit,NotebookEdit"`

Result: `claude_args` is just `--allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"`, as in the upstream reusable workflow.

## Why

The pinned `claude-opus-4-8` **stubbed out** (exited success without posting a review) on ~2 of 3 first attempts. Both the model pin and the `--disallowedTools` block were additions the original DS workflow lacked — two unisolated variables. This reverts both so we can measure the known-good baseline's stub rate.

Dropping `--disallowedTools` is safe: the file-mutation tools aren't in the action's allowlist, so CI already blocks them without an explicit deny. The `Verify review was posted` guard still catches any stub.

## Next

After merge, trigger the review several times on a code PR and tally the guard (green = review, red = stub) to get the baseline stub rate. If reliable, re-add the model pin alone to see if opus was the culprit.