### PR TITLE
fix(health): use shared 24h-cadence threshold for admin datasets badge

### DIFF
--- a/src/app/[locale]/datasets/page.tsx
+++ b/src/app/[locale]/datasets/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/db";
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
 import { getTranslations, getLocale } from "next-intl/server";
 import { DATASET_FAILURE_FLAG_THRESHOLD } from "@/lib/constants";
+import { isFleetHealthy } from "@/lib/dataset-health";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +16,6 @@ export const metadata: Metadata = {
 
 async function getUpdateStatus() {
   const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-  const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
   const activeWhere = { isActive: true } as const;
 
   const [activeTotal, refreshed24h, flagged, freshness, flaggedDatasets] =
@@ -54,7 +54,7 @@ async function getUpdateStatus() {
     flagged,
     newestCheck,
     oldestCheck: freshness._min.lastChecked,
-    isHealthy: !!newestCheck && newestCheck >= twoHoursAgo,
+    isHealthy: isFleetHealthy(newestCheck),
     flaggedDatasets,
   };
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,23 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-
-// The update-datasets cron refreshes each dataset on roughly this cadence
-// (a dataset becomes eligible once its lastAttempted is older than this window;
-// see api/tasks/update-datasets). The fleet refreshes in a daily burst then sits
-// idle, so a healthy system only produces a *successful* check about once per
-// interval — health must be judged against that cadence, not a tighter one.
-const REFRESH_INTERVAL_HOURS = 24;
-// Grace on top of the interval before we call the pipeline stalled: absorbs the
-// idle gap between bursts plus cron/Overpass jitter. Peak healthy age of the
-// newest successful check is ~the idle gap (< interval); this margin keeps a
-// healthy idle stretch from tripping a false alarm.
-const GRACE_HOURS = 6;
-const STALE_THRESHOLD_MS =
-  (REFRESH_INTERVAL_HOURS + GRACE_HOURS) * 60 * 60 * 1000;
+import { isFleetHealthy } from "@/lib/dataset-health";
 
 export async function GET() {
-  const staleBefore = new Date(Date.now() - STALE_THRESHOLD_MS);
-
   try {
     // "Has ANY active dataset refreshed successfully recently?" — the newest
     // lastChecked across the fleet. lastChecked advances only on success, so:
@@ -45,7 +30,7 @@ export async function GET() {
       reference = oldestActive?.createdAt ?? null;
     }
 
-    const isDegraded = reference !== null && reference < staleBefore;
+    const isDegraded = !isFleetHealthy(reference);
 
     return NextResponse.json(
       {

--- a/src/lib/__tests__/dataset-health.test.ts
+++ b/src/lib/__tests__/dataset-health.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { STALE_THRESHOLD_MS, isFleetHealthy } from "../dataset-health";
+
+const NOW = new Date("2026-07-31T12:00:00Z").getTime();
+const hoursAgo = (h: number) => new Date(NOW - h * 60 * 60 * 1000);
+
+describe("isFleetHealthy", () => {
+  it("is healthy when the reference is within the cadence window", () => {
+    expect(isFleetHealthy(hoursAgo(11), NOW)).toBe(true);
+  });
+
+  it("stays healthy across the idle stretch of a daily refresh cycle (25h < 30h)", () => {
+    expect(isFleetHealthy(hoursAgo(25), NOW)).toBe(true);
+  });
+
+  it("is unhealthy once the reference ages past interval + grace (40h > 30h)", () => {
+    expect(isFleetHealthy(hoursAgo(40), NOW)).toBe(false);
+  });
+
+  it("treats a null reference (nothing to judge) as healthy", () => {
+    expect(isFleetHealthy(null, NOW)).toBe(true);
+  });
+
+  it("uses a 30h (24h interval + 6h grace) window", () => {
+    expect(STALE_THRESHOLD_MS).toBe(30 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/dataset-health.ts
+++ b/src/lib/dataset-health.ts
@@ -1,0 +1,30 @@
+// Shared dataset-fleet freshness thresholds and health verdict, used by both
+// the /api/health endpoint and the admin dataset-updates page so the two can't
+// drift apart.
+//
+// The update-datasets cron refreshes each dataset on roughly this cadence (a
+// dataset becomes eligible once its lastAttempted is older than the interval;
+// see api/tasks/update-datasets). The fleet refreshes in a daily burst then
+// sits idle, so a healthy system only produces a *successful* check about once
+// per interval — health must be judged against that cadence, not a tighter one.
+export const REFRESH_INTERVAL_HOURS = 24;
+// Grace on top of the interval before we call the pipeline stalled: absorbs the
+// idle gap between bursts plus cron/Overpass jitter. Peak healthy age of the
+// newest successful check is ~the idle gap (< interval); this margin keeps a
+// healthy idle stretch from tripping a false alarm.
+export const GRACE_HOURS = 6;
+export const STALE_THRESHOLD_MS =
+  (REFRESH_INTERVAL_HOURS + GRACE_HOURS) * 60 * 60 * 1000;
+
+/**
+ * Is the dataset fleet healthy, given a reference date (the newest successful
+ * check across active datasets, or a fresh-instance fallback)? A null reference
+ * means there is nothing to judge (no active datasets) and reads as healthy.
+ */
+export function isFleetHealthy(
+  reference: Date | null,
+  now: number = Date.now()
+): boolean {
+  if (reference === null) return true;
+  return reference.getTime() >= now - STALE_THRESHOLD_MS;
+}


### PR DESCRIPTION
## Problem

The admin dataset-updates page (`/[locale]/datasets`, new in this cycle via #432) judged fleet health with a hardcoded **2-hour** threshold:

```ts
const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
isHealthy: !!newestCheck && newestCheck >= twoHoursAgo,
```

This reintroduces the exact false-"degraded" bug #435 just fixed for `/api/health`. The fleet refreshes in a ~24h burst-then-idle cadence, so the newest successful check is routinely older than 2h on a perfectly healthy system — the admin badge would read **Degraded** (red) for most of every day.

Flagged by the automated review on the v1.16.0 release PR (#440). Admin-only and cosmetic (no functional/data impact), but the page is new this cycle so it would ship broken.

## Fix

Extract the shared threshold + verdict into `src/lib/dataset-health.ts` so the two call sites can't drift again:

- `STALE_THRESHOLD_MS` = 24h interval + 6h grace
- `isFleetHealthy(reference)` — the health verdict

`api/health/route.ts` now delegates its verdict to `isFleetHealthy` (behavior identical; existing route tests unchanged). The admin page drops `twoHoursAgo` and uses `isFleetHealthy(newestCheck)`.

## Verification

- `pnpm type-check` clean
- `pnpm vitest run` — 12/12 (5 new `dataset-health` + 7 existing `/api/health` route)
- eslint clean
