### PR TITLE
fix(health): judge /api/health against the 24h refresh cadence

### DIFF
--- a/src/app/api/health/__tests__/route.test.ts
+++ b/src/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/lib/db", () => ({
+  prisma: { dataset: { findFirst: vi.fn() } },
+}));
+
+import { GET } from "../route";
+
+const hoursAgo = (h: number) => new Date(Date.now() - h * 60 * 60 * 1000);
+
+describe("GET /api/health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is ok when the newest successful check is within the cadence window", async () => {
+    vi.mocked(prisma.dataset.findFirst).mockResolvedValueOnce({
+      lastChecked: hoursAgo(11),
+    } as never);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "ok" });
+  });
+
+  it("stays ok across the idle stretch of a normal daily refresh cycle", async () => {
+    // Fleet refreshes in a burst then idles; the newest successful check ages
+    // toward the interval before the next burst. This must NOT read as degraded.
+    vi.mocked(prisma.dataset.findFirst).mockResolvedValueOnce({
+      lastChecked: hoursAgo(25),
+    } as never);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "ok" });
+  });
+
+  it("degrades when nothing has refreshed past interval + grace (e.g. Overpass down)", async () => {
+    // Overpass outage: cron keeps attempting but every refresh fails, so no
+    // lastChecked advances and the newest success ages out.
+    vi.mocked(prisma.dataset.findFirst).mockResolvedValueOnce({
+      lastChecked: hoursAgo(40),
+    } as never);
+
+    const res = await GET();
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      status: "degraded",
+      reason: "datasets not updating",
+    });
+  });
+
+  it("does not degrade on a fresh instance whose datasets have not run a first cycle", async () => {
+    // No successful check yet; oldest active dataset was created recently.
+    vi.mocked(prisma.dataset.findFirst)
+      .mockResolvedValueOnce(null as never) // newest lastChecked
+      .mockResolvedValueOnce({ createdAt: hoursAgo(1) } as never); // oldest active
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "ok" });
+  });
+
+  it("degrades when datasets have existed past the window but never succeeded", async () => {
+    vi.mocked(prisma.dataset.findFirst)
+      .mockResolvedValueOnce(null as never) // newest lastChecked
+      .mockResolvedValueOnce({ createdAt: hoursAgo(40) } as never); // oldest active
+
+    const res = await GET();
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ status: "degraded" });
+  });
+
+  it("is ok when there are no active datasets", async () => {
+    vi.mocked(prisma.dataset.findFirst)
+      .mockResolvedValueOnce(null as never) // newest lastChecked
+      .mockResolvedValueOnce(null as never); // oldest active
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "ok" });
+  });
+
+  it("degrades with 'database unavailable' when the query throws", async () => {
+    vi.mocked(prisma.dataset.findFirst).mockRejectedValue(new Error("boom"));
+
+    const res = await GET();
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      status: "degraded",
+      reason: "database unavailable",
+    });
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,19 +1,51 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 
+// The update-datasets cron refreshes each dataset on roughly this cadence
+// (a dataset becomes eligible once its lastAttempted is older than this window;
+// see api/tasks/update-datasets). The fleet refreshes in a daily burst then sits
+// idle, so a healthy system only produces a *successful* check about once per
+// interval — health must be judged against that cadence, not a tighter one.
+const REFRESH_INTERVAL_HOURS = 24;
+// Grace on top of the interval before we call the pipeline stalled: absorbs the
+// idle gap between bursts plus cron/Overpass jitter. Peak healthy age of the
+// newest successful check is ~the idle gap (< interval); this margin keeps a
+// healthy idle stretch from tripping a false alarm.
+const GRACE_HOURS = 6;
+const STALE_THRESHOLD_MS =
+  (REFRESH_INTERVAL_HOURS + GRACE_HOURS) * 60 * 60 * 1000;
+
 export async function GET() {
-  const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  const staleBefore = new Date(Date.now() - STALE_THRESHOLD_MS);
 
   try {
-    const latestUpdate = await prisma.dataset.findFirst({
+    // "Has ANY active dataset refreshed successfully recently?" — the newest
+    // lastChecked across the fleet. lastChecked advances only on success, so:
+    //  - one permanently-failing dataset can't drag health down (others succeed;
+    //    its failure surfaces via consecutiveFailures/lastError in admin), and
+    //  - a total outage (cron dead, DB down, Overpass down → nothing succeeds)
+    //    ages the newest success past the window and degrades health.
+    const newestChecked = await prisma.dataset.findFirst({
       where: { isActive: true, lastChecked: { not: null } },
       orderBy: { lastChecked: "desc" },
       select: { lastChecked: true },
     });
 
-    const isDegraded =
-      !latestUpdate?.lastChecked ||
-      latestUpdate.lastChecked < twoHoursAgo;
+    let reference = newestChecked?.lastChecked ?? null;
+
+    if (!reference) {
+      // Nothing has ever refreshed successfully. Only degrade once the oldest
+      // active dataset has waited past the window — a fresh instance gets grace
+      // to run its first cycle. No active datasets at all => nothing to do => ok.
+      const oldestActive = await prisma.dataset.findFirst({
+        where: { isActive: true },
+        orderBy: { createdAt: "asc" },
+        select: { createdAt: true },
+      });
+      reference = oldestActive?.createdAt ?? null;
+    }
+
+    const isDegraded = reference !== null && reference < staleBefore;
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## Health check: fix false "degraded" from a cadence mismatch

**Problem:** Production paged as "down" while actually serving traffic (HTTP 200). Only `GET /api/health` returned 503 `{"reason":"datasets not updating"}`. Root cause is a threshold bug, not an outage: the endpoint degraded when the **newest** `lastChecked` was older than **2h**, but datasets only become eligible for refresh after **24h** (`api/tasks/update-datasets`). The fleet (~354 datasets) refreshes in a ~6h daily burst then idles ~18h, so the newest successful check routinely ages past 2h and health flapped to 503 every day even when perfectly healthy.

**Acceptance Criteria:**
- [ ] `/api/health` stays `ok` across the normal idle window of a 24h refresh cycle
- [ ] Degrades only on a real stall (cron dead, DB down, or Overpass down → nothing refreshes successfully within the cadence)
- [ ] A single permanently-failing dataset does not drag health down
- [ ] Fresh instances and empty fleets are not falsely degraded

**Changes:**
Judge health against the refresh cadence instead of a fixed 2h: degrade only when no active dataset has refreshed successfully within `REFRESH_INTERVAL_HOURS (24) + GRACE_HOURS (6) = 30h`. Signal is the **newest** `lastChecked` (max) — advanced only on success, so one failing dataset can't drag it down (its failure surfaces via `consecutiveFailures`/`lastError` in admin, from #432), while a total outage ages the newest success out and degrades. Falls back to the oldest active dataset's `createdAt` when nothing has ever succeeded (grace for a first cycle), and treats an empty fleet as `ok`. Adds 7 unit tests (idle window, Overpass-down staleness, fresh instance, never-succeeded, empty, DB error).

Part of the monitoring architecture tracked in infra#30 (this is the app-side slice; the prompt Overpass alerting is handled separately via outbound heartbeats). Type-check passes; unit tests pass; verified live against a real DB (`ok`/200).