### PR TITLE
fix(map): consistent zoom control on all platform maps

### DIFF
--- a/src/components/dataset/full-map.tsx
+++ b/src/components/dataset/full-map.tsx
@@ -25,6 +25,7 @@ import { StyleTuningPanel } from "./map/style-tuning-panel";
 import { useMapData, useFeatureSelection } from "./map/hooks";
 import type { Feature, FeatureCollection } from "geojson";
 import { MapErrorState, MapNoDataState } from "./map/map-states";
+import { MapZoomControl } from "@/components/ui/map-zoom-control";
 import { mapStyle } from "@/lib/map-tiles";
 import { AGE_COLORS } from "./map/layers/map-style";
 import {
@@ -204,7 +205,7 @@ export const DatasetFullMap = forwardRef<
       {/* Map */}
       <div className="flex-1 relative">
         {hasFilteredData && (
-          /* Legend: the map's single control */
+          /* Legend: the map's primary control (zoom sits top-left) */
           <div className="absolute z-10 top-4 end-4">
             <InteractiveLegend
               views={views}
@@ -241,6 +242,7 @@ export const DatasetFullMap = forwardRef<
             touchZoomRotate={true}
           >
             {boundary && <AoiBoundaryLayer boundary={boundary} />}
+            <MapZoomControl />
             <MemoizedMapLayers
               geoJSONData={processedData}
               curatedTheme={activeTheme}

--- a/src/components/home/shared/featured-dataset-map-client.tsx
+++ b/src/components/home/shared/featured-dataset-map-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import Map, { NavigationControl } from "react-map-gl/maplibre";
+import Map from "react-map-gl/maplibre";
 import type { MapRef } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { Link } from "react-aria-components";
@@ -9,6 +9,7 @@ import { ArrowRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { FeatureCollection } from "geojson";
 import { mapStyle } from "@/lib/map-tiles";
+import { MapZoomControl } from "@/components/ui/map-zoom-control";
 import { getTemplateIcon } from "@/lib/category-icons";
 import { calculateBbox, computeInitialViewState } from "@/lib/utils";
 import type { InitialViewState } from "@/lib/utils";
@@ -151,14 +152,13 @@ export function FeaturedDatasetMapClient({
         {processedData && (
           <MapLayers geoJSONData={processedData} curatedTheme={null} />
         )}
-        <div className="absolute right-3 bottom-3">
-          <NavigationControl showCompass={false} visualizePitch={false} />
-        </div>
+        <MapZoomControl />
       </Map>
 
-      {/* Bottom is owned by the info card on small screens, so the legend moves to the top-left corner there */}
+      {/* Bottom is owned by the info card on small screens, so the legend moves
+          to the top-right corner there (top-left holds the shared zoom control) */}
       {processedData && (
-        <div className="absolute start-3 top-3 sm:start-4 sm:top-auto sm:bottom-4">
+        <div className="absolute end-3 top-3 sm:end-auto sm:start-4 sm:top-auto sm:bottom-4">
           <AgeLegendCompact />
         </div>
       )}

--- a/src/components/home/shared/hero-map.tsx
+++ b/src/components/home/shared/hero-map.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useMemo } from "react";
-import Map, { NavigationControl } from "react-map-gl/maplibre";
+import Map from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { HERO_LOCATIONS } from "./hero-map-locations";
 import { mapStyle } from "@/lib/map-tiles";
+import { MapZoomControl } from "@/components/ui/map-zoom-control";
 
 export function HeroMap() {
 
@@ -36,9 +37,7 @@ export function HeroMap() {
         key={location?.id ?? "hero-map"}
         style={{ width: "100%", height: "100%" }}
       >
-        <div className="absolute right-3 bottom-3">
-          <NavigationControl showCompass={false} visualizePitch={false} />
-        </div>
+        <MapZoomControl />
       </Map>
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-black/25 via-transparent to-transparent" />
     </div>

--- a/src/components/ui/map-zoom-control.tsx
+++ b/src/components/ui/map-zoom-control.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { NavigationControl } from "react-map-gl/maplibre";
+
+/**
+ * Shared zoom (+/-) control for every platform map. Rendered as a child of a
+ * react-map-gl <Map>. Position comes from the control's own `position` prop —
+ * react-map-gl mounts it into maplibre's corner container, so wrapping it in a
+ * positioned div has no effect. Top-left, no compass/pitch: the one corner free
+ * on every map (dataset legend is top-right, featured info card is bottom-right,
+ * attribution is bottom-right), so all maps expose zoom consistently.
+ */
+export function MapZoomControl() {
+  return (
+    <NavigationControl
+      position="top-left"
+      showCompass={false}
+      visualizePitch={false}
+    />
+  );
+}


### PR DESCRIPTION
## Consistent map zoom control

**Problem:** The dataset-page map had no zoom (+/-) control, so users could only zoom by scroll/pinch. The two home maps (hero, featured) *did* include a `NavigationControl`, but wrapped it in a positioned `<div className="absolute right-3 bottom-3">` — a no-op: react-map-gl mounts controls into maplibre's own corner containers via the `position` prop, so the wrapper was ignored and the control rendered at the default top-right, not the intended bottom-right. Result: zoom was missing on the main map and inconsistently placed elsewhere.

**Acceptance Criteria:**
- [x] Every platform map (dataset, hero, featured) exposes a zoom control
- [x] Same placement and config across all maps
- [x] No overlap with existing overlays (legend, info card, attribution) on desktop or mobile
- [x] Accessible zoom-in/zoom-out labels

**Changes:**
- New shared `MapZoomControl` (`src/components/ui/map-zoom-control.tsx`): `NavigationControl` with `position="top-left"`, no compass/pitch. Top-left is the only corner free on every map (dataset legend owns top-right; featured info card + attribution own bottom-right).
- Wired it into `full-map.tsx` (dataset), `hero-map.tsx`, and `featured-dataset-map-client.tsx`, replacing the two broken inline no-op wrappers.
- Moved the featured map's mobile legend from top-left to top-right (`end-3 top-3`; desktop bottom-left unchanged) so it clears the top-left zoom.

Verified in-browser (dataset, hero, featured desktop + mobile) with live data; `pnpm type-check` clean; a11y tree exposes "Zoom in"/"Zoom out" labels.