### PR TITLE
chore(release): 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # osmforcities
 
+## 1.16.1
+
+### Fixed
+
+- Datasets no longer get stuck behind a false "too large" pre-flight failure: template queries now use exact tag matching on indexed keys, so size checks answer in ~1s instead of timing out, and a timed-out check is retried after 30 minutes instead of being cached for 24 hours [#446]
+
+[#446]: https://github.com/osmforcities/osmforcities/pull/446
+
 ## 1.16.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmforcities",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "scripts": {
     "dev": "COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null || echo 'unknown') next dev",


### PR DESCRIPTION
## 1.16.1

### Fixed

- Datasets no longer get stuck behind a false "too large" pre-flight failure: template queries now use exact tag matching on indexed keys, so size checks answer in ~1s instead of timing out, and a timed-out check is retried after 30 minutes instead of being cached for 24 hours [#446]

[#446]: https://github.com/osmforcities/osmforcities/pull/446
