### PR TITLE
style(map): align area/line strokes with point markers

### DIFF
--- a/src/components/dataset/map/layers/detailed-features-layer-group.tsx
+++ b/src/components/dataset/map/layers/detailed-features-layer-group.tsx
@@ -14,9 +14,11 @@ import {
 } from "./map-style";
 import { createSmallPolygonProxyPoints } from "./polygon-proxy-points";
 
-// Proxy circles carry small polygons at low zoom, then hand off to the
-// real footprints as they become resolvable
-const PROXY_FADE = ["interpolate", ["linear"], ["zoom"], 12.5, 0.9, 14, 0];
+// Proxy circles carry small polygons at low zoom, then hand off to the real
+// footprints as they become resolvable. Fully opaque through z13 so the circle
+// hides its (still-tiny) polygon rather than letting it show through, then a
+// quick crossfade to the resolved footprint by z14.
+const PROXY_FADE = ["interpolate", ["linear"], ["zoom"], 13, 1, 14, 0];
 import type { CuratedTheme } from "@/lib/curated-themes";
 import { buildCuratedColorExpression } from "@/lib/curated-themes";
 import { PALETTES } from "@/lib/map-palettes";
@@ -69,21 +71,6 @@ export function DetailedFeaturesLayerGroup({
 
   return (
     <>
-      {proxyPoints.length > 0 && (
-        <MapLayer
-          id="polygon-proxy-points"
-          features={proxyPoints}
-          layerType="circle"
-          filter={visibilityFilter}
-          paint={{
-            ...buildThemePointPaint(themeColor, proxyPoints.length),
-            "circle-opacity": PROXY_FADE,
-            "circle-stroke-opacity": PROXY_FADE,
-          }}
-          layout={{ "circle-sort-key": AGE_SORT_KEY }}
-        />
-      )}
-
       {polygonFeatures.length > 0 && (
         <MapLayer
           id="detailed-polygons"
@@ -106,6 +93,24 @@ export function DetailedFeaturesLayerGroup({
                 }
               : POLYGON_STYLE.stroke,
           }}
+        />
+      )}
+
+      {/* Above the polygons so a small polygon's circle covers it at low zoom
+          and crossfades out (PROXY_FADE) to reveal the real footprint by ~z14,
+          instead of the subpixel polygon covering its own proxy */}
+      {proxyPoints.length > 0 && (
+        <MapLayer
+          id="polygon-proxy-points"
+          features={proxyPoints}
+          layerType="circle"
+          filter={visibilityFilter}
+          paint={{
+            ...buildThemePointPaint(themeColor, proxyPoints.length),
+            "circle-opacity": PROXY_FADE,
+            "circle-stroke-opacity": PROXY_FADE,
+          }}
+          layout={{ "circle-sort-key": AGE_SORT_KEY }}
         />
       )}
 

--- a/src/components/dataset/map/layers/map-style.ts
+++ b/src/components/dataset/map/layers/map-style.ts
@@ -81,8 +81,10 @@ export const DEFAULT_STYLE_KNOBS: MapStyleKnobs = {
   recent: {
     haloWidth: 1.5,
   },
-  line: { widthZ8: 3.5, widthZ13: 2, widthZ18: 6 },
-  polygonStroke: { widthZ8: 2.5, widthZ13: 1.5, widthZ18: 3 },
+  // Thinner to match the point marker's restraint; areas take a thin white
+  // outline (buildPolygonStyle) like the point's stroke ring
+  line: { widthZ8: 2, widthZ13: 1.5, widthZ18: 3 },
+  polygonStroke: { widthZ8: 1, widthZ13: 1, widthZ18: 1.5 },
   // Administrative boundary: brand olive (design token olive-500) so it
   // reads as chrome, not data; the old #0b4ad8 blue collided with the
   // teal/blue-green data ramps
@@ -90,14 +92,6 @@ export const DEFAULT_STYLE_KNOBS: MapStyleKnobs = {
 };
 
 export const AGE_COLORS = DEFAULT_STYLE_KNOBS.colors;
-
-// Darker steps of the viridis ramp for polygon outlines
-export const AGE_STROKE_COLORS: AgeCategoryColors = {
-  recent: "#2e3060",
-  medium: "#1d5464",
-  older: "#17755c",
-  "very-old": "#559239",
-};
 
 // The one mapping from per-age values to a MapLibre case expression.
 // Collapses to the bare value when everything matches and skips branches
@@ -166,6 +160,7 @@ export function buildLineWidth(knobs: MapStyleKnobs) {
   ];
 }
 
+
 // City-zoom radius scales with density: sparse points keep a touch more bulk
 // on city-wide views, dense ones stay tiny so they don't blend into a blob.
 // At high zoom individual features become the subject, so radius grows again.
@@ -228,7 +223,9 @@ export function buildPolygonStyle(knobs: MapStyleKnobs) {
       "fill-opacity": 0.7,
     },
     stroke: {
-      "line-color": ageCase(AGE_STROKE_COLORS),
+      // White outline, like the point's stroke ring — replaces the old
+      // darker-viridis outline so the area reads as one color, not two
+      "line-color": knobs.point.strokeColor,
       "line-width": buildPolygonStrokeWidth(knobs),
       "line-opacity": 0.9,
     },

--- a/src/components/dataset/map/style-tuning-panel.tsx
+++ b/src/components/dataset/map/style-tuning-panel.tsx
@@ -303,6 +303,11 @@ function StyleTuningPanelInner({ features }: StyleTuningPanelProps) {
     setPaint("detailed-polygons", "fill-color", ageColor);
     setPaint(
       "detailed-polygons-stroke",
+      "line-color",
+      knobs.point.strokeColor
+    );
+    setPaint(
+      "detailed-polygons-stroke",
       "line-width",
       buildPolygonStrokeWidth(knobs)
     );


### PR DESCRIPTION
## Map geometry styling: areas & lines consistent with points

**Problem:** Area (polygon) and line features used heavy strokes that didn't match the point markers. Polygons got a *darker-viridis* outline (a separate color ramp) and lines were thick — neither matched the clean thin **white** outline the point markers use, so the three geometry types read as different visual languages. Separately, small-polygon proxy circles (shown at low zoom for subpixel areas) were drawn *under* the polygons and capped at 0.9 opacity, so a small area showed through / covered its own proxy.

**Changes:**
- **Areas:** white hairline outline (reuses the existing polygon stroke layer, no new layer) replacing the darker-viridis outline; thinner widths. Removes the now-unused `AGE_STROKE_COLORS` ramp.
- **Lines:** thinner colored lines (2→3px). No separate casing — a line white-outline would require a dedicated second layer, not worth it for a hairline.
- **Small-area proxies:** render proxy circles *above* the polygons and keep them fully opaque through z13, then crossfade to the real footprint by z14. Fixes the small polygon showing through / covering its own proxy circle at low zoom.

Confined to `map-style.ts` (the single source of truth for the dev tune panel + baked defaults) and `detailed-features-layer-group.tsx`. Verified in-browser on Paris parks (areas + small-polygon crossfade) and rail-tracks (lines) across zoom levels; `pnpm type-check` and `pnpm lint` clean.