### PR TITLE
chore(nav): stretch navbar to full width

### DIFF
--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -17,7 +17,7 @@ export default async function NavBar() {
 
   return (
     <nav className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 shadow-sm">
-      <div className="w-full max-w-7xl mx-auto px-2 md:px-4">
+      <div className="w-full px-3 md:px-6">
         <div className="flex h-16 items-center justify-between">
           <Link
             href="/"


### PR DESCRIPTION
## Issue #421: chore(nav): stretch navbar to full width

**Problem:** The global navbar caps its contents at `max-w-7xl mx-auto` while the redesigned dataset page is full-bleed, so on screens wider than 1280px the nav visibly stops short above a map that runs to the viewport edge.

**Acceptance Criteria:**
- [x] Nav bar background and border span the full viewport width
- [x] Content keeps sensible horizontal padding; no horizontal overflow
- [x] Consistent across home / area / dataset / explore

**Changes:**
Dropped the `max-w-7xl mx-auto` inner cap in `nav-bar.tsx`, leaving `w-full px-3 md:px-6`.

Note on criterion 1: the `<nav>` element was already `w-full border-b`, so its background and border always spanned the viewport. The actual defect was the inner container, which is what this changes.

Gutter chosen as `px-3 md:px-6` rather than keeping `px-2 md:px-4` so the brand aligns with the surfaces below it: `md:px-6` (24px) matches the dataset side-panel, explore, and area content gutters. On mobile, `px-3` (12px) plus the Home icon's own `p-3` puts the glyph at 24px — the same gutter — while keeping the touch target at 52x52.

Verified at 1920px and 375px across home, explore, area, and dataset. On the dataset page the nav brand and the panel breadcrumb both measure `left: 24`. No horizontal overflow on any route at either width; leading and trailing insets are symmetric. i18n check, type-check, lint (0 errors), and `tests/navbar.spec.ts` (4 passed) all pass.

Out of scope: uncapping the explore/area/home content grids. Chrome spans the viewport, content column stays centered.

Closes #421