### PR TITLE
fix(i18n): stop leaking AddressTypes message keys in search results

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -277,7 +277,17 @@
     "administrative": "Administrative Area",
     "postcode": "Postal Code",
     "road": "Road",
-    "house_number": "House Number"
+    "house_number": "House Number",
+    "census": "Census Area",
+    "borough": "Borough",
+    "quarter": "Quarter",
+    "locality": "Locality",
+    "island": "Island",
+    "islet": "Islet",
+    "civil_parish": "Civil Parish",
+    "isolated_dwelling": "Isolated Dwelling",
+    "subdistrict": "Subdistrict",
+    "allotments": "Allotments"
   },
   "AreaSelector": {
     "searchPlaceholder": "Please enter at least 3 characters to search",

--- a/messages/en.json
+++ b/messages/en.json
@@ -280,7 +280,6 @@
     "house_number": "House Number",
     "census": "Census Area",
     "borough": "Borough",
-    "quarter": "Quarter",
     "locality": "Locality",
     "island": "Island",
     "islet": "Islet",

--- a/messages/es.json
+++ b/messages/es.json
@@ -277,7 +277,17 @@
     "administrative": "Área Administrativa",
     "postcode": "Código Postal",
     "road": "Calle",
-    "house_number": "Número de Casa"
+    "house_number": "Número de Casa",
+    "census": "Área Censal",
+    "borough": "Distrito Municipal",
+    "quarter": "Barrio",
+    "locality": "Localidad",
+    "island": "Isla",
+    "islet": "Islote",
+    "civil_parish": "Parroquia",
+    "isolated_dwelling": "Vivienda Aislada",
+    "subdistrict": "Subdistrito",
+    "allotments": "Parcelas"
   },
   "AreaSelector": {
     "searchPlaceholder": "Por favor ingresa al menos 3 caracteres para buscar",

--- a/messages/es.json
+++ b/messages/es.json
@@ -280,14 +280,13 @@
     "house_number": "Número de Casa",
     "census": "Área Censal",
     "borough": "Distrito Municipal",
-    "quarter": "Barrio",
     "locality": "Localidad",
     "island": "Isla",
     "islet": "Islote",
     "civil_parish": "Parroquia",
     "isolated_dwelling": "Vivienda Aislada",
     "subdistrict": "Subdistrito",
-    "allotments": "Parcelas"
+    "allotments": "Huertos Urbanos"
   },
   "AreaSelector": {
     "searchPlaceholder": "Por favor ingresa al menos 3 caracteres para buscar",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -277,7 +277,17 @@
     "administrative": "Área Administrativa",
     "postcode": "Código Postal",
     "road": "Rua",
-    "house_number": "Número da Casa"
+    "house_number": "Número da Casa",
+    "census": "Área Censitária",
+    "borough": "Distrito Municipal",
+    "quarter": "Quarteirão",
+    "locality": "Localidade",
+    "island": "Ilha",
+    "islet": "Ilhota",
+    "civil_parish": "Freguesia",
+    "isolated_dwelling": "Habitação Isolada",
+    "subdistrict": "Subdistrito",
+    "allotments": "Loteamento"
   },
   "AreaSelector": {
     "searchPlaceholder": "Digite pelo menos 3 caracteres para pesquisar",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -280,14 +280,13 @@
     "house_number": "Número da Casa",
     "census": "Área Censitária",
     "borough": "Distrito Municipal",
-    "quarter": "Quarteirão",
     "locality": "Localidade",
     "island": "Ilha",
     "islet": "Ilhota",
     "civil_parish": "Freguesia",
     "isolated_dwelling": "Habitação Isolada",
     "subdistrict": "Subdistrito",
-    "allotments": "Loteamento"
+    "allotments": "Hortas Comunitárias"
   },
   "AreaSelector": {
     "searchPlaceholder": "Digite pelo menos 3 caracteres para pesquisar",

--- a/src/components/nav-search.tsx
+++ b/src/components/nav-search.tsx
@@ -15,6 +15,7 @@ import { Search, X } from "lucide-react";
 import { useNominatimAreas } from "@/hooks/useNominatimSearch";
 import { Area } from "@/types/area";
 import { getAreaCharacteristics } from "@/lib/utils";
+import type { MessageResolver } from "@/lib/tag-i18n";
 
 type SearchResultItem = Area | SpecialSearchItem;
 
@@ -54,7 +55,11 @@ const createSpecialSearchItem = (
 
 function NavSearch() {
   const t = useTranslations("NavSearch");
-  const translateAddressType = useTranslations("AddressTypes");
+  // Nominatim address types are resolved dynamically (from OSM data), which
+  // cannot be checked against next-intl's literal message-key types.
+  const translateAddressType = useTranslations(
+    "AddressTypes"
+  ) as unknown as MessageResolver;
   const locale = useLocale();
   const router = useRouter();
 

--- a/src/lib/__tests__/tag-i18n.test.ts
+++ b/src/lib/__tests__/tag-i18n.test.ts
@@ -1,7 +1,13 @@
 // src/lib/__tests__/tag-i18n.test.ts
 
 import { describe, it, expect } from "vitest";
-import { tagLabel, tagValue, toTitleCase, type MessageResolver } from "../tag-i18n";
+import {
+  tagLabel,
+  tagValue,
+  toSentenceCase,
+  toTitleCase,
+  type MessageResolver,
+} from "../tag-i18n";
 
 /**
  * Build a MessageResolver over a flat dict of dot-joined keys, e.g.
@@ -16,10 +22,17 @@ const resolver = (dict: Record<string, string>): MessageResolver => {
   return fn;
 };
 
-describe("toTitleCase", () => {
+describe("toSentenceCase", () => {
   it("prettifies snake_case keys", () => {
-    expect(toTitleCase("tactile_paving")).toBe("Tactile paving");
-    expect(toTitleCase("covered")).toBe("Covered");
+    expect(toSentenceCase("tactile_paving")).toBe("Tactile paving");
+    expect(toSentenceCase("covered")).toBe("Covered");
+  });
+});
+
+describe("toTitleCase", () => {
+  it("capitalizes every word, unlike toSentenceCase", () => {
+    expect(toTitleCase("isolated_dwelling")).toBe("Isolated Dwelling");
+    expect(toTitleCase("census")).toBe("Census");
   });
 });
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -5,6 +5,8 @@ import {
   getAreaCharacteristics,
 } from "@/lib/utils";
 import type { Bbox } from "@/types/geojson";
+import type { MessageResolver } from "@/lib/tag-i18n";
+import enMessages from "../../../messages/en.json";
 
 // GeoJSON bbox order: [minLon, minLat, maxLon, maxLat]
 const smallTownBbox: Bbox = [-9.2, 38.69, -9.1, 38.79]; // ~0.1 deg span
@@ -160,10 +162,10 @@ describe("getAreaCharacteristics", () => {
 
   // Mirrors next-intl: a missing message resolves to the NAMESPACED key
   // ("AddressTypes.census"), never the bare key.
-  const t = Object.assign(
+  const t: MessageResolver = Object.assign(
     (key: string) => messages[key] ?? `AddressTypes.${key}`,
     { has: (key: string) => key in messages }
-  ) as unknown as Parameters<typeof getAreaCharacteristics>[1];
+  );
 
   it("translates a known address type", () => {
     expect(getAreaCharacteristics({ id: 1, addresstype: "city" }, t)).toEqual([
@@ -194,5 +196,12 @@ describe("getAreaCharacteristics", () => {
       "City",
       "ID: 4",
     ]);
+  });
+
+  // The cases above assert the lookup logic against a hand-built dict, so they
+  // would still pass if a key were dropped from the shipped messages. i18n:check
+  // only enforces locale parity, so guard the values themselves here.
+  it("ships a message for census, the reported Nominatim value", () => {
+    expect(enMessages.AddressTypes).toHaveProperty("census");
   });
 });

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isSmallAreaBounds, computeInitialViewState } from "@/lib/utils";
+import {
+  isSmallAreaBounds,
+  computeInitialViewState,
+  getAreaCharacteristics,
+} from "@/lib/utils";
 import type { Bbox } from "@/types/geojson";
 
 // GeoJSON bbox order: [minLon, minLat, maxLon, maxLat]
@@ -145,5 +149,50 @@ describe("computeInitialViewState", () => {
     );
 
     expect(view).toEqual({ longitude: 0, latitude: 0, zoom: 2 });
+  });
+});
+
+describe("getAreaCharacteristics", () => {
+  const messages: Record<string, string> = {
+    city: "City",
+    census: "Census Area",
+  };
+
+  // Mirrors next-intl: a missing message resolves to the NAMESPACED key
+  // ("AddressTypes.census"), never the bare key.
+  const t = Object.assign(
+    (key: string) => messages[key] ?? `AddressTypes.${key}`,
+    { has: (key: string) => key in messages }
+  ) as unknown as Parameters<typeof getAreaCharacteristics>[1];
+
+  it("translates a known address type", () => {
+    expect(getAreaCharacteristics({ id: 1, addresstype: "city" }, t)).toEqual([
+      "City",
+      "ID: 1",
+    ]);
+  });
+
+  it("translates census, the reported Nominatim value", () => {
+    expect(getAreaCharacteristics({ id: 2, addresstype: "census" }, t)).toEqual([
+      "Census Area",
+      "ID: 2",
+    ]);
+  });
+
+  it("Title-Cases an untranslated type instead of leaking the message key", () => {
+    const result = getAreaCharacteristics(
+      { id: 3, addresstype: "isolated_dwelling" },
+      t
+    );
+
+    expect(result).toEqual(["Isolated Dwelling", "ID: 3"]);
+    expect(result[0]).not.toContain("AddressTypes.");
+  });
+
+  it("falls back to type when addresstype is absent", () => {
+    expect(getAreaCharacteristics({ id: 4, type: "city" }, t)).toEqual([
+      "City",
+      "ID: 4",
+    ]);
   });
 });

--- a/src/lib/tag-i18n.ts
+++ b/src/lib/tag-i18n.ts
@@ -1,6 +1,6 @@
 /**
- * Localization helpers for curated OSM tag keys and values shown in the
- * interactive map legend.
+ * Localization helpers for OSM-derived keys and values: curated tag keys and
+ * values in the interactive map legend, and Nominatim address types in search.
  *
  * - Tag KEYS (legend view labels) resolve from the `TagLabel` namespace.
  * - Tag VALUES (legend category rows) resolve from the `TagValue` namespace with
@@ -23,11 +23,24 @@ export type MessageResolver = {
   has(key: string): boolean;
 };
 
+const capitalize = (word: string) => word.charAt(0).toUpperCase() + word.slice(1);
+
 /** Fallback prettifier: "tactile_paving" -> "Tactile paving". */
+export function toSentenceCase(raw: string): string {
+  const spaced = raw.replace(/_/g, " ").trim();
+  if (!spaced) return raw;
+  return capitalize(spaced);
+}
+
+/**
+ * Fallback prettifier: "isolated_dwelling" -> "Isolated Dwelling". Used where the
+ * neighbouring translated strings are Title Case (the AddressTypes badges), so a
+ * sentence-cased fallback would read as a different kind of label.
+ */
 export function toTitleCase(raw: string): string {
   const spaced = raw.replace(/_/g, " ").trim();
   if (!spaced) return raw;
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+  return spaced.split(" ").map(capitalize).join(" ");
 }
 
 /**
@@ -36,7 +49,7 @@ export function toTitleCase(raw: string): string {
  * a missing-key error.
  */
 export function tagLabel(tTagLabel: MessageResolver, field: string): string {
-  return tTagLabel.has(field) ? tTagLabel(field) : toTitleCase(field);
+  return tTagLabel.has(field) ? tTagLabel(field) : toSentenceCase(field);
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,7 +4,7 @@ import { bbox } from "@turf/bbox";
 import type { FeatureCollection } from "geojson";
 import { BboxSchema, type Bbox } from "@/types/geojson";
 import type { Area } from "@/types/area";
-import type { useTranslations } from "next-intl";
+import { toTitleCase, type MessageResolver } from "./tag-i18n";
 import {
   SUPPORTED_LOCALES,
   AREA_BOUNDS_MAX_SPAN_DEG,
@@ -173,7 +173,7 @@ export function getAreaCharacteristics(
         country?: string;
         countryCode?: string;
       },
-  translateAddressType: ReturnType<typeof useTranslations<"AddressTypes">>
+  translateAddressType: MessageResolver
 ): string[] {
   if (typeof item.id === "string" && item.id === "no-results") return [];
 
@@ -184,15 +184,10 @@ export function getAreaCharacteristics(
   // Title Case rather than rendering the raw "AddressTypes.<key>" message key.
   const addressType = item.addresstype || item.type;
   if (addressType) {
-    if (translateAddressType.has(addressType as never)) {
-      characteristics.push(translateAddressType(addressType as never));
+    if (translateAddressType.has(addressType)) {
+      characteristics.push(translateAddressType(addressType));
     } else {
-      characteristics.push(
-        addressType
-          .split("_")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(" ")
-      );
+      characteristics.push(toTitleCase(addressType));
 
       if (process.env.NODE_ENV === "development") {
         console.warn(`Untranslated address type: ${addressType}`);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -179,45 +179,23 @@ export function getAreaCharacteristics(
 
   const characteristics: string[] = [];
 
-  // Add address type
+  // Add address type. Nominatim derives addresstype from the main OSM tag, so the
+  // value set is open-ended — anything we do not ship a message for falls back to
+  // Title Case rather than rendering the raw "AddressTypes.<key>" message key.
   const addressType = item.addresstype || item.type;
   if (addressType) {
-    try {
-      const translatedType = translateAddressType(addressType as never);
-
-      // If translation returns the same key, it means it's not translated
-      // Show the original value with a fallback format
-      if (translatedType === addressType) {
-        // Convert snake_case to Title Case for better display
-        const formattedType = addressType
+    if (translateAddressType.has(addressType as never)) {
+      characteristics.push(translateAddressType(addressType as never));
+    } else {
+      characteristics.push(
+        addressType
           .split("_")
           .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(" ");
+          .join(" ")
+      );
 
-        characteristics.push(formattedType);
-
-        // Log untranslated address types for debugging
-        if (process.env.NODE_ENV === "development") {
-          console.warn(`Untranslated address type: ${addressType}`);
-        }
-      } else {
-        characteristics.push(translatedType);
-      }
-    } catch (error) {
-      // Fallback to formatted original value if translation fails
-      const formattedType = addressType
-        .split("_")
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(" ");
-
-      characteristics.push(formattedType);
-
-      // Log translation errors for debugging
       if (process.env.NODE_ENV === "development") {
-        console.warn(
-          `Translation error for address type "${addressType}":`,
-          error
-        );
+        console.warn(`Untranslated address type: ${addressType}`);
       }
     }
   }


### PR DESCRIPTION
## No originating issue (reported in conversation)

**Problem:** The nav-search result badge rendered the literal string `AddressTypes.census` instead of a label.

Root cause is not a missing translation key. `getAreaCharacteristics` detected an untranslated address type by comparing the translated string to the bare key:

```ts
const translatedType = translateAddressType(addressType as never);
if (translatedType === addressType) {   // never true
```

next-intl returns the **namespaced** key for a missing message (`"AddressTypes.census"`), and `src/i18n/request.ts` sets no `getMessageFallback`. So the comparison never held: the Title Case fallback and the dev warning were unreachable, and the `catch` was dead too (next-intl logs `MISSING_MESSAGE` rather than throwing).

The key set also cannot be closed. Nominatim derives `addresstype` from the main OSM tag, so the value space is open-ended. Reproduced live: `Alamo, Contra Costa County, California` returns an `osm_type: relation` (passing the filter at `src/lib/nominatim.ts:59`) with `addresstype: census`, from `boundary=census`.

**Acceptance Criteria:**
- [x] Unknown address types never render a raw `AddressTypes.*` message key
- [x] The reported `census` value renders a real label in all three locales
- [x] Locale key parity holds (`i18n:check`)
- [x] A regression test fails against the pre-fix code

**Changes:**
Replaced the broken check with next-intl v4's `t.has()`, so any unshipped address type degrades to Title Case. Reused the existing `MessageResolver` type and helpers from `src/lib/tag-i18n.ts`, which already solve this exact problem for map-legend tag keys; this dropped the `as never` casts (the `useTranslations` cast moves to `nav-search.tsx`, matching `full-map.tsx`). `tag-i18n` exported `toTitleCase` but produced sentence case, so it is split into `toSentenceCase` (legend, unchanged behaviour) and `toTitleCase` (address badges, whose neighbouring strings are Title Case).

Added 9 high-frequency address types to en/es/pt-BR: `census`, `borough`, `locality`, `island`, `islet`, `civil_parish`, `isolated_dwelling`, `subdistrict`, `allotments`. `quarter` was deliberately left out: pt-BR "Quarteirão" means city block and collides with `city_block` ("Quadra"), and es "Barrio" duplicates `neighbourhood`, so the Title Case fallback is more honest than either translation.

Verified in the browser (en + pt-BR): `Alamo` renders "Census Area" / "Área Censitária"; `Yellowstone National Park` (`nature_reserve`, deliberately unshipped) renders "Nature Reserve" with the dev warning now firing.

Note: `is-featured`, `feature/route`, and `geojson/route` suites fail locally on an unseeded dataset table. Confirmed identical failures on unmodified `develop`.