### PR TITLE
Release v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # osmforcities
 
+## 1.16.1
+
+### Fixed
+
+- Datasets no longer get stuck behind a false "too large" pre-flight failure: template queries now use exact tag matching on indexed keys, so size checks answer in ~1s instead of timing out, and a timed-out check is retried after 30 minutes instead of being cached for 24 hours [#446]
+
+[#446]: https://github.com/osmforcities/osmforcities/pull/446
+
 ## 1.16.0
 
 ### Added

--- a/docs/features/template-management.md
+++ b/docs/features/template-management.md
@@ -13,6 +13,15 @@ YAML is the source of truth; deploy runs the sync. No admin UI.
   parent, and optional `filterableTags`. Row: `[id, query, category, icon?, parent?]`.
   Query syntax: `;` = OR, `&` = AND, `*`/empty = wildcard; `{OSM_RELATION_ID}` is
   substituted per area at fetch time.
+- **Value matching** — values compile to exact `["key"="value"]` so Overpass can use its
+  value index. Keys in `MULTI_VALUE_KEYS` (`prisma/lib/template-parser.ts`) instead get a
+  semicolon-boundary regex, for values OSM routinely combines (`vending=drinks;food`).
+  A regex cannot use the index and scans every element carrying the key in the area —
+  21.4s vs 1.27s for `highway=traffic_signals` in Tucson — so it is reserved for keys that
+  need it. **Adding a template on a key not in that set:** check taginfo first
+  (`/api/4/key/values?key=<key>&query=%3B`) and add the key if semicolon-combined values
+  are material. Low-cardinality keys pay almost nothing for the regex; high-cardinality
+  primary keys (`highway`, `building`, `natural`, `amenity`) pay 3-17x.
 - **Sub-template** — a template with a `parent`. Use when the query is a strict subset
   of a broader template (`bus-stops` under `public-transit`). Standalone → top-level.
 - **Parent (umbrella)** — a template whose query is the union of its children, giving a
@@ -398,6 +407,12 @@ active/featured set bounded.
   `building`, `highway`, `railway`, `waterway`) is a primary classification key that OSM
   convention treats as single-valued; only descriptive/attribute keys like `vending=*` are
   routinely semicolon-combined.
+  **Superseded 2026-08-04:** the catalog-wide regex was reverted to exact match for all
+  keys except `MULTI_VALUE_KEYS` — the regex defeats Overpass's value index, and on
+  high-cardinality keys it made the size-check pre-flight time out and blacklist the
+  area+template for 24h (`highway=traffic_signals` in Tucson: 21.4s vs 1.27s). The reading
+  above was right that these keys are single-valued in practice; it was wrong that the
+  regex was free. See Value matching under Definitions.
 - **canteens — rejected.** `amenity=canteen` returned zero features in 5 of 6 test cities
   (Paris, Wrocław, Barcelona, Mexico City, Tokyo); only Munich had any data (16 features).
   Even there, `access` (the key that would carry a students-vs-employees food-security
@@ -603,6 +618,7 @@ during that pass, beyond the per-domain notes above:
   "nothing to enter by wheelchair" case, not a coverage drop.
 - **Shared-infra fixes carried in from the food batch apply catalog-wide:** the
   semicolon-boundary value match in `buildOverpassQuery` (`prisma/lib/template-parser.ts`)
+  — since narrowed to `MULTI_VALUE_KEYS`, see Value matching under Definitions —
   and the semicolon-split token counting in `computeTagDimension`
   (`src/lib/filter-dimensions.ts`), merged with healthcare's `keepEmpty` all-Missing legend
   in the same file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmforcities",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "scripts": {
     "dev": "COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null || echo 'unknown') next dev",

--- a/prisma/lib/__tests__/template-parser.test.ts
+++ b/prisma/lib/__tests__/template-parser.test.ts
@@ -114,11 +114,11 @@ describe("template-parser", () => {
   });
 
   describe("buildOverpassQuery", () => {
-    it("builds query for key=value", () => {
+    it("builds an exact-match query for key=value", () => {
       const query = buildOverpassQuery("amenity=restaurant");
-      expect(query).toContain('node["amenity"~"(^|;)restaurant(;|$)"]');
-      expect(query).toContain('way["amenity"~"(^|;)restaurant(;|$)"]');
-      expect(query).toContain('relation["amenity"~"(^|;)restaurant(;|$)"]');
+      expect(query).toContain('node["amenity"="restaurant"]');
+      expect(query).toContain('way["amenity"="restaurant"]');
+      expect(query).toContain('relation["amenity"="restaurant"]');
       expect(query).toContain("area.searchArea");
     });
 
@@ -129,35 +129,66 @@ describe("template-parser", () => {
       expect(query).toContain('relation["sport"]');
     });
 
+    // A value regex cannot use Overpass's value index, so it scans every element
+    // carrying the key in the area — 21.4s vs 1.27s for highway=traffic_signals in
+    // Tucson. Only keys where semicolon-combined values are actually common keep it.
+    it("keeps the semicolon regex for multi-value keys (sport=soccer;basketball)", () => {
+      const query = buildOverpassQuery("sport=soccer");
+      expect(query).toContain('node["sport"~"(^|;)soccer(;|$)"]');
+      expect(query).toContain('way["sport"~"(^|;)soccer(;|$)"]');
+      expect(query).toContain('relation["sport"~"(^|;)soccer(;|$)"]');
+    });
+
+    it("keeps the semicolon regex for the other multi-value keys", () => {
+      expect(buildOverpassQuery("healthcare=laboratory")).toContain(
+        '"healthcare"~"(^|;)laboratory(;|$)"',
+      );
+      expect(buildOverpassQuery("traffic_sign=maxspeed")).toContain(
+        '"traffic_sign"~"(^|;)maxspeed(;|$)"',
+      );
+      expect(buildOverpassQuery("traffic_calming=bump")).toContain(
+        '"traffic_calming"~"(^|;)bump(;|$)"',
+      );
+    });
+
     it("matches semicolon-combined tag values (e.g. vending=drinks;food)", () => {
       const query = buildOverpassQuery("amenity=vending_machine&vending=food");
+      expect(query).toContain('["amenity"="vending_machine"]');
       expect(query).toContain('"vending"~"(^|;)food(;|$)"');
     });
 
-    it("escapes regex metacharacters in values", () => {
+    it("escapes regex metacharacters for multi-value keys", () => {
+      const query = buildOverpassQuery("healthcare=Eat+Fresh");
+      expect(query).toContain('"healthcare"~"(^|;)Eat\\+Fresh(;|$)"');
+    });
+
+    it("does not regex-escape exact-match values", () => {
       const query = buildOverpassQuery("brand=Eat+Fresh");
-      expect(query).toContain('"brand"~"(^|;)Eat\\+Fresh(;|$)"');
+      expect(query).toContain('node["brand"="Eat+Fresh"]');
+    });
+
+    it("escapes quotes and backslashes in exact-match values", () => {
+      const query = buildOverpassQuery('name=A"B\\C');
+      expect(query).toContain('node["name"="A\\"B\\\\C"]');
     });
 
     it("builds query for composite tags with ; separator", () => {
       const query = buildOverpassQuery("natural=tree;natural=tree_row");
-      expect(query).toContain('node["natural"~"(^|;)tree(;|$)"]');
-      expect(query).toContain('node["natural"~"(^|;)tree_row(;|$)"]');
-      expect(query).toContain('way["natural"~"(^|;)tree(;|$)"]');
-      expect(query).toContain('way["natural"~"(^|;)tree_row(;|$)"]');
-      expect(query).toContain('relation["natural"~"(^|;)tree(;|$)"]');
-      expect(query).toContain('relation["natural"~"(^|;)tree_row(;|$)"]');
+      expect(query).toContain('node["natural"="tree"]');
+      expect(query).toContain('node["natural"="tree_row"]');
+      expect(query).toContain('way["natural"="tree"]');
+      expect(query).toContain('way["natural"="tree_row"]');
+      expect(query).toContain('relation["natural"="tree"]');
+      expect(query).toContain('relation["natural"="tree_row"]');
     });
 
     it("builds query for 3+ composite tags", () => {
       const query = buildOverpassQuery(
         "building=house;building=detached;building=semidetached_house",
       );
-      expect(query).toContain('node["building"~"(^|;)house(;|$)"]');
-      expect(query).toContain('node["building"~"(^|;)detached(;|$)"]');
-      expect(query).toContain(
-        'node["building"~"(^|;)semidetached_house(;|$)"]',
-      );
+      expect(query).toContain('node["building"="house"]');
+      expect(query).toContain('node["building"="detached"]');
+      expect(query).toContain('node["building"="semidetached_house"]');
     });
 
     it("builds query for mixed key-only and key=value composites", () => {
@@ -168,19 +199,15 @@ describe("template-parser", () => {
 
     it("builds query for AND conditions with & separator", () => {
       const query = buildOverpassQuery("natural=tree&species=*");
-      expect(query).toContain(
-        'node["natural"~"(^|;)tree(;|$)"]["species"]',
-      );
-      expect(query).toContain('way["natural"~"(^|;)tree(;|$)"]["species"]');
-      expect(query).toContain(
-        'relation["natural"~"(^|;)tree(;|$)"]["species"]',
-      );
+      expect(query).toContain('node["natural"="tree"]["species"]');
+      expect(query).toContain('way["natural"="tree"]["species"]');
+      expect(query).toContain('relation["natural"="tree"]["species"]');
     });
 
     it("builds query for multiple AND conditions", () => {
       const query = buildOverpassQuery("highway=path&surface=paved&lit=yes");
       expect(query).toContain(
-        'node["highway"~"(^|;)path(;|$)"]["surface"~"(^|;)paved(;|$)"]["lit"~"(^|;)yes(;|$)"]',
+        'node["highway"="path"]["surface"="paved"]["lit"="yes"]',
       );
     });
 
@@ -188,10 +215,14 @@ describe("template-parser", () => {
       const query = buildOverpassQuery(
         "highway=footway;highway=path&surface=paved",
       );
-      expect(query).toContain('node["highway"~"(^|;)footway(;|$)"]');
-      expect(query).toContain(
-        'node["highway"~"(^|;)path(;|$)"]["surface"~"(^|;)paved(;|$)"]',
-      );
+      expect(query).toContain('node["highway"="footway"]');
+      expect(query).toContain('node["highway"="path"]["surface"="paved"]');
+    });
+
+    it("uses the indexed fast path for the traffic-lights template", () => {
+      const query = buildOverpassQuery("highway=traffic_signals");
+      expect(query).toContain('node["highway"="traffic_signals"]');
+      expect(query).not.toContain("~");
     });
   });
 
@@ -219,9 +250,7 @@ describe("template-parser", () => {
       expect(template.description).toBe("Test Restaurants in the area");
       expect(template.category).toBe("food");
       expect(template.tags).toEqual(["amenity=restaurant"]);
-      expect(template.overpassQuery).toContain(
-        'node["amenity"~"(^|;)restaurant(;|$)"]',
-      );
+      expect(template.overpassQuery).toContain('node["amenity"="restaurant"]');
     });
 
     it("auto-generates name and description when not provided", () => {
@@ -274,12 +303,8 @@ describe("template-parser", () => {
       };
       const template = buildTemplate(config);
       expect(template.tags).toEqual(["natural=tree", "natural=tree_row"]);
-      expect(template.overpassQuery).toContain(
-        'node["natural"~"(^|;)tree(;|$)"]',
-      );
-      expect(template.overpassQuery).toContain(
-        'node["natural"~"(^|;)tree_row(;|$)"]',
-      );
+      expect(template.overpassQuery).toContain('node["natural"="tree"]');
+      expect(template.overpassQuery).toContain('node["natural"="tree_row"]');
     });
   });
 

--- a/prisma/lib/template-parser.ts
+++ b/prisma/lib/template-parser.ts
@@ -156,6 +156,40 @@ function escapeRegex(value: string): string {
 }
 
 /**
+ * Escape a literal value for embedding in a double-quoted Overpass QL string.
+ */
+function escapeQuoted(value: string): string {
+  return value.replace(/[\\"]/g, "\\$&");
+}
+
+/**
+ * Keys whose values are routinely semicolon-combined in OSM, so an exact match
+ * would silently miss features (e.g. sport=soccer;basketball).
+ *
+ * Everything else uses exact match, which lets Overpass hit the value index.
+ * The difference is large on high-cardinality keys: for highway=traffic_signals
+ * in Tucson the regex form takes 21.4s (and trips the size-check pre-flight)
+ * while exact match takes 1.27s. Measured global semicolon usage justifies the
+ * split — highway has 1,326 semicolon uses worldwide and natural 213 of 93.0M,
+ * whereas sport has 20,452 distinct semicolon-combined values.
+ *
+ * When adding a template on a key that is not listed here, check taginfo for
+ * semicolon-combined values first:
+ *   https://taginfo.openstreetmap.org/api/4/key/values?key=<key>&query=%3B
+ * and add the key below if they are material.
+ */
+const MULTI_VALUE_KEYS = new Set([
+  "content",
+  "healthcare",
+  "social_facility:for",
+  "species",
+  "sport",
+  "traffic_calming",
+  "traffic_sign",
+  "vending",
+]);
+
+/**
  * Build Overpass query from key=value pair.
  *
  * Supports composite queries:
@@ -166,13 +200,15 @@ function escapeRegex(value: string): string {
  * - Mixed: "highway=footway;highway=path&surface=paved"
  *   Example: (footway) OR (path WITH paved surface)
  *
- * Value matches use a semicolon-boundary regex ("(^|;)value(;|$)") rather than
- * exact equality, since OSM tags on keys like vending=* or cuisine=* are
- * routinely multi-valued (e.g. vending=drinks;food) and an exact match would
- * silently miss those combined-value features.
+ * Value matches use exact equality so Overpass can use its value index. Keys in
+ * MULTI_VALUE_KEYS instead use a semicolon-boundary regex ("(^|;)value(;|$)"),
+ * since their values are routinely combined (e.g. vending=drinks;food) and an
+ * exact match would silently miss those features. See MULTI_VALUE_KEYS for the
+ * cost/recall evidence behind the split.
  *
  * Note: YAML is trusted developer input, so no sanitization is needed beyond
- * regex-escaping the value itself.
+ * escaping the value for the form it lands in — regex metacharacters on the
+ * MULTI_VALUE_KEYS path, quotes and backslashes on the exact-match path.
  */
 export function buildOverpassQuery(kv: string): string {
   // Split on ; to get OR groups
@@ -200,8 +236,11 @@ export function buildOverpassQuery(kv: string): string {
       }
 
       if (value && value !== "*") {
-        const escaped = escapeRegex(value);
-        tagFilters.push(`"${key}"~"(^|;)${escaped}(;|$)"`);
+        if (MULTI_VALUE_KEYS.has(key)) {
+          tagFilters.push(`"${key}"~"(^|;)${escapeRegex(value)}(;|$)"`);
+        } else {
+          tagFilters.push(`"${key}"="${escapeQuoted(value)}"`);
+        }
       } else {
         tagFilters.push(`"${key}"`);
       }

--- a/src/lib/__tests__/dataset-snapshot.test.ts
+++ b/src/lib/__tests__/dataset-snapshot.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   fetchDatasetSnapshot,
   DatasetTooLargeError,
+  DatasetSizeCheckTimeoutError,
 } from "@/lib/dataset-snapshot";
 import { prisma } from "@/lib/db";
 import { MAX_DATASET_BYTES, OVERPASS_BYTES_PER_ELEMENT_ESTIMATE } from "@/lib/constants";
@@ -233,5 +234,63 @@ describe("fetchDatasetSnapshot", () => {
         create: expect.objectContaining({ status: "ok" }),
       })
     );
+  });
+
+  it("rejects instantly from a fresh timeout verdict", async () => {
+    findUnique.mockResolvedValue({
+      id: "check-1",
+      areaId: 1,
+      templateId: "tpl-1",
+      status: "timeout",
+      estimatedBytes: null,
+      actualBytes: null,
+      checkedAt: new Date(),
+    });
+    const fetchSpy = vi.mocked(fetch);
+
+    await expect(fetchDatasetSnapshot(1, "query", "tpl-1")).rejects.toThrow(
+      DatasetSizeCheckTimeoutError
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  // A timeout is usually transient load, unlike too_large — it must expire in
+  // minutes, not hold the area+template hostage for a full day.
+  it("retries a timeout verdict well before the too_large TTL expires", async () => {
+    findUnique.mockResolvedValue({
+      id: "check-1",
+      areaId: 1,
+      templateId: "tpl-1",
+      status: "timeout",
+      estimatedBytes: null,
+      actualBytes: null,
+      checkedAt: new Date(Date.now() - 31 * 60 * 1000),
+    });
+
+    const snapshot = await fetchDatasetSnapshot(1, "query", "tpl-1");
+    expect(snapshot.dataCount).toBe(2);
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ status: "ok" }),
+      })
+    );
+  });
+
+  it("still honours a too_large verdict at an age that expires a timeout", async () => {
+    findUnique.mockResolvedValue({
+      id: "check-1",
+      areaId: 1,
+      templateId: "tpl-1",
+      status: "too_large",
+      estimatedBytes: 20_000_000,
+      actualBytes: null,
+      checkedAt: new Date(Date.now() - 31 * 60 * 1000),
+    });
+    const fetchSpy = vi.mocked(fetch);
+
+    await expect(fetchDatasetSnapshot(1, "query", "tpl-1")).rejects.toThrow(
+      DatasetTooLargeError
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,8 +17,16 @@ export const MAX_DATASET_BYTES = 25 * 1024 * 1024;
 /** Empirical average JSON bytes per Overpass element, used to pre-estimate payload size from an element count */
 export const OVERPASS_BYTES_PER_ELEMENT_ESTIMATE = 500;
 
-/** Hours an AreaSizeCheck verdict stays fresh before re-checking against Overpass */
+/** Hours a "too_large" AreaSizeCheck verdict stays fresh before re-checking against Overpass */
 export const SIZE_CHECK_TTL_HOURS = 24;
+
+/**
+ * Minutes a "timeout" AreaSizeCheck verdict stays fresh. Much shorter than
+ * SIZE_CHECK_TTL_HOURS: a dataset that is too large stays too large, but a
+ * timeout is usually transient Overpass load, and caching it for a day
+ * blackholes the area+template long after the blip has passed.
+ */
+export const SIZE_CHECK_TIMEOUT_TTL_MINUTES = 30;
 
 /** Consecutive failed refresh attempts before a dataset is flagged for admin review */
 export const DATASET_FAILURE_FLAG_THRESHOLD = 3;

--- a/src/lib/dataset-snapshot.ts
+++ b/src/lib/dataset-snapshot.ts
@@ -16,6 +16,7 @@ import { prisma } from "@/lib/db";
 import {
   MAX_DATASET_BYTES,
   OVERPASS_BYTES_PER_ELEMENT_ESTIMATE,
+  SIZE_CHECK_TIMEOUT_TTL_MINUTES,
   SIZE_CHECK_TTL_HOURS,
 } from "@/lib/constants";
 
@@ -60,7 +61,11 @@ async function recordSizeCheck(
   });
 }
 
-/** Reject immediately if a fresh verdict already marked this area+template too large */
+/**
+ * Reject immediately if a fresh verdict already marked this area+template too
+ * large or timed out. The two kinds age differently: too_large is stable, a
+ * timeout is usually transient load.
+ */
 async function assertNoFreshNegativeVerdict(
   areaId: number,
   templateId: string
@@ -70,7 +75,10 @@ async function assertNoFreshNegativeVerdict(
   });
   if (!check) return;
 
-  const ttlMs = SIZE_CHECK_TTL_HOURS * 60 * 60 * 1000;
+  const ttlMs =
+    check.status === "timeout"
+      ? SIZE_CHECK_TIMEOUT_TTL_MINUTES * 60 * 1000
+      : SIZE_CHECK_TTL_HOURS * 60 * 60 * 1000;
   if (Date.now() - check.checkedAt.getTime() > ttlMs) return;
 
   if (check.status === "too_large") {

--- a/src/lib/overpass/__tests__/transport.test.ts
+++ b/src/lib/overpass/__tests__/transport.test.ts
@@ -105,6 +105,46 @@ describe("countOverpassElements", () => {
     expect(decodeURIComponent(body)).toBe("data=[out:json]; rel(1); out count;");
   });
 
+  // The pre-flight exists to protect the data fetch, so it must never be
+  // stricter than the fetch it guards: a 10s cap made Overpass abort counting
+  // queries that the 25s data query then served without trouble, and the
+  // resulting "timeout" verdict blocked the area+template for 24h.
+  it("does not shrink the template's own timeout", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ elements: [{ type: "count", tags: { total: "1" } }] }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await countOverpassElements(
+      "[out:json][timeout:25]; rel(1); out geom meta;"
+    );
+
+    const body = decodeURIComponent(
+      String((fetchMock.mock.calls[0][1] as RequestInit).body)
+    );
+    const timeout = Number(body.match(/\[timeout:(\d+)\]/)?.[1]);
+    expect(timeout).toBeGreaterThanOrEqual(25);
+  });
+
+  it("returns 0 for a genuinely empty result", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            elements: [{ type: "count", tags: { total: "0" } }],
+          }),
+      } as unknown as Response)
+    );
+
+    await expect(countOverpassElements("query")).resolves.toBe(0);
+  });
+
   it("throws OverpassTimeoutError on a 504 response", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/lib/overpass/transport.ts
+++ b/src/lib/overpass/transport.ts
@@ -105,9 +105,11 @@ export async function executeOverpassQuery(
 export async function countOverpassElements(query: string): Promise<number> {
   preventExternalCallsInTests();
 
-  const countQuery = query
-    .replace(/\[timeout:\d+\]/, "[timeout:10]")
-    .replace(/\bout(\s+[^;]+)?;\s*$/, "out count;");
+  // Only the output statement changes — the template's own [timeout:N] is kept.
+  // Capping the count at a lower value made Overpass abort (HTTP 200 + remark)
+  // on queries the data fetch then served fine, and that false timeout verdict
+  // blocked the area+template for SIZE_CHECK_TTL_HOURS.
+  const countQuery = query.replace(/\bout(\s+[^;]+)?;\s*$/, "out count;");
 
   let response: Response;
   try {


### PR DESCRIPTION
## 1.16.1

### Fixed

- Datasets no longer get stuck behind a false "too large" pre-flight failure: template queries now use exact tag matching on indexed keys, so size checks answer in ~1s instead of timing out, and a timed-out check is retried after 30 minutes instead of being cached for 24 hours [#446]

[#446]: https://github.com/osmforcities/osmforcities/pull/446
