### PR TITLE
perf: cache area boundaries and slim down geojson export

### DIFF
--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -41,8 +41,6 @@ export async function GET(
       "_"
     );
 
-    // Compact: indentation costs ~1.6x bytes and stringify/gzip CPU for a file
-    // that goes straight to disk.
     return new NextResponse(JSON.stringify(dataset.geojson), {
       status: 200,
       headers: {

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -41,15 +41,15 @@ export async function GET(
       "_"
     );
 
-    // Compact, not pretty-printed: indentation costs ~1.6x the bytes and the
-    // matching stringify/gzip CPU on a single-process box, for a file that goes
-    // straight to disk. Measured on the Paris fixtures: 6.5MB -> 4.0MB.
+    // Compact: indentation costs ~1.6x bytes and stringify/gzip CPU for a file
+    // that goes straight to disk.
     return new NextResponse(JSON.stringify(dataset.geojson), {
       status: 200,
       headers: {
         "Content-Type": "application/geo+json",
         "Content-Disposition": `attachment; filename="${safeName}"`,
-        "Cache-Control": "public, max-age=300, s-maxage=300, stale-while-revalidate=3600",
+        // No Cache-Control on purpose: a cached response never reaches the
+        // origin, so the DATASET_DOWNLOAD event above would go unrecorded.
       },
     });
   } catch (error) {

--- a/src/app/api/datasets/[id]/export/route.ts
+++ b/src/app/api/datasets/[id]/export/route.ts
@@ -41,11 +41,15 @@ export async function GET(
       "_"
     );
 
-    return new NextResponse(JSON.stringify(dataset.geojson, null, 2), {
+    // Compact, not pretty-printed: indentation costs ~1.6x the bytes and the
+    // matching stringify/gzip CPU on a single-process box, for a file that goes
+    // straight to disk. Measured on the Paris fixtures: 6.5MB -> 4.0MB.
+    return new NextResponse(JSON.stringify(dataset.geojson), {
       status: 200,
       headers: {
         "Content-Type": "application/geo+json",
         "Content-Disposition": `attachment; filename="${safeName}"`,
+        "Cache-Control": "public, max-age=300, s-maxage=300, stale-while-revalidate=3600",
       },
     });
   } catch (error) {

--- a/src/lib/__tests__/area-boundary.test.ts
+++ b/src/lib/__tests__/area-boundary.test.ts
@@ -17,7 +17,15 @@ vi.mock("@/lib/overpass/transport", () => ({
   }),
 }));
 
-import { fetchOsmRelationData } from "@/lib/area-boundary";
+// unstable_cache is identity here so the tests exercise the real read path;
+// revalidateTag is a no-op (it throws without a request store outside Next).
+vi.mock("next/cache", () => ({
+  unstable_cache: <T>(fn: T) => fn,
+  revalidateTag: vi.fn(),
+}));
+
+import { fetchOsmRelationData, getAreaBoundary } from "@/lib/area-boundary";
+import { prisma } from "@/lib/db";
 import {
   executeOverpassQuery,
   convertOverpassToGeoJSON,
@@ -25,6 +33,56 @@ import {
 
 const mockExecuteOverpassQuery = vi.mocked(executeOverpassQuery);
 const mockConvert = vi.mocked(convertOverpassToGeoJSON);
+const mockFindUnique = vi.mocked(prisma.area.findUnique);
+const mockUpdate = vi.mocked(prisma.area.update);
+
+/** A real boundary: >5 points in the outer ring. */
+const storedPolygon = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [13.0, -8.9],
+            [13.1, -8.9],
+            [13.2, -8.85],
+            [13.2, -8.8],
+            [13.1, -8.75],
+            [13.0, -8.8],
+            [13.0, -8.9],
+          ],
+        ],
+      },
+    },
+  ],
+};
+
+/** A bbox rectangle: exactly 5 points, treated as "no real boundary stored". */
+const storedBbox = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [13.0, -8.9],
+            [13.2, -8.9],
+            [13.2, -8.7],
+            [13.0, -8.7],
+            [13.0, -8.9],
+          ],
+        ],
+      },
+    },
+  ],
+};
 
 const luandaRelation = {
   type: "relation",
@@ -109,5 +167,84 @@ describe("fetchOsmRelationData", () => {
     } as never);
 
     expect(await fetchOsmRelationData(1802546)).toBeNull();
+  });
+});
+
+describe("getAreaBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConvert.mockReturnValue({ type: "FeatureCollection", features: [] });
+  });
+
+  it("returns the stored boundary without querying Overpass", async () => {
+    mockFindUnique.mockResolvedValueOnce({ geojson: storedPolygon } as never);
+
+    const result = await getAreaBoundary(1802546);
+
+    expect(result?.features).toHaveLength(1);
+    expect(mockExecuteOverpassQuery).not.toHaveBeenCalled();
+  });
+
+  it("simplifies the stored boundary rather than returning it verbatim", async () => {
+    mockFindUnique.mockResolvedValueOnce({ geojson: storedPolygon } as never);
+
+    const result = await getAreaBoundary(1802546);
+
+    const ring = (result?.features[0].geometry as { coordinates: number[][][] })
+      .coordinates[0];
+    const storedRing = storedPolygon.features[0].geometry.coordinates[0];
+    expect(ring.length).toBeLessThanOrEqual(storedRing.length);
+    // Still a closed ring after simplification.
+    expect(ring[0]).toEqual(ring[ring.length - 1]);
+  });
+
+  it("falls back to Overpass when only a bbox rectangle is stored", async () => {
+    mockFindUnique.mockResolvedValueOnce({ geojson: storedBbox } as never);
+    mockExecuteOverpassQuery.mockResolvedValueOnce({ elements: [] } as never);
+    mockConvert.mockReturnValueOnce({
+      type: "FeatureCollection",
+      features: [
+        {
+          id: "relation/1802546",
+          type: "Feature",
+          properties: {},
+          geometry: storedPolygon.features[0].geometry,
+        },
+      ],
+    } as never);
+
+    const result = await getAreaBoundary(1802546);
+
+    expect(mockExecuteOverpassQuery).toHaveBeenCalledOnce();
+    // The freshly fetched boundary is written back for the next caller.
+    expect(mockUpdate).toHaveBeenCalledOnce();
+    expect(result?.features).toHaveLength(1);
+  });
+
+  it("falls back to Overpass when nothing is stored", async () => {
+    mockFindUnique.mockResolvedValueOnce({ geojson: null } as never);
+    mockExecuteOverpassQuery.mockResolvedValueOnce({ elements: [] } as never);
+    mockConvert.mockReturnValueOnce({
+      type: "FeatureCollection",
+      features: [
+        {
+          id: "relation/1802546",
+          type: "Feature",
+          properties: {},
+          geometry: storedPolygon.features[0].geometry,
+        },
+      ],
+    } as never);
+
+    expect(await getAreaBoundary(1802546)).not.toBeNull();
+    expect(mockExecuteOverpassQuery).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when nothing is stored and Overpass fails", async () => {
+    mockFindUnique.mockResolvedValueOnce({ geojson: null } as never);
+    mockExecuteOverpassQuery.mockRejectedValueOnce(new Error("timeout"));
+
+    expect(await getAreaBoundary(1802546)).toBeNull();
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/area-boundary.ts
+++ b/src/lib/area-boundary.ts
@@ -28,13 +28,18 @@ function isRealPolygon(fc: FeatureCollection): boolean {
   return false;
 }
 
-export const AREA_BOUNDARY_TAG = "area-boundaries";
+const AREA_BOUNDARY_TAG = "area-boundaries";
 
 /**
  * Stored boundary, simplified. Null when nothing usable is stored yet.
  *
  * Only the read path is cached: the Overpass fallback below writes back to the
  * DB, and caching that too would pin a `null` and keep re-querying Overpass.
+ *
+ * TTL is deliberately short. A `null` gets cached like any other result, and the
+ * bust after the fallback write cannot run from a Server Component render — the
+ * dataset page is exactly that. So for a cold area the TTL, not the bust, is
+ * what bounds how long every visitor keeps re-hitting Overpass.
  */
 const getStoredBoundary = unstable_cache(
   async (areaId: number): Promise<FeatureCollection | null> => {
@@ -51,7 +56,7 @@ const getStoredBoundary = unstable_cache(
     return simplify(stored, { tolerance: BOUNDARY_SIMPLIFICATION_TOLERANCE, highQuality: false });
   },
   ["area-boundary-stored"],
-  { revalidate: 86400, tags: [AREA_BOUNDARY_TAG] }
+  { revalidate: 300, tags: [AREA_BOUNDARY_TAG] }
 );
 
 /**
@@ -94,9 +99,10 @@ export async function getAreaBoundary(areaId: number): Promise<FeatureCollection
     data: { geojson: JSON.parse(JSON.stringify(featureCollection)) },
   });
 
-  // getStoredBoundary has this cached as absent. Busts all areas, not just this
-  // one — unstable_cache tags are static per function. Throws without a request
-  // store (render, vitest); best-effort, worst case is one more Overpass query.
+  // getStoredBoundary has this cached as absent. Only lands from a Route Handler
+  // (/api/areas/[id]/boundary); from a page render it always throws and the
+  // short TTL above is what clears the stale null instead. Busts every area, not
+  // just this one — unstable_cache tags are static per function.
   try {
     revalidateTag(AREA_BOUNDARY_TAG);
   } catch {}

--- a/src/lib/area-boundary.ts
+++ b/src/lib/area-boundary.ts
@@ -31,17 +31,10 @@ function isRealPolygon(fc: FeatureCollection): boolean {
 export const AREA_BOUNDARY_TAG = "area-boundaries";
 
 /**
- * Stored boundary for an area, simplified for display. Null when nothing usable
- * is stored yet (no geojson, or only a bbox rectangle).
+ * Stored boundary, simplified. Null when nothing usable is stored yet.
  *
- * Cached because both the dataset page and /api/areas/[id]/boundary call this on
- * every request, and each call otherwise re-reads a multi-MB polygon out of
- * Postgres and re-runs Douglas-Peucker over it. Boundaries effectively never
- * change, so this revalidates daily; bust AREA_BOUNDARY_TAG to refresh sooner.
- *
- * Only the read path is cached. The Overpass fallback below writes back to the
- * DB, and caching that too would pin a `null` result in place and keep sending
- * every subsequent request to Overpass.
+ * Only the read path is cached: the Overpass fallback below writes back to the
+ * DB, and caching that too would pin a `null` and keep re-querying Overpass.
  */
 const getStoredBoundary = unstable_cache(
   async (areaId: number): Promise<FeatureCollection | null> => {
@@ -101,10 +94,9 @@ export async function getAreaBoundary(areaId: number): Promise<FeatureCollection
     data: { geojson: JSON.parse(JSON.stringify(featureCollection)) },
   });
 
-  // We just stored a boundary that getStoredBoundary has cached as absent. Drop
-  // the tag so the next caller reads it from the DB instead of hitting Overpass
-  // again. Throws when there is no request store (during render, and in vitest);
-  // best-effort is fine, the only cost is re-querying Overpass.
+  // getStoredBoundary has this cached as absent. Busts all areas, not just this
+  // one — unstable_cache tags are static per function. Throws without a request
+  // store (render, vitest); best-effort, worst case is one more Overpass query.
   try {
     revalidateTag(AREA_BOUNDARY_TAG);
   } catch {}

--- a/src/lib/area-boundary.ts
+++ b/src/lib/area-boundary.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { unstable_cache, revalidateTag } from "next/cache";
 import simplify from "@turf/simplify";
 import {
   executeOverpassQuery,
@@ -27,6 +28,39 @@ function isRealPolygon(fc: FeatureCollection): boolean {
   return false;
 }
 
+export const AREA_BOUNDARY_TAG = "area-boundaries";
+
+/**
+ * Stored boundary for an area, simplified for display. Null when nothing usable
+ * is stored yet (no geojson, or only a bbox rectangle).
+ *
+ * Cached because both the dataset page and /api/areas/[id]/boundary call this on
+ * every request, and each call otherwise re-reads a multi-MB polygon out of
+ * Postgres and re-runs Douglas-Peucker over it. Boundaries effectively never
+ * change, so this revalidates daily; bust AREA_BOUNDARY_TAG to refresh sooner.
+ *
+ * Only the read path is cached. The Overpass fallback below writes back to the
+ * DB, and caching that too would pin a `null` result in place and keep sending
+ * every subsequent request to Overpass.
+ */
+const getStoredBoundary = unstable_cache(
+  async (areaId: number): Promise<FeatureCollection | null> => {
+    const area = await prisma.area.findUnique({
+      where: { id: areaId },
+      select: { geojson: true },
+    });
+
+    if (!area?.geojson) return null;
+
+    const stored = area.geojson as unknown as FeatureCollection;
+    if (!isRealPolygon(stored)) return null;
+
+    return simplify(stored, { tolerance: BOUNDARY_SIMPLIFICATION_TOLERANCE, highQuality: false });
+  },
+  ["area-boundary-stored"],
+  { revalidate: 86400, tags: [AREA_BOUNDARY_TAG] }
+);
+
 /**
  * Fetch area boundary for visualization.
  * Checks DB cache first, then fetches from Overpass if needed.
@@ -36,17 +70,8 @@ function isRealPolygon(fc: FeatureCollection): boolean {
  * @returns Simplified boundary GeoJSON, or null if not found
  */
 export async function getAreaBoundary(areaId: number): Promise<FeatureCollection | null> {
-  const area = await prisma.area.findUnique({
-    where: { id: areaId },
-    select: { geojson: true },
-  });
-
-  if (area?.geojson) {
-    const cached = area.geojson as unknown as FeatureCollection;
-    if (isRealPolygon(cached)) {
-      return simplify(cached, { tolerance: BOUNDARY_SIMPLIFICATION_TOLERANCE, highQuality: false });
-    }
-  }
+  const stored = await getStoredBoundary(areaId);
+  if (stored) return stored;
 
   const queryString = `[out:json][timeout:60];rel(${areaId});out geom;`;
   let overpassData;
@@ -75,6 +100,14 @@ export async function getAreaBoundary(areaId: number): Promise<FeatureCollection
     where: { id: areaId },
     data: { geojson: JSON.parse(JSON.stringify(featureCollection)) },
   });
+
+  // We just stored a boundary that getStoredBoundary has cached as absent. Drop
+  // the tag so the next caller reads it from the DB instead of hitting Overpass
+  // again. Throws when there is no request store (during render, and in vitest);
+  // best-effort is fine, the only cost is re-querying Overpass.
+  try {
+    revalidateTag(AREA_BOUNDARY_TAG);
+  } catch {}
 
   return simplify(featureCollection, { tolerance: BOUNDARY_SIMPLIFICATION_TOLERANCE, highQuality: false });
 }


### PR DESCRIPTION
## Origin-load hardening ahead of SotM Paris

**Related:** #354 (context only — see below)

**Problem:** With ~100 people hitting the site during the SotM Paris talk, the
origin is the constraint. Measured on production:

- `/api/datasets/[id]/geojson` and `/api/areas/[id]/boundary` send `s-maxage`
  but had no server-side cache, and Cloudflare was not caching them
  (`cf-cache-status: DYNAMIC`) — every visitor's hero triggered a full
  multi-MB Prisma read + transform + gzip.
- `getAreaBoundary` re-read a multi-MB polygon and re-ran Douglas-Peucker on
  every call. The dataset page calls it *after* `getOrCreateDataset` already
  fetched the same `area.geojson` — two reads of one blob per view.
- `/api/datasets/[id]/export` pretty-printed its response (~1.6x bytes and
  matching stringify/gzip CPU) and sent no `Cache-Control` at all.

This ran against 1 Node worker on 3 vCPUs with a 1024M PM2 restart ceiling.

Note on #354: that issue proposed making the homepage static/ISR. Measurement
showed the homepage HTML already does zero DB queries in steady state (featured
query is `unstable_cache`d, `auth()` short-circuits for anonymous visitors) and
serves in ~135ms. The cost is downstream of it, so this PR targets that instead.

**Acceptance Criteria:**
- [x] Area boundary read is cached rather than recomputed per request
- [x] Overpass fallback still works and is not poisoned by a cached `null`
- [x] Export response is materially smaller (caching deliberately skipped to preserve download analytics)
- [x] `getAreaBoundary` has test coverage (it had none)

**Changes:**

`src/lib/area-boundary.ts` — extract the stored-boundary read into
`unstable_cache` (5 min TTL, tag `area-boundaries` — short on purpose so a
cached `null` for a cold area self-heals when the tag bust can't run from a
page render). Only the read path is cached: the Overpass fallback writes back
to the DB, so caching it would pin a `null` and keep sending every subsequent
request to Overpass. After writing it busts the tag when called from the API
route; from the dataset page render the bust can't run (throws, swallowed) and
the 5-min TTL clears the stale null instead.

`src/app/api/datasets/[id]/export/route.ts` — compact `JSON.stringify`;
`Cache-Control` deliberately NOT added — a cached response would skip the
origin and drop the awaited DATASET_DOWNLOAD analytics event. Measured on the
repo's own Paris fixtures: 6.5MB -> 4.0MB (bicycle parking), 2.35MB -> 1.50MB
(bus stops). The awaited Umami call is deliberately left alone.

`src/lib/__tests__/area-boundary.test.ts` — 5 tests for `getAreaBoundary`
(stored polygon, simplification, bbox-rectangle fallback, empty fallback,
Overpass failure). Existing tests only covered `fetchOsmRelationData`.

Complementary Cloudflare Cache Rule for the two API paths is already applied
and verified (`DYNAMIC` -> `MISS` -> `HIT`); infra playbooks land separately.

`pnpm type-check`, `pnpm i18n:check`, eslint clean. 257 unit tests pass.
