### PR TITLE
test: measure Claude review stub rate (DS baseline)

### DIFF
--- a/src/lib/review-smoke.ts
+++ b/src/lib/review-smoke.ts
@@ -1,0 +1,11 @@
+// Throwaway smoke test for the automated PR reviewers. Delete after the trial.
+// Contains a deliberate empty-array divide-by-zero bug.
+
+/**
+ * Average dataset feature count across a set of datasets.
+ */
+export function averageFeatureCount(counts: number[]): number {
+  const total = counts.reduce((sum, count) => sum + count, 0);
+  // Bug on purpose: empty input divides by zero -> NaN, no guard.
+  return total / counts.length;
+}


### PR DESCRIPTION
Throwaway PR to measure the Claude review stub rate on the DS baseline args (default model, no tool blocks).

- Adds `src/lib/review-smoke.ts` with a deliberate divide-by-zero.
- The Claude job will be re-run several times; each run's guard (green = review posted, red = stub) is one sample.

Will be closed (not merged).