### PR TITLE
feat(i18n): add French locale (fr)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,11 +7,13 @@ import React from 'react';
 import enMessages from '../messages/en.json';
 import esMessages from '../messages/es.json';
 import ptBRMessages from '../messages/pt-BR.json';
+import frMessages from '../messages/fr.json';
 
 const messages: Record<string, Record<string, unknown>> = {
   en: enMessages,
   es: esMessages,
   'pt-BR': ptBRMessages,
+  fr: frMessages,
 };
 
 const preview: Preview = {
@@ -48,6 +50,7 @@ const preview: Preview = {
           { value: 'en', title: 'English' },
           { value: 'es', title: 'Español' },
           { value: 'pt-BR', title: 'Português (BR)' },
+          { value: 'fr', title: 'Français' },
         ],
         dynamicTitle: true,
       },

--- a/docs/features/translation-system.md
+++ b/docs/features/translation-system.md
@@ -9,6 +9,7 @@ This project uses [next-intl](https://next-intl.com/) for internationalization (
 - **English (en)** - Default language
 - **Spanish (es)** - Español
 - **Portuguese (pt-BR)** - Português Brasileiro
+- **French (fr)** - Français
 
 ## File Structure
 
@@ -17,6 +18,7 @@ messages/
 ├── en.json          # English translations (source)
 ├── es.json          # Spanish translations
 ├── pt-BR.json       # Portuguese (Brazil) translations
+├── fr.json          # French translations
 └── en.d.json.ts     # TypeScript definitions
 ```
 
@@ -47,7 +49,7 @@ head -10 messages/en.json
 ## Two Translation Systems
 
 ### UI Translations (next-intl)
-- Files: `messages/en.json`, `messages/pt-BR.json`, `messages/es.json`
+- Files: `messages/en.json`, `messages/pt-BR.json`, `messages/es.json`, `messages/fr.json`
 - Content: Interface text, labels, buttons, navigation
 - Usage: `getTranslations()`, `useTranslations()`
 
@@ -57,7 +59,7 @@ head -10 messages/en.json
 - Code: `src/lib/template-locale.ts` → `resolveTemplateForLocale()`
 - Content: Dataset template names and descriptions
 
-Both use the URL locale (`/en/...`, `/pt-BR/...`, `/es/...`).
+Both use the URL locale (`/en/...`, `/pt-BR/...`, `/es/...`, `/fr/...`).
 
 ## Using Template Translations
 

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -51,7 +51,7 @@
     "noSavedDatasetsTitle": "Aucun jeu de données enregistré pour l'instant",
     "noSavedDatasetsDescription": "Recherchez ci-dessus pour commencer.",
     "savedDatasetsGridLabel": "Jeux de données enregistrés",
-    "saveCount": "{count, plural, =1 {# enregistrement} other {# enregistrements}}",
+    "saveCount": "{count, plural, one {# enregistrement} other {# enregistrements}}",
     "saveCountAriaLabel": "{used, number} jeux de données enregistrés sur {limit, number}",
     "savedLabel": "{used, number}/{limit, number} enregistrés",
     "limitReachedSuffix": "— limite atteinte",
@@ -382,7 +382,7 @@
     "flaggedHeading": "Jeux de données signalés",
     "flaggedCount": "({count, number})",
     "flaggedEmpty": "Aucun jeu de données n'est actuellement en échec.",
-    "failureCount": "{count, plural, =1 {# échec consécutif} other {# échecs consécutifs}}",
+    "failureCount": "{count, plural, one {# échec consécutif} other {# échecs consécutifs}}",
     "lastError": "Dernière erreur : {message}",
     "lastAttempted": "Dernière tentative : {value}",
     "lastChecked": "Dernière vérification : {value}"
@@ -596,7 +596,7 @@
     "datasetsOne": "jeu de données",
     "datasetsOther": "jeux de données",
     "templateDeprecated": "Ce modèle a été retiré du catalogue.",
-    "templateDeprecatedDaysRemaining": "Il vous reste {days} jour{days, plural, =1 {} other {s}} avant la suppression de ce jeu de données.",
+    "templateDeprecatedDaysRemaining": "Il vous reste {days} jour{days, plural, one {} other {s}} avant la suppression de ce jeu de données.",
     "greeting": "Bonjour !"
   },
   "AboutPage": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,0 +1,1084 @@
+{
+  "Index": {
+    "title": "Bienvenue sur OSM for Cities",
+    "description": "Suivez et surveillez les données OpenStreetMap de votre ville",
+    "learnMore": "En savoir plus",
+    "enter": "Entrer"
+  },
+  "Navigation": {
+    "home": "Accueil",
+    "dashboard": "Tableau de bord",
+    "about": "À propos",
+    "myDatasets": "Mes jeux de données",
+    "public": "Publics",
+    "saved": "Enregistrés",
+    "templates": "Modèles",
+    "users": "Utilisateurs",
+    "preferences": "Préférences",
+    "brandName": "OSM for Cities",
+    "explore": "Explorer",
+    "signIn": "Se connecter",
+    "signOut": "Se déconnecter",
+    "mainMenu": "Menu de navigation principal",
+    "menu": "Menu",
+    "close": "Fermer",
+    "breadcrumbLabel": "Fil d'Ariane"
+  },
+  "Common": {
+    "shareFeedback": "Donner votre avis",
+    "viewOnGitHub": "Voir sur GitHub"
+  },
+  "TabLayout": {
+    "welcomeBack": "Bon retour, {name}",
+    "welcomeBackGeneric": "Bon retour",
+    "manageDatasetsSubtitle": "Gérez vos jeux de données et explorez la plateforme",
+    "saved": "Enregistrés",
+    "savedAriaLabel": "Enregistrés - Voir les jeux de données que vous avez enregistrés",
+    "explore": "Explorer",
+    "templates": "Modèles",
+    "users": "Utilisateurs",
+    "usersAriaLabel": "Utilisateurs - Accéder à la page de gestion des utilisateurs",
+    "templatesAriaLabel": "Modèles - Accéder à la page de gestion des modèles",
+    "datasetsTab": "Jeux de données",
+    "datasetsTabAriaLabel": "Jeux de données - Accéder à la page d'état des mises à jour des jeux de données",
+    "myDatasetsEmptyMessage": "Vous n'avez pas encore créé de jeu de données.",
+    "myDatasetsEmptyAction": "Créer un jeu de données",
+    "openParen": "(",
+    "closeParen": ")",
+    "datasets": "Jeux de données :",
+    "viewAllTemplates": "Voir tous les modèles",
+    "viewAllUsers": "Voir tous les utilisateurs",
+    "noSavedDatasetsTitle": "Aucun jeu de données enregistré pour l'instant",
+    "noSavedDatasetsDescription": "Recherchez ci-dessus pour commencer.",
+    "savedDatasetsGridLabel": "Jeux de données enregistrés",
+    "saveCount": "{count, plural, =1 {# enregistrement} other {# enregistrements}}",
+    "saveCountAriaLabel": "{used, number} jeux de données enregistrés sur {limit, number}",
+    "savedLabel": "{used, number}/{limit, number} enregistrés",
+    "limitReachedSuffix": "— limite atteinte",
+    "quotaInfoTooltip": "Chaque utilisateur peut enregistrer jusqu'à {limit, number} jeux de données. Retirez-en un depuis votre tableau de bord pour libérer une place.",
+    "quotaInfoButtonLabel": "Que signifie la limite d'enregistrement ?",
+    "active": "Actif",
+    "inactive": "Inactif"
+  },
+  "Public": {
+    "metaTitle": "Jeux de données publics - OSM for Cities",
+    "metaDescription": "Tous les jeux de données publics de la plateforme",
+    "title": "Jeux de données publics",
+    "emptyMessage": "Aucun jeu de données public trouvé.",
+    "emptyActionText": "Créer le premier jeu de données public"
+  },
+  "DatasetList": {
+    "active": "Actif",
+    "inactive": "Inactif",
+    "public": "Public",
+    "private": "Privé",
+    "dataCount": "Nombre de données : {count, number}",
+    "saves": "Enregistrements",
+    "view": "Voir",
+    "deactivate": "Désactiver",
+    "activate": "Activer",
+    "makePrivate": "Rendre privé",
+    "makePublic": "Rendre public",
+    "delete": "Supprimer",
+    "deleting": "Suppression...",
+    "by": "par",
+    "cannotDeleteTooltip": "Impossible de supprimer un jeu de données avec {count, plural, =0 {aucun enregistrement} one {# enregistrement} other {# enregistrements}}. Rendez-le d'abord privé ou demandez aux personnes concernées de le retirer de leurs enregistrements.",
+    "in": "dans",
+    "colon": ":",
+    "openParen": "(",
+    "closeParen": ")",
+    "backToHome": "Retour à l'accueil",
+    "datasetStats": "Statistiques du jeu de données",
+    "category": "Catégorie",
+    "totalFeatures": "Total des éléments",
+    "totalEditors": "Total des contributeurs",
+    "changesets": "Groupes de modifications",
+    "avgAgeDays": "Âge moyen (jours)",
+    "recentActivity": "Activité récente (3 derniers mois)",
+    "elementsEdited": "Éléments modifiés",
+    "percentOfTotal": "% du total",
+    "activeEditors": "Contributeurs actifs",
+    "recentChangesets": "Groupes de modifications récents",
+    "overallAssessment": "Évaluation globale",
+    "activityLevel": "Niveau d'activité",
+    "communityStrength": "Force de la communauté",
+    "communityActivity": "Activité de la communauté",
+    "lastChecked": "Dernière vérification :"
+  },
+  "Watched": {
+    "metaTitle": "Enregistrés - OSM for Cities",
+    "metaDescription": "Jeux de données que vous avez enregistrés",
+    "title": "Enregistrés",
+    "emptyMessage": "Vous n'avez pas encore enregistré de jeu de données.",
+    "emptyActionText": "Parcourir les jeux de données publics"
+  },
+  "EnterPage": {
+    "metaTitle": "Connexion - OSM for Cities",
+    "metaDescription": "Connectez-vous pour suivre les jeux de données OpenStreetMap",
+    "signIn": "Se connecter",
+    "enterEmailToStart": "Saisissez votre e-mail pour commencer",
+    "notFound": "Introuvable",
+    "testAuthNotEnabled": "L'authentification de test n'est pas activée.",
+    "signInWithEmailPassword": "Connectez-vous avec votre e-mail et votre mot de passe",
+    "createAccount": "Créer un compte",
+    "signupForTesting": "Inscription à des fins de test",
+    "testEnvOnly": "Cette page n'est disponible qu'en environnement de test."
+  },
+  "DatasetPage": {
+    "backToHome": "Retour à l'accueil",
+    "emptyTitle": "Aucun élément « {dataset} » trouvé dans {area}",
+    "emptyDescription": "Ce jeu de données ne contient encore aucun élément dans cette zone. Il n'existe peut-être pas ici, ou les données n'ont pas été cartographiées dans OpenStreetMap.",
+    "tooLargeTitle": "{dataset} dans {area} est trop volumineux pour être affiché",
+    "tooLargeDescription": "Ce jeu de données est trop volumineux pour être affiché sur une carte. Essayez un modèle plus spécifique, ou <link>travaillez avec les données brutes dans Overpass Turbo</link>.",
+    "backToArea": "← Retour à {area}",
+    "backToAreaLabel": "Retour à {area}",
+    "categoryFacetLabel": "Catégorie : {category}. Voir tous les jeux de données {category} dans {area}.",
+    "categoryUncategorized": "Autre",
+    "back": "Retour",
+    "features": "Éléments",
+    "geomPoints": "Points",
+    "geomLines": "Lignes",
+    "geomAreas": "Surfaces",
+    "geomPointsLower": "points",
+    "geomLinesLower": "lignes",
+    "geomAreasLower": "surfaces",
+    "geomNone": "sans {type}",
+    "detailTotal": "Total",
+    "detailTitleGeometry": "Éléments par type",
+    "detailTitleFreshness": "Éléments par dernière modification",
+    "detailTitleMappers": "Cartographes par dernière modification",
+    "titleMappers": "Cartographes",
+    "titleFeatures": "Éléments",
+    "titleTags": "Attributs",
+    "statsRegion": "Statistiques du jeu de données",
+    "geometryMix": "Répartition des géométries",
+    "mostUsedTags": "Attributs les plus utilisés",
+    "tagCoverage": "Couverture critique",
+    "recentlyEdited": "Modifiés récemment",
+    "activeRecently": "Actifs récemment",
+    "band90d": "≤ 90 j",
+    "band90dTo1y": "90 j–1 an",
+    "band1yTo2y": "1–2 ans",
+    "band2yPlus": "2 ans et +",
+    "bandWithin1y": "Moins d'1 an",
+    "share": "Partager",
+    "shareCopied": "Lien copié",
+    "linkCopied": "Lien copié dans le presse-papiers",
+    "linkCopyFailed": "Impossible de copier le lien",
+    "datasetSynced": "Jeu de données synchronisé",
+    "shareTooltip": "Copier le lien vers ce jeu de données",
+    "admin": "Admin",
+    "lastEdited": "Modifié",
+    "lastCheckedLabel": "Récupéré",
+    "timestampDescription": "{label} {relative}",
+    "fetchCadence": "Les jeux de données sont synchronisés une fois par jour dans OSM for Cities ; ceci est le délai actuel par rapport à OpenStreetMap.",
+    "downloadData": "Télécharger les données",
+    "download": "Télécharger",
+    "datasetTitle": "{template}",
+    "invalidData": "Données invalides",
+    "invalidDataMessage": "Le jeu de données contient des données GeoJSON invalides.",
+    "value": "Valeur",
+    "refreshData": "Synchroniser",
+    "refreshing": "Synchronisation...",
+    "refreshTitle": "Synchroniser avec les dernières données OpenStreetMap",
+    "refreshInactiveTitle": "Seuls les jeux de données actifs peuvent être synchronisés",
+    "save": "Enregistrer",
+    "signInToSave": "Connectez-vous pour enregistrer",
+    "unsave": "Retirer",
+    "saveTooltip": "Enregistrer pour y revenir plus tard",
+    "unsaveTooltip": "Retirer des enregistrés",
+    "saveLimitReached": "Limite d'enregistrement atteinte",
+    "saveLimitMessage": "Vous pouvez enregistrer jusqu'à {limit, number} jeux de données. Retirez-en d'abord un depuis votre tableau de bord. <link>Aller au tableau de bord</link>.",
+    "featured": "En vedette",
+    "featuredTooltip": "Ceci est un jeu de données en vedette",
+    "feature": "Mettre en vedette",
+    "unfeature": "Retirer de la vedette",
+    "featureTitle": "Mettre ce jeu de données en vedette sur la page d'accueil",
+    "unfeatureTitle": "Retirer des jeux de données en vedette",
+    "featureError": "Impossible de mettre à jour le statut en vedette. Réessayez."
+  },
+  "AuthForm": {
+    "checkYourEmail": "Consultez votre boîte mail",
+    "sentLinkTo": "Nous avons envoyé un lien à {email}",
+    "tryDifferentEmail": "Essayer une autre adresse",
+    "emailPlaceholder": "E-mail",
+    "sending": "Envoi...",
+    "continue": "Continuer",
+    "emailIcon": "📧"
+  },
+  "AreaPage": {
+    "backToHome": "← Retour à l'accueil",
+    "osmId": "ID OSM",
+    "adminLevel": "Niveau administratif",
+    "population": "Population",
+    "country": "Pays",
+    "findData": "Trouver des données",
+    "filterByCategory": "Filtrer par catégorie",
+    "status": "Statut",
+    "statusAll": "Tous",
+    "statusFeatured": "En vedette",
+    "statusSaved": "Enregistrés",
+    "statFeatures": "{count} éléments",
+    "statContributors": "{count} contributeurs",
+    "statSaved": "{count} enregistrements",
+    "lastEditedAria": "Dernière modification",
+    "featuredBadge": "En vedette",
+    "allDatasets": "Tous les types de données",
+    "searchPlaceholder": "Rechercher des types de données...",
+    "noResults": "Aucun type de données trouvé",
+    "noResultsDescription": "Essayez un autre terme de recherche ou une autre catégorie.",
+    "noDatasetsAvailable": "Aucun jeu de données disponible",
+    "noDatasetsDescription": "Il n'y a actuellement aucun jeu de données disponible pour cette zone. Revenez plus tard ou contactez-nous si vous avez besoin de types de données spécifiques.",
+    "moreTags": "+{count} de plus",
+    "dataset": "jeu de données",
+    "datasets": "jeux de données",
+    "idLabel": "ID : ",
+    "comingSoon": "La découverte de jeux de données arrive bientôt !",
+    "comingSoonDescription": "Vous pourrez explorer et créer des jeux de données pour cette zone directement depuis cette page.",
+    "areaDetails": "Détails de la zone",
+    "boundingBox": "Emprise",
+    "sections": {
+      "featured": "En vedette",
+      "largest": "Plus grands jeux de données",
+      "mostSaved": "Les plus enregistrés",
+      "mostContributors": "Le plus de contributeurs",
+      "recentlyEdited": "Modifiés récemment"
+    }
+  },
+  "CategoryCards": {
+    "title": "Trouver des données dans {area}",
+    "subtitle": "Parcourez les catégories de données OpenStreetMap. La disponibilité dépend de la cartographie locale."
+  },
+  "NavSearch": {
+    "searchPlaceholder": "Rechercher des villes et des zones...",
+    "noAreasFound": "Aucune zone trouvée",
+    "searching": "Recherche...",
+    "typeMoreChars": "Saisissez {count} caractère{count, plural, one {} other {s}} de plus pour rechercher",
+    "searchHint": "Essayez de rechercher des villes, des régions ou des pays",
+    "idLabel": "ID : ",
+    "clearSearch": "Effacer la recherche"
+  },
+  "AddressTypes": {
+    "city": "Grande ville",
+    "town": "Ville",
+    "village": "Village",
+    "hamlet": "Hameau",
+    "municipality": "Municipalité",
+    "county": "Comté",
+    "state": "État",
+    "country": "Pays",
+    "region": "Région",
+    "province": "Province",
+    "district": "District",
+    "suburb": "Banlieue",
+    "neighbourhood": "Quartier",
+    "city_block": "Îlot urbain",
+    "city_district": "Arrondissement",
+    "administrative": "Zone administrative",
+    "postcode": "Code postal",
+    "road": "Voie",
+    "house_number": "Numéro de rue",
+    "census": "Zone de recensement",
+    "borough": "Arrondissement",
+    "locality": "Lieu-dit",
+    "island": "Île",
+    "islet": "Îlot",
+    "civil_parish": "Paroisse civile",
+    "isolated_dwelling": "Habitat isolé",
+    "subdistrict": "Sous-district",
+    "allotments": "Jardins familiaux"
+  },
+  "AreaSelector": {
+    "searchPlaceholder": "Veuillez saisir au moins 3 caractères pour rechercher",
+    "searchDescription": "Seules les zones administratives (villes, communes, quartiers) apparaîtront dans les résultats",
+    "id": "ID :",
+    "noAreasFound": "Aucune zone trouvée. Essayez un autre terme de recherche.",
+    "boundingBox": "Emprise : [",
+    "boundingBoxEnd": "]",
+    "viewOnOsm": "Voir sur OpenStreetMap →",
+    "change": "Changer"
+  },
+  "CreateDatasetWizard": {
+    "selectArea": "Sélectionnez une zone",
+    "selectAreaDescription": "Saisissez un nom de zone et choisissez parmi les suggestions. Il peut s'agir d'une ville, d'un quartier ou de toute zone administrative dans OpenStreetMap.",
+    "nextSelectTemplate": "Suivant : sélectionner un modèle",
+    "selectTemplate": "Sélectionnez un modèle",
+    "selectTemplateDescription": "Choisissez un modèle de données qui définit les éléments OpenStreetMap à suivre.",
+    "back": "Retour",
+    "nextTestQuery": "Suivant : tester la requête",
+    "testYourQuery": "Testez votre requête",
+    "testQueryDescription": "Testez la requête du modèle sélectionné sur la zone choisie pour voir quelles données seront suivies.",
+    "nextConfirm": "Suivant : confirmer",
+    "confirmDatasetCreation": "Confirmez la création du jeu de données",
+    "confirmDescription": "Vérifiez vos sélections et créez votre jeu de données.",
+    "selectedArea": "Zone sélectionnée :",
+    "selectedTemplate": "Modèle sélectionné :"
+  },
+  "CreateDatasetPage": {
+    "backToHome": "← Retour à l'accueil",
+    "createNewDataset": "Créer un nouveau jeu de données",
+    "createDescription": "Suivez les étapes ci-dessous pour créer un nouveau jeu de données de suivi des données OpenStreetMap."
+  },
+  "QueryTester": {
+    "selectAreaTemplateFirst": "Veuillez d'abord sélectionner une zone et un modèle.",
+    "queryPreview": "Aperçu de la requête",
+    "queryingOverpass": "Interrogation de l'API Overpass...",
+    "error": "Erreur",
+    "noResults": "Aucun résultat",
+    "noResultsDescription": "La requête n'a renvoyé aucun résultat. Cela peut signifier :",
+    "noFeaturesMatch": "Aucun élément ne correspond aux critères dans cette zone",
+    "areaNoAmenities": "La zone ne contient peut-être pas les équipements spécifiés",
+    "queryNeedsAdjustment": "La requête doit peut-être être ajustée",
+    "testQuery": "Tester la requête",
+    "testingQuery": "Test de la requête..."
+  },
+  "TemplateSelector": {
+    "close": "✕",
+    "noTemplatesFound": "Aucun modèle ne correspond à \"",
+    "quote": "\"",
+    "selected": "✓",
+    "selectedTemplate": "Modèle sélectionné :",
+    "searchPlaceholder": "Rechercher des modèles..."
+  },
+  "PreferencesPage": {
+    "emailPreferences": "Préférences d'e-mail",
+    "reports": "Rapports",
+    "reportsDescription": "Recevez des e-mails lorsque vos jeux de données enregistrés changent."
+  },
+  "PreferencesForm": {
+    "enableReports": "Activer les rapports",
+    "frequency": "Fréquence :",
+    "daily": "Quotidien",
+    "weekly": "Hebdomadaire",
+    "language": "Langue"
+  },
+  "TemplatesPage": {
+    "templates": "Modèles",
+    "openParen": "(",
+    "closeParen": ")",
+    "noTemplatesFound": "Aucun modèle trouvé.",
+    "datasets": "Jeux de données :",
+    "tags": "Attributs :"
+  },
+  "UsersPage": {
+    "users": "Utilisateurs",
+    "openParen": "(",
+    "closeParen": ")",
+    "noUsersFound": "Aucun utilisateur trouvé.",
+    "datasets": "Jeux de données :",
+    "joined": "Inscription : {date}"
+  },
+  "DatasetUpdatesPage": {
+    "title": "Mises à jour des jeux de données",
+    "healthOk": "Sain",
+    "healthDegraded": "Dégradé",
+    "statActive": "Jeux de données actifs",
+    "statRefreshed": "Actualisés (24 h)",
+    "statStale": "Obsolètes / jamais vérifiés",
+    "statFlagged": "Signalés pour vérification",
+    "newestCheck": "Actualisation la plus récente : {value}",
+    "oldestCheck": "Actualisation la plus ancienne : {value}",
+    "never": "Jamais",
+    "flaggedHeading": "Jeux de données signalés",
+    "flaggedCount": "({count, number})",
+    "flaggedEmpty": "Aucun jeu de données n'est actuellement en échec.",
+    "failureCount": "{count, plural, =1 {# échec consécutif} other {# échecs consécutifs}}",
+    "lastError": "Dernière erreur : {message}",
+    "lastAttempted": "Dernière tentative : {value}",
+    "lastChecked": "Dernière vérification : {value}"
+  },
+  "DatasetMap": {
+    "back": "Retour",
+    "openInOsm": "Ouvrir dans OpenStreetMap",
+    "key": "Clé",
+    "value": "Valeur",
+    "lastEditedBy": "Dernière modification par <link>{user}</link>",
+    "mapLabel": "Carte interactive du jeu de données",
+    "fullScreenMapLabel": "Carte interactive en plein écran du jeu de données",
+    "loadingMap": "Chargement de la carte...",
+    "noDataAvailable": "Aucune donnée disponible. Les données seront automatiquement actualisées lorsque vous visiterez cette page.",
+    "noGeographicData": "Aucune donnée géographique trouvée dans les résultats du jeu de données.",
+    "tags": "Attributs",
+    "meta": "Méta",
+    "noAdditionalInfo": "Aucune information supplémentaire disponible",
+    "colon": ":",
+    "lastEditedLegend": "Dernière modification",
+    "recentChanges": "il y a ≤ 7 jours",
+    "mediumChanges": "il y a 8 à 30 jours",
+    "olderChanges": "il y a 31 à 90 jours",
+    "veryOldChanges": "il y a plus de 90 jours",
+    "legendViewLabel": "Colorer par",
+    "legendOther": "Autre",
+    "legendMissing": "Manquant",
+    "collapseLegend": "Masquer la légende",
+    "expandLegend": "Afficher la légende"
+  },
+  "DatasetWatchButton": {
+    "privateDataset": "Jeu de données privé"
+  },
+  "PublicDatasetsFeed": {
+    "noDatasetsYet": "Aucun jeu de données public pour l'instant.",
+    "title": "Jeux de données urbains publics",
+    "subtitle": "Découvrez les jeux de données que d'autres suivent dans différentes villes",
+    "dataCount": "Nombre de données : {count, number}",
+    "lastChecked": "Dernière vérification : {date}",
+    "never": "Jamais",
+    "by": "Par",
+    "viewDataset": "Voir le jeu de données",
+    "in": "dans",
+    "colon": ":",
+    "datasetTitle": "{templateName} à {cityName} ({countryCode})"
+  },
+  "Home": {
+    "hero": {
+      "title": "Comprenez votre ville grâce aux données ouvertes",
+      "description": "OSM for Cities organise les données OpenStreetMap en jeux de données que vous pouvez suivre. Suivez les écoles, les transports, les parcs et les cliniques au fil de leurs changements, recevez des mises à jour par e-mail et comprenez comment votre ville évolue dans le temps.",
+      "seeHowItWorks": "Voir comment ça marche",
+      "exploreDatasets": "Explorer les jeux de données",
+      "osmAttribution": "© les contributeurs d'OpenStreetMap"
+    },
+    "featuredDataset": {
+      "title": "{template} à {city}",
+      "viewDataset": "Voir le jeu de données",
+      "stats": {
+        "features": "Éléments",
+        "contributors": "Contributeurs",
+        "lastEdited": "Dernière modification"
+      }
+    },
+    "features": {
+      "subtitle": "Fonctionnalités",
+      "title": "Comment fonctionne OSM for Cities",
+      "description": "Suivez des jeux de données, surveillez les changements, explorez les données visuellement et téléchargez-les pour analyse",
+      "curate": {
+        "title": "Sélectionnez vos jeux de données",
+        "description": "Choisissez ce qui compte pour votre ville. Suivez les écoles, les transports, les parcs, les cliniques ou tout jeu de données suivi dans OpenStreetMap. Organisez les infrastructures qui vous tiennent à cœur."
+      },
+      "notifications": {
+        "title": "Soyez averti des changements",
+        "description": "Recevez des alertes par e-mail lorsque les jeux de données que vous suivez sont mis à jour. Restez informé des nouveaux équipements, des évolutions d'infrastructure et du développement urbain au fil des modifications apportées à la carte par les contributeurs OpenStreetMap."
+      },
+      "inspect": {
+        "title": "Inspectez les données sur une carte",
+        "description": "Explorez les jeux de données visuellement sur une carte interactive. Cliquez sur un élément pour voir ses informations détaillées, comparez les données historiques et comprenez les relations spatiales de votre ville."
+      },
+      "download": {
+        "title": "Téléchargez les données pour analyse",
+        "description": "Exportez les jeux de données au format GeoJSON pour les utiliser dans des outils externes, des projets de recherche ou des analyses personnalisées. Toutes les données sont disponibles sous licence Open Database License (ODbL).",
+        "licenseLink": "https://www.openstreetmap.org/copyright/"
+      }
+    },
+    "useCases": {
+      "subtitle": "Cas d'usage",
+      "title": "Les cartes servent de nombreux usages",
+      "description": "Un même jeu de données raconte des histoires différentes selon qui le lit et ce qu'il cherche à savoir.",
+      "urbanPlanners": {
+        "category": "Urbanistes",
+        "title": "Surveiller les évolutions des infrastructures",
+        "description": "Suivez les écoles, les transports, la santé et d'autres services à travers les quartiers pour comprendre les lacunes de couverture et les dynamiques de développement."
+      },
+      "journalists": {
+        "category": "Journalistes",
+        "title": "Suivre les sujets de développement urbain",
+        "description": "Surveillez les ouvertures et fermetures d'équipements, identifiez les disparités entre quartiers et vérifiez des affirmations avec des données à jour."
+      },
+      "researchers": {
+        "category": "Chercheurs",
+        "title": "Étudier les dynamiques de changement urbain",
+        "description": "Accédez à des données fiables pour analyser l'évolution des services dans le temps et comparer l'accessibilité entre différentes zones."
+      },
+      "developers": {
+        "category": "Acteurs de la civic tech",
+        "title": "Construire avec des données fiables",
+        "description": "Accédez à des jeux de données urbains cohérents et à jour pour vos applications, outils d'analyse et projets de cartographie communautaire."
+      },
+      "communityGroups": {
+        "category": "Collectifs locaux",
+        "title": "Surveiller les services locaux",
+        "description": "Suivez les équipements et services essentiels de votre secteur pour identifier les manques et défendre les besoins de la communauté."
+      },
+      "publicInstitutions": {
+        "category": "Institutions publiques et ONG",
+        "title": "Partager la localisation des services",
+        "description": "Offrez un accès transparent à l'emplacement actuel des équipements et gardez une vision des services disponibles."
+      },
+      "residents": {
+        "category": "Habitants",
+        "title": "Rester informé localement",
+        "description": "Suivez les évolutions de votre quartier et recevez des mises à jour lorsque de nouveaux services ouvrent ou que des services existants déménagent près de chez vous."
+      },
+      "businesses": {
+        "category": "Entreprises",
+        "title": "Surveiller l'exactitude des localisations",
+        "description": "Vérifiez comment vos établissements apparaissent dans les données cartographiques et assurez-vous que vos clients trouvent des services à jour à proximité."
+      }
+    },
+    "showcase": {
+      "subtitle": "Catégories",
+      "title": "Explorez les catégories de jeux de données",
+      "description": "Parcourez les différents types d'infrastructures urbaines suivis dans OpenStreetMap",
+      "datasets": {
+        "healthcare": {
+          "category": "Santé",
+          "title": "Établissements et services médicaux",
+          "description": "Hôpitaux, cliniques, pharmacies et autres établissements de santé qui fournissent des services médicaux essentiels aux communautés."
+        },
+        "transportation": {
+          "category": "Transports",
+          "title": "Infrastructures de transport",
+          "description": "Arrêts de bus, vélos en libre-service, bornes de recharge et autres équipements qui maintiennent les villes en mouvement et connectées."
+        },
+        "education": {
+          "category": "Éducation",
+          "title": "Établissements d'enseignement",
+          "description": "Écoles, universités, bibliothèques et jardins d'enfants qui offrent des possibilités d'apprentissage à tous les âges."
+        },
+        "leisure": {
+          "category": "Sports et loisirs",
+          "title": "Équipements et activités sportives",
+          "description": "Installations sportives, espaces de loisirs et équipements qui favorisent un mode de vie actif et l'engagement communautaire."
+        },
+        "environment": {
+          "category": "Environnement",
+          "title": "Éléments naturels et environnementaux",
+          "description": "Cascades, barrages, bassins de résidus et autres éléments environnementaux qui influencent les écosystèmes locaux."
+        },
+        "amenities": {
+          "category": "Équipements publics",
+          "title": "Équipements publics essentiels",
+          "description": "Toilettes publiques, points d'eau potable et équipements collectifs qui soutiennent la vie urbaine quotidienne des habitants et des visiteurs."
+        },
+        "tourism": {
+          "category": "Tourisme",
+          "title": "Hébergement et attractions",
+          "description": "Hôtels, chambres d'hôtes et attractions touristiques qui accueillent les visiteurs et mettent en valeur la culture locale."
+        },
+        "culture": {
+          "category": "Culture et patrimoine",
+          "title": "Lieux culturels et monuments",
+          "description": "Cinémas, monuments, galeries et sites patrimoniaux qui préservent et mettent en valeur la culture et l'histoire locales."
+        },
+        "social": {
+          "category": "Services sociaux",
+          "title": "Équipements communautaires et sociaux",
+          "description": "Structures sociales, centres communautaires et services qui soutiennent les populations vulnérables et le bien-être collectif."
+        }
+      }
+    },
+    "signup": {
+      "title": "Commencer",
+      "description": "Créez un compte pour suivre des jeux de données et recevoir des e-mails lorsque les données changent.",
+      "signUp": "Créer un compte"
+    },
+    "footer": {
+      "about": "À propos",
+      "contact": "Contact",
+      "github": "GitHub"
+    }
+  },
+  "DatasetLoading": {
+    "creatingDataset": "Création du jeu de données",
+    "thisUsuallyTakesLessThan30Seconds": "Cela prend généralement moins de 30 secondes"
+  },
+  "Email": {
+    "magicLinkSubject": "Connexion à OSM for Cities",
+    "magicLinkBody": "Cliquez sur {magicLink} pour vous connecter.",
+    "reportSubjectChanged": "{count} {datasets} avec des changements {lastPeriod}",
+    "reportSubjectNoChanges": "Aucun changement {lastPeriod}",
+    "reportChanged": "Les jeux de données suivants ont été mis à jour {lastPeriod} :",
+    "reportNoChanges": "Il n'y a eu aucun changement sur vos {savedDatasetsLink} {lastPeriod}.",
+    "reportSaved": "jeux de données enregistrés",
+    "preferencesPage": "page des préférences",
+    "lastPeriodDay": "au cours du dernier jour",
+    "lastPeriodWeek": "au cours de la dernière semaine",
+    "generatedAt": "Ce rapport a été généré à {timestamp}Z. Toutes les dates affichées sont en UTC.",
+    "unsubscribe": "Pour ne plus recevoir ces rapports, rendez-vous sur la {preferencesLink}.",
+    "datasetsOne": "jeu de données",
+    "datasetsOther": "jeux de données",
+    "templateDeprecated": "Ce modèle a été retiré du catalogue.",
+    "templateDeprecatedDaysRemaining": "Il vous reste {days} jour{days, plural, =1 {} other {s}} avant la suppression de ce jeu de données.",
+    "greeting": "Bonjour !"
+  },
+  "AboutPage": {
+    "metaTitle": "À propos - OSM for Cities",
+    "metaDescription": "Découvrez OSM for Cities - des jeux de données OpenStreetMap mis à jour quotidiennement",
+    "title": "À propos du projet",
+    "description1": "**OSM for Cities** est une plateforme pour explorer et suivre les mises à jour d'OpenStreetMap — une carte du monde libre et ouverte construite par des bénévoles. Chaque jour, des personnes ajoutent et améliorent des données sur les rues, les bâtiments, les écoles, les parcs, les transports et bien plus. Ce projet vous permet de suivre ces changements dans les lieux qui vous tiennent à cœur.",
+    "description2": "Vous pouvez vouloir garder un œil sur les modifications des écoles de votre région, ou suivre l'ajout de passages piétons, d'arrêts de bus ou de stationnements vélo dans votre ville. Peut-être êtes-vous simplement curieux de l'évolution du parc de votre quartier. Qu'il s'agisse d'un jeu de données pour l'urbanisme ou de quelque chose de plus personnel et informel, la plateforme vous permet de le créer et de le suivre.",
+    "featuresTitle": "Fonctionnalités principales",
+    "features": {
+      "create": "Créez des jeux de données personnalisés en choisissant un lieu et un thème",
+      "follow": "Suivez des jeux de données et recevez des résumés quotidiens ou hebdomadaires",
+      "activity": "Consultez l'activité des contributeurs et la fréquence des modifications pour chaque jeu de données"
+    },
+    "projectTitle": "Le projet",
+    "projectDescription1": "OSM for Cities a été créé par",
+    "projectDescription2": "et incubé lors d'un cycle",
+    "projectDescription3": "Labs. C'est une expérimentation ouverte pour rendre les données OSM utiles et accessibles — conçue pour les villes, mais suffisamment flexible pour servir de suivi OSM générique.",
+    "projectEvolution": "Sa direction évoluera avec l'usage et les retours de la communauté.",
+    "getInvolvedTitle": "Participer",
+    "getInvolvedDescription": "Vos retours contribuent à façonner ce projet. Que vous ayez des idées de nouvelles fonctionnalités, trouvé quelque chose qui ne fonctionne pas tout à fait, ou simplement envie de partager la façon dont vous l'utilisez — nous serions ravis de vous lire."
+  },
+  "DatasetErrors": {
+    "templateNotFoundTitle": "Modèle de jeu de données introuvable",
+    "templateNotFoundDescription": "Le modèle de jeu de données \"{templateId}\" n'existe pas ou n'est plus disponible.",
+    "templateNotFoundForArea": "Nous n'avons pas trouvé ce type de jeu de données pour {areaName}.",
+    "viewAvailableDatasets": "Voir les jeux de données disponibles pour {areaName}",
+    "browseAllTemplates": "Parcourir tous les modèles",
+    "backToHome": "Retour à l'accueil",
+    "areaNotFoundTitle": "Zone introuvable",
+    "areaNotFoundDescription": "La zone avec l'ID \"{areaId}\" n'existe pas dans OpenStreetMap ou n'a pas pu être trouvée. Vérifiez l'ID de la zone et réessayez.",
+    "searchForAreas": "Rechercher des zones",
+    "checkOnOSM": "Vérifier sur OpenStreetMap",
+    "requestTimedOutTitle": "Délai d'attente dépassé",
+    "datasetTooLargeTitle": "Jeu de données trop volumineux",
+    "datasetCreationFailedTitle": "Échec de la création du jeu de données",
+    "timeoutDescription": "La création de ce jeu de données a pris trop de temps. Cela arrive généralement avec de très grandes zones ou pendant les périodes de forte affluence.",
+    "tooLargeDescription": "Cette zone contient trop de données pour le modèle sélectionné. Essayez une zone plus petite ou un modèle plus spécifique.",
+    "creationErrorDescription": "Une erreur s'est produite lors de la création du jeu de données",
+    "creationErrorDescriptionWithDetails": "Une erreur s'est produite lors de la création du jeu de données \"{templateName}\" pour {areaName}.",
+    "creationErrorFor": "\"{templateName}\" pour {areaName}",
+    "tryAgain": "Réessayer",
+    "retryCreation": "Relancer la création",
+    "chooseDifferentTemplate": "Choisir un autre modèle",
+    "suggestions": "Suggestions :",
+    "suggestionSmallerArea": "Essayez une ville ou un district plus petit plutôt qu'une grande région",
+    "suggestionSpecificTemplate": "Utilisez un modèle plus spécifique (par ex. \"Écoles primaires\" plutôt que \"Toutes les écoles\")",
+    "suggestionContactUs": "Contactez-nous si vous avez besoin de données pour de grandes zones",
+    "somethingWentWrongTitle": "Une erreur s'est produite",
+    "unexpectedErrorDescription": "Une erreur inattendue s'est produite lors du chargement du jeu de données. Veuillez réessayer.",
+    "errorDetails": "Détails de l'erreur"
+  },
+  "DatasetUpsell": {
+    "accountRequired": "Connectez-vous pour voir",
+    "signInToBrowse": "Explorez la carte de <strong>{dataset} dans {area}</strong>, réalisée par la communauté OpenStreetMap.",
+    "continueWithEmail": "Continuer avec l'e-mail",
+    "back": "Retour"
+  },
+  "ExplorePage": {
+    "metaTitle": "Explorer — OSM for Cities",
+    "title": "Explorer",
+    "description": "Découvrez les données ouvertes de villes du monde entier",
+    "noDatasets": "Aucun jeu de données en vedette pour l'instant.",
+    "noDatasetsFound": "Aucun jeu de données trouvé",
+    "seeAll": "Tout voir →",
+    "backToExplore": "← Retour à Explorer",
+    "stats": {
+      "features": "Éléments",
+      "contributors": "Contributeurs",
+      "lastEdited": "Dernière modification",
+      "saves": "Enregistrements"
+    },
+    "sections": {
+      "featured": "En vedette",
+      "largest": "Plus grands jeux de données",
+      "mostSaved": "Les plus enregistrés",
+      "mostContributors": "Le plus de contributeurs",
+      "recentlyEdited": "Modifiés récemment"
+    }
+  },
+  "SEO": {
+    "home": {
+      "title": "OSM for Cities - Parcourez et téléchargez des données urbaines",
+      "description": "Recherchez n'importe quelle ville, parcourez plus de 200 catégories d'infrastructures urbaines et téléchargez les données en GeoJSON. Construit sur OpenStreetMap."
+    },
+    "about": {
+      "title": "À propos - OSM for Cities",
+      "description": "OSM for Cities rend les données OpenStreetMap accessibles. Parcourez plus de 200 catégories et téléchargez des données urbaines."
+    },
+    "dataset": {
+      "title": "{template} dans {area} - OSM for Cities",
+      "description": "Jeu de données {description} pour {area}"
+    },
+    "area": {
+      "title": "{area} - Jeux de données - OSM for Cities",
+      "description": "Explorez les jeux de données OpenStreetMap pour {area}"
+    }
+  },
+  "TagLabel": {
+    "shelter": "Abri",
+    "bench": "Banc",
+    "covered": "Couvert",
+    "lit": "Éclairé",
+    "tactile_paving": "Bandes podotactiles",
+    "operator": "Opérateur",
+    "network": "Réseau",
+    "bicycle_rental": "Type",
+    "bicycle_parking": "Type",
+    "capacity": "Capacité",
+    "access": "Accès",
+    "fee": "Payant",
+    "crossing": "Passage",
+    "crossing:markings": "Marquage",
+    "station": "Type de station",
+    "wheelchair": "Accès fauteuil roulant",
+    "cuisine": "Cuisine",
+    "outdoor_seating": "Terrasse",
+    "indoor_seating": "Places en intérieur",
+    "takeaway": "À emporter",
+    "delivery": "Livraison",
+    "diet:vegetarian": "Options végétariennes",
+    "smoking": "Fumeurs",
+    "vending": "Type",
+    "real_ale": "Real ale",
+    "food": "Restauration",
+    "changing_table": "Table à langer",
+    "toilets:disposal": "Type d'évacuation",
+    "backrest": "Dossier",
+    "material": "Matériau",
+    "man_made": "Type d'équipement",
+    "bottle": "Remplissage de bouteilles",
+    "recycling_type": "Type de recyclage",
+    "public_bookcase:type": "Type de contenant",
+    "information": "Type",
+    "drinking_water": "Potable",
+    "display": "Affichage",
+    "support": "Support",
+    "visibility": "Visibilité",
+    "post_box:type": "Type de boîte",
+    "stars": "Étoiles",
+    "shower": "Douche",
+    "power_supply": "Alimentation électrique",
+    "social_facility": "Type d'établissement",
+    "social_facility:for": "Public accueilli",
+    "community_centre": "Type de centre",
+    "building": "Type de bâtiment",
+    "townhall:type": "Type de mairie",
+    "parking": "Type",
+    "surface": "Revêtement",
+    "location": "Emplacement",
+    "seasonal": "Saisonnier",
+    "fitness_station": "Type",
+    "traffic_signals:sound": "Signal sonore",
+    "smoothness": "Régularité",
+    "oneway": "Sens unique",
+    "maxspeed": "Limite de vitesse",
+    "sidewalk": "Trottoir",
+    "railway": "Type de voie ferrée",
+    "electrified": "Électrification",
+    "usage": "Usage",
+    "service": "Voie de service",
+    "traffic_calming": "Type",
+    "operator:type": "Type d'opérateur",
+    "emergency": "Urgences",
+    "healthcare:speciality": "Spécialité",
+    "dispensing": "Délivrance d'ordonnances",
+    "isced:level": "Niveau d'enseignement",
+    "internet_access": "Accès Internet",
+    "brand": "Marque",
+    "atm": "Distributeur de billets",
+    "museum": "Type de musée",
+    "memorial": "Type de mémorial",
+    "government": "Type d'administration",
+    "admin_level": "Niveau administratif",
+    "religion": "Religion",
+    "denomination": "Confession",
+    "organic": "Bio",
+    "clothes": "Type de vêtements",
+    "garden:type": "Type de jardin",
+    "leaf_type": "Type de feuillage",
+    "water": "Type de plan d'eau",
+    "wetland": "Type de zone humide",
+    "trees": "Arbres cultivés",
+    "tower:type": "Type de tour",
+    "surveillance:type": "Type de surveillance",
+    "surveillance": "Zone de surveillance",
+    "substance": "Substance",
+    "content": "Contenu",
+    "fire_hydrant:type": "Type de borne incendie",
+    "fire_hydrant:position": "Position",
+    "fire_hydrant:diameter": "Diamètre de conduite",
+    "fire_hydrant:pressure": "Pression",
+    "cash_in": "Dépôt d'espèces",
+    "indoor": "Intérieur",
+    "sport": "Sport"
+  },
+  "TagValue": {
+    "__common__": {
+      "yes": "Oui",
+      "no": "Non",
+      "limited": "Limité",
+      "unknown": "Inconnu"
+    },
+    "healthcare:speciality": {
+      "general": "Médecine générale",
+      "internal": "Médecine interne",
+      "paediatrics": "Pédiatrie",
+      "gynaecology": "Gynécologie",
+      "dermatology": "Dermatologie",
+      "psychiatry": "Psychiatrie",
+      "neurology": "Neurologie",
+      "cardiology": "Cardiologie",
+      "ophthalmology": "Ophtalmologie",
+      "otolaryngology": "Oto-rhino-laryngologie (ORL)",
+      "orthopaedics": "Orthopédie",
+      "urology": "Urologie",
+      "radiology": "Radiologie",
+      "surgery": "Chirurgie",
+      "plastic_surgery": "Chirurgie plastique",
+      "neurosurgery": "Neurochirurgie",
+      "gastroenterology": "Gastro-entérologie",
+      "oncology": "Oncologie",
+      "nephrology": "Néphrologie",
+      "orthodontics": "Orthodontie",
+      "pulmonology": "Pneumologie",
+      "palliative": "Soins palliatifs",
+      "proctology": "Proctologie",
+      "phlebology": "Phlébologie",
+      "child_psychiatry": "Pédopsychiatrie",
+      "diabetology": "Diabétologie",
+      "dentist": "Dentisterie",
+      "stomatology": "Stomatologie",
+      "psychotherapy": "Psychothérapie",
+      "physiatry": "Médecine physique",
+      "anaesthetics": "Anesthésie",
+      "biology": "Biologie médicale",
+      "acupuncture": "Acupuncture",
+      "chiropractic": "Chiropraxie",
+      "osteopathy": "Ostéopathie",
+      "naturopathy": "Naturopathie",
+      "homeopathy": "Homéopathie",
+      "traditional_chinese_medicine": "Médecine traditionnelle chinoise",
+      "massage": "Massothérapie",
+      "reiki": "Reiki"
+    },
+    "operator:type": {
+      "public": "Public",
+      "private": "Privé",
+      "government": "Gouvernement",
+      "religious": "Religieux",
+      "university": "Université",
+      "ngo": "ONG",
+      "community": "Communautaire",
+      "business": "Entreprise",
+      "military": "Militaire",
+      "private_non_profit": "Privé à but non lucratif"
+    },
+    "religion": {
+      "christian": "Christianisme",
+      "muslim": "Islam",
+      "jewish": "Judaïsme",
+      "buddhist": "Bouddhisme",
+      "hindu": "Hindouisme",
+      "sikh": "Sikhisme",
+      "taoist": "Taoïsme",
+      "shinto": "Shintoïsme",
+      "bahai": "Bahaïsme",
+      "jain": "Jaïnisme"
+    },
+    "fire_hydrant:type": {
+      "pillar": "Poteau",
+      "underground": "Souterrain",
+      "wall": "Mural",
+      "pipe": "Tuyau"
+    },
+    "memorial": {
+      "plaque": "Plaque",
+      "statue": "Statue",
+      "war_memorial": "Monument aux morts",
+      "bust": "Buste",
+      "stone": "Pierre",
+      "sculpture": "Sculpture",
+      "stele": "Stèle"
+    },
+    "leaf_type": {
+      "broadleaved": "Feuillu",
+      "needleleaved": "Résineux",
+      "mixed": "Mixte",
+      "leafless": "Sans feuilles"
+    },
+    "fitness_station": {
+      "horizontal_bar": "Barre fixe",
+      "parallel_bars": "Barres parallèles",
+      "horizontal_ladder": "Échelle horizontale",
+      "sit-up": "Banc à abdominaux",
+      "sign": "Panneau d'instructions",
+      "elliptical_trainer": "Vélo elliptique",
+      "exercise_bike": "Vélo d'appartement"
+    },
+    "location": {
+      "outdoor": "Extérieur",
+      "indoor": "Intérieur",
+      "roof": "Sur le toit",
+      "underground": "Souterrain"
+    },
+    "seasonal": {
+      "winter": "Hiver",
+      "spring": "Printemps",
+      "summer": "Été",
+      "autumn": "Automne"
+    },
+    "access": {
+      "private": "Privé",
+      "customers": "Clients",
+      "permissive": "Toléré",
+      "designated": "Réservé",
+      "permit": "Sur autorisation"
+    },
+    "public_bookcase:type": {
+      "metal_cabinet": "Armoire métallique",
+      "glass_cabinet": "Armoire vitrée",
+      "wooden_cabinet": "Armoire en bois",
+      "phone_box": "Ancienne cabine téléphonique",
+      "shelf": "Étagère",
+      "reading_box": "Boîte à lire"
+    },
+    "information": {
+      "board": "Panneau d'information",
+      "terminal": "Borne",
+      "map": "Carte",
+      "guidepost": "Poteau indicateur",
+      "office": "Office de tourisme",
+      "route_marker": "Balise d'itinéraire"
+    },
+    "display": {
+      "analog": "Analogique",
+      "digital": "Numérique",
+      "sundial": "Cadran solaire"
+    },
+    "support": {
+      "wall": "Mur",
+      "wall_mounted": "Fixé au mur",
+      "pole": "Poteau",
+      "roof": "Toit",
+      "ground": "Sol",
+      "pillar": "Pilier",
+      "billboard": "Panneau d'affichage",
+      "street_lamp": "Lampadaire"
+    },
+    "visibility": {
+      "area": "Zone",
+      "street": "Rue",
+      "house": "Maison"
+    },
+    "post_box:type": {
+      "pillar": "Boîte sur pied",
+      "lamp": "Boîte sur poteau",
+      "wall": "Boîte murale"
+    },
+    "toilets:disposal": {
+      "flush": "Chasse d'eau",
+      "pitlatrine": "Latrines à fosse",
+      "chemical": "Chimique",
+      "bucket": "Seau"
+    },
+    "man_made": {
+      "water_tap": "Robinet",
+      "fountain": "Fontaine",
+      "drinking_fountain": "Fontaine à boire",
+      "water_well": "Puits"
+    },
+    "recycling_type": {
+      "container": "Conteneur",
+      "centre": "Centre de recyclage"
+    },
+    "bicycle_parking": {
+      "stands": "Arceaux",
+      "wide_stands": "Arceaux larges",
+      "low_stands": "Arceaux bas",
+      "large_stands": "Grands arceaux",
+      "wall_loops": "Anneaux muraux",
+      "safe_loops": "Anneaux sécurisés",
+      "ground_slots": "Fentes au sol",
+      "rack": "Râtelier",
+      "two-tier": "À deux étages",
+      "shed": "Abri",
+      "floor": "Sol",
+      "lockers": "Consignes",
+      "building": "Bâtiment",
+      "bollard": "Borne",
+      "anchors": "Ancrages",
+      "handlebar_holder": "Support de guidon",
+      "crossbar": "Barre transversale",
+      "informal": "Informel"
+    },
+    "parking": {
+      "surface": "En surface",
+      "underground": "Souterrain",
+      "multi-storey": "À étages",
+      "rooftop": "Sur le toit",
+      "street_side": "En bord de rue",
+      "lane": "Sur voie",
+      "sheds": "Abris",
+      "carports": "Auvents",
+      "garage_boxes": "Boxes"
+    },
+    "surface": {
+      "asphalt": "Asphalte",
+      "concrete": "Béton",
+      "paving_stones": "Pavés",
+      "sett": "Pavés taillés",
+      "cobblestone": "Pavés irréguliers",
+      "paved": "Revêtu",
+      "unpaved": "Non revêtu",
+      "compacted": "Compacté",
+      "fine_gravel": "Gravier fin",
+      "gravel": "Gravier",
+      "ground": "Sol naturel",
+      "dirt": "Terre",
+      "grass": "Herbe"
+    },
+    "traffic_signals:sound": {
+      "locate": "Localisation uniquement",
+      "walk": "Traversée uniquement"
+    },
+    "smoothness": {
+      "excellent": "Excellent",
+      "good": "Bon",
+      "intermediate": "Intermédiaire",
+      "bad": "Mauvais",
+      "very_bad": "Très mauvais",
+      "horrible": "Horrible",
+      "very_horrible": "Exécrable",
+      "impassable": "Impraticable"
+    },
+    "oneway": {
+      "-1": "Sens inverse"
+    },
+    "sidewalk": {
+      "both": "Des deux côtés",
+      "left": "Côté gauche",
+      "right": "Côté droit",
+      "separate": "Cartographié séparément",
+      "none": "Aucun"
+    },
+    "railway": {
+      "tram": "Tramway",
+      "subway": "Métro",
+      "light_rail": "Métro léger",
+      "rail": "Train classique"
+    },
+    "electrified": {
+      "contact_line": "Caténaire",
+      "rail": "Troisième rail"
+    },
+    "usage": {
+      "main": "Ligne principale",
+      "branch": "Ligne secondaire",
+      "industrial": "Industriel",
+      "tourism": "Touristique",
+      "military": "Militaire"
+    },
+    "service": {
+      "yard": "Faisceau de triage",
+      "siding": "Voie d'évitement",
+      "spur": "Embranchement",
+      "crossover": "Communication"
+    },
+    "traffic_calming": {
+      "hump": "Dos d'âne",
+      "bump": "Ralentisseur",
+      "table": "Plateau surélevé",
+      "island": "Îlot",
+      "dip": "Creux",
+      "cushion": "Coussin berlinois",
+      "chicane": "Chicane",
+      "choker": "Rétrécissement",
+      "rumble_strip": "Bande rugueuse"
+    },
+    "internet_access": {
+      "wlan": "Wi-Fi",
+      "terminal": "Borne"
+    }
+  }
+}

--- a/prisma/sync-templates.ts
+++ b/prisma/sync-templates.ts
@@ -11,11 +11,8 @@
  */
 
 import { PrismaClient } from "@prisma/client";
-import {
-  DEPRECATION_DAYS,
-  SUPPORTED_LOCALES,
-  YML_LOCALE_MAP,
-} from "../src/lib/constants";
+import { DEPRECATION_DAYS, YML_LOCALE_MAP } from "../src/lib/constants";
+import { AVAILABLE_LOCALES } from "../src/i18n/constants";
 import {
   loadTemplatesI18n,
   loadTemplatesYaml,
@@ -170,7 +167,7 @@ async function main() {
     upserted++;
 
     // Upsert translations
-    for (const locale of SUPPORTED_LOCALES) {
+    for (const locale of AVAILABLE_LOCALES) {
       const ymlLocale = YML_LOCALE_MAP[locale] ?? locale;
       const translatedName = i18n?.name?.[ymlLocale] ?? name;
       const translatedDesc =

--- a/prisma/templates.i18n.yml
+++ b/prisma/templates.i18n.yml
@@ -5,2169 +5,2651 @@ templates:
       en: Bicycle Parking
       pt: Estacionamento para bicicletas
       es: Estacionamiento de bicicletas
+      fr: Stationnement vélo
     desc:
       en: Bicycle Parking
       pt: Estacionamento para bicicletas
       es: Estacionamiento de bicicletas
+      fr: Stationnement vélo
   bicycle-rental:
     name:
       en: Bicycle Rental
       pt: Aluguel de bicicletas
       es: Alquiler de bicicletas
+      fr: Location de vélos
     desc:
       en: Bicycle Rental
       pt: Aluguel de bicicletas
       es: Alquiler de bicicletas
+      fr: Location de vélos
   bicycle-shop:
     name:
       en: Bicycle Shop
       pt: Loja de bicicletas
       es: Tienda de bicicletas
+      fr: Magasins de vélos
     desc:
       en: Bicycle Shop
       pt: Loja de bicicletas
       es: Tienda de bicicletas
+      fr: Magasins de vélos
   markets:
     name:
       en: Markets
       pt: Mercados e feiras
       es: Mercados
+      fr: Marchés
     desc:
       en: Public marketplaces
       pt: Mercados e feiras públicas
       es: Mercados públicos
+      fr: Marchés publics
   bus-stops:
     name:
       en: Bus Stops
       pt: Pontos de ônibus
       es: Paradas de autobús
+      fr: Arrêts de bus
     desc:
       en: Bus Stops
       pt: Pontos de ônibus
       es: Paradas de autobús
+      fr: Arrêts de bus
   ev-charging:
     name:
       en: Ev Charging
       pt: Recarga para veículos elétricos
       es: Carga de vehículos eléctricos
+      fr: Recharge de véhicules électriques
     desc:
       en: Ev Charging
       pt: Recarga para veículos elétricos
       es: Carga de vehículos eléctricos
+      fr: Recharge de véhicules électriques
   railway-stations:
     name:
       en: Railway Stations
       pt: Estações ferroviárias
       es: Estaciones de tren
+      fr: Gares ferroviaires
     desc:
       en: Railway Stations
       pt: Estações ferroviárias
       es: Estaciones de tren
+      fr: Gares ferroviaires
   tram-stops:
     name:
       en: Tram Stops
       pt: Paradas de bonde
       es: Paradas de tranvía
+      fr: Arrêts de tramway
     desc:
       en: Tram Stops
       pt: Paradas de bonde
       es: Paradas de tranvía
+      fr: Arrêts de tramway
   subway-entrances:
     name:
       en: Subway Entrances
       pt: Acessos ao metrô
       es: Accesos de metro
+      fr: Entrées de métro
     desc:
       en: Subway Entrances
       pt: Acessos ao metrô
       es: Accesos de metro
+      fr: Entrées de métro
   transit-platforms:
     name:
       en: Transit Platforms
       pt: Plataformas de transporte público
       es: Andenes de transporte público
+      fr: Quais de transport en commun
     desc:
       en: Transit Platforms
       pt: Plataformas de transporte público
       es: Andenes de transporte público
+      fr: Quais de transport en commun
   ferry-terminals:
     name:
       en: Ferry Terminals
       pt: Terminais de balsas
       es: Terminales de ferry
+      fr: Terminaux de ferry
     desc:
       en: Ferry Terminals
       pt: Terminais de balsas
       es: Terminales de ferry
+      fr: Terminaux de ferry
   taxi-ranks:
     name:
       en: Taxi Ranks
       pt: Pontos de táxi
       es: Paradas de taxi
+      fr: Stations de taxi
     desc:
       en: Taxi Ranks
       pt: Pontos de táxi
       es: Paradas de taxi
+      fr: Stations de taxi
   parking:
     name:
       en: Parking
       pt: Estacionamentos
       es: Estacionamientos
+      fr: Parkings
     desc:
       en: Parking
       pt: Estacionamentos
       es: Estacionamientos
+      fr: Parkings
   rail-tracks:
     name:
       en: Rail Tracks
       pt: Trilhos ferroviários
       es: Vías férreas
+      fr: Voies ferrées
     desc:
       en: Tram, subway, light rail and mainline railway tracks
       pt: Trilhos de bonde, metrô, VLT e ferrovias
       es: Vías de tranvía, metro, tren ligero y ferrocarril
+      fr: Voies de tramway, métro, train léger et chemin de fer
   busways:
     name:
       en: Busways
       pt: Corredores de ônibus
       es: Corredores de autobús
+      fr: Couloirs de bus
     desc:
       en: Dedicated bus rapid transit corridors
       pt: Corredores exclusivos de ônibus (BRT)
       es: Corredores exclusivos de autobús (BRT)
+      fr: Couloirs réservés de bus à haut niveau de service (BRT)
   bus-lanes:
     name:
       en: Bus Lanes
       pt: Faixas de ônibus
       es: Carriles de autobús
+      fr: Voies de bus
     desc:
       en: On-street exclusive bus lanes
       pt: Faixas exclusivas de ônibus na via
       es: Carriles exclusivos de autobús en la vía
+      fr: Voies réservées aux bus sur chaussée
   atms:
     name:
       en: Atms
       pt: Caixas eletrônicos
       es: Cajeros automáticos
+      fr: Distributeurs automatiques de billets
     desc:
       en: Atms
       pt: Caixas eletrônicos
       es: Cajeros automáticos
+      fr: Distributeurs automatiques de billets
   banks:
     name:
       en: Banks
       pt: Bancos
       es: Bancos
+      fr: Banques
     desc:
       en: Banks
       pt: Bancos
       es: Bancos
+      fr: Banques
   public-toilets:
     name:
       en: Public Toilets
       pt: Banheiros públicos
       es: Baños públicos
+      fr: Toilettes publiques
     desc:
       en: Public Toilets
       pt: Banheiros públicos
       es: Baños públicos
+      fr: Toilettes publiques
   drinking-water:
     name:
       en: Drinking Water
       pt: Água potável
       es: Agua potable
+      fr: Eau potable
     desc:
       en: Drinking Water
       pt: Água potável
       es: Agua potable
+      fr: Eau potable
   post-offices:
     name:
       en: Post Offices
       pt: Correios
       es: Oficinas de correos
+      fr: Bureaux de poste
     desc:
       en: Post Offices
       pt: Correios
       es: Oficinas de correos
+      fr: Bureaux de poste
   parcel-lockers:
     name:
       en: Parcel Lockers
       pt: Lockers de encomendas
       es: Consignas de paquetes
+      fr: Consignes à colis
     desc:
       en: Parcel Lockers
       pt: Lockers de encomendas
       es: Consignas de paquetes
+      fr: Consignes à colis
   shower:
     name:
       en: Showers
       pt: Chuveiros públicos
       es: Duchas públicas
+      fr: Douches publiques
     desc:
       en: Showers
       pt: Chuveiros públicos
       es: Duchas públicas
+      fr: Douches publiques
   public-bookcase:
     name:
       en: Public Bookcases
       pt: Estantes públicas de livros
       es: Estanterías públicas de libros
+      fr: Boîtes à livres
     desc:
       en: Public Bookcases
       pt: Estantes públicas de livros
       es: Estanterías públicas de libros
+      fr: Boîtes à livres
   luggage-lockers:
     name:
       en: Luggage Lockers
       pt: Guarda-volumes
       es: Consignas de equipaje
+      fr: Consignes à bagages
     desc:
       en: Luggage Lockers
       pt: Guarda-volumes
       es: Consignas de equipaje
+      fr: Consignes à bagages
   post-boxes:
     name:
       en: Post Boxes
       pt: Caixas de coleta postal
       es: Buzones de correos
+      fr: Boîtes aux lettres
     desc:
       en: Post Boxes
       pt: Caixas de coleta postal
       es: Buzones de correos
+      fr: Boîtes aux lettres
   give-box:
     name:
       en: Give Boxes
       pt: Armários de doação
       es: Armarios de intercambio
+      fr: Boîtes à dons
     desc:
       en: Give Boxes
       pt: Armários de doação
       es: Armarios de intercambio
+      fr: Boîtes à dons
   hospitals:
     name:
       en: Hospitals
       pt: Hospitais
       es: Hospitales
+      fr: Hôpitaux
     desc:
       en: Hospitals
       pt: Hospitais
       es: Hospitales
+      fr: Hôpitaux
   clinics:
     name:
       en: Clinics
       pt: Clínicas
       es: Clínicas
+      fr: Cliniques
     desc:
       en: Clinics
       pt: Clínicas
       es: Clínicas
+      fr: Cliniques
   doctors:
     name:
       en: Doctors
       pt: Médicos
       es: Médicos
+      fr: Médecins
     desc:
       en: Doctors
       pt: Médicos
       es: Médicos
+      fr: Médecins
   dentists:
     name:
       en: Dentists
       pt: Dentistas
       es: Dentistas
+      fr: Dentistes
     desc:
       en: Dentists
       pt: Dentistas
       es: Dentistas
+      fr: Dentistes
   pharmacies:
     name:
       en: Pharmacies
       pt: Farmácias
       es: Farmacias
+      fr: Pharmacies
     desc:
       en: Pharmacies
       pt: Farmácias
       es: Farmacias
+      fr: Pharmacies
   health-post:
     name:
       en: Health Post
       pt: Posto de saúde
       es: Puesto de salud
+      fr: Poste de santé
     desc:
       en: Health Post
       pt: Posto de saúde
       es: Puesto de salud
+      fr: Poste de santé
   nursing-home:
     name:
       en: Nursing Home
       pt: Lar de idosos
       es: Residencia de ancianos
+      fr: Maison de retraite
     desc:
       en: Nursing Home
       pt: Lar de idosos
       es: Residencia de ancianos
+      fr: Maison de retraite
   veterinary:
     name:
       en: Veterinary
       pt: Veterinários
       es: Veterinaria
+      fr: Vétérinaires
     desc:
       en: Veterinary
       pt: Veterinários
       es: Veterinaria
+      fr: Vétérinaires
   opticians:
     name:
       en: Opticians
       pt: Óticas
       es: Ópticas
+      fr: Opticiens
     desc:
       en: Opticians
       pt: Óticas
       es: Ópticas
+      fr: Opticiens
   medical-laboratories:
     name:
       en: Medical Laboratories
       pt: Laboratórios médicos
       es: Laboratorios médicos
+      fr: Laboratoires médicaux
     desc:
       en: Medical Laboratories
       pt: Laboratórios médicos
       es: Laboratorios médicos
+      fr: Laboratoires médicaux
   psychotherapists:
     name:
       en: Psychotherapists
       pt: Psicoterapeutas
       es: Psicoterapeutas
+      fr: Psychothérapeutes
     desc:
       en: Psychotherapists
       pt: Psicoterapeutas
       es: Psicoterapeutas
+      fr: Psychothérapeutes
   physiotherapists:
     name:
       en: Physiotherapists
       pt: Fisioterapeutas
       es: Fisioterapeutas
+      fr: Kinésithérapeutes
     desc:
       en: Physiotherapists
       pt: Fisioterapeutas
       es: Fisioterapeutas
+      fr: Kinésithérapeutes
   optometrists:
     name:
       en: Optometrists
       pt: Optometristas
       es: Optometristas
+      fr: Optométristes
     desc:
       en: Optometrists
       pt: Optometristas
       es: Optometristas
+      fr: Optométristes
   podiatrists:
     name:
       en: Podiatrists
       pt: Podólogos
       es: Podólogos
+      fr: Podologues
     desc:
       en: Podiatrists
       pt: Podólogos
       es: Podólogos
+      fr: Podologues
   rehabilitation-centres:
     name:
       en: Rehabilitation Centres
       pt: Centros de reabilitação
       es: Centros de rehabilitación
+      fr: Centres de réadaptation
     desc:
       en: Rehabilitation Centres
       pt: Centros de reabilitação
       es: Centros de rehabilitación
+      fr: Centres de réadaptation
   counselling-services:
     name:
       en: Counselling Services
       pt: Serviços de aconselhamento
       es: Servicios de asesoramiento
+      fr: Services de conseil
     desc:
       en: Counselling Services
       pt: Serviços de aconselhamento
       es: Servicios de asesoramiento
+      fr: Services de conseil
   speech-therapists:
     name:
       en: Speech Therapists
       pt: Fonoaudiólogos
       es: Logopedas
+      fr: Orthophonistes
     desc:
       en: Speech Therapists
       pt: Fonoaudiólogos
       es: Logopedas
+      fr: Orthophonistes
   occupational-therapists:
     name:
       en: Occupational Therapists
       pt: Terapeutas ocupacionais
       es: Terapeutas ocupacionales
+      fr: Ergothérapeutes
     desc:
       en: Occupational Therapists
       pt: Terapeutas ocupacionais
       es: Terapeutas ocupacionales
+      fr: Ergothérapeutes
   alternative-medicine:
     name:
       en: Alternative Medicine
       pt: Medicina alternativa
       es: Medicina alternativa
+      fr: Médecine alternative
     desc:
       en: Alternative Medicine
       pt: Medicina alternativa
       es: Medicina alternativa
+      fr: Médecine alternative
   blood-donation:
     name:
       en: Blood Donation
       pt: Doação de sangue
       es: Donación de sangre
+      fr: Don du sang
     desc:
       en: Blood Donation
       pt: Doação de sangue
       es: Donación de sangre
+      fr: Don du sang
   dialysis-centres:
     name:
       en: Dialysis Centres
       pt: Centros de diálise
       es: Centros de diálisis
+      fr: Centres de dialyse
     desc:
       en: Dialysis Centres
       pt: Centros de diálise
       es: Centros de diálisis
+      fr: Centres de dialyse
   midwives:
     name:
       en: Midwives
       pt: Parteiras
       es: Parteras
+      fr: Sages-femmes
     desc:
       en: Midwives
       pt: Parteiras
       es: Parteras
+      fr: Sages-femmes
   schools:
     name:
       en: Schools
       pt: Escolas
       es: Escuelas
+      fr: Écoles
     desc:
       en: Schools
       pt: Escolas
       es: Escuelas
+      fr: Écoles
   universities:
     name:
       en: Universities
       pt: Universidades
       es: Universidades
+      fr: Universités
     desc:
       en: Universities
       pt: Universidades
       es: Universidades
+      fr: Universités
   libraries:
     name:
       en: Libraries
       pt: Bibliotecas
       es: Bibliotecas
+      fr: Bibliothèques
     desc:
       en: Libraries
       pt: Bibliotecas
       es: Bibliotecas
+      fr: Bibliothèques
   kindergarten:
     name:
       en: Kindergarten
       pt: Jardins de infância
       es: Jardines de infancia
+      fr: Jardins d'enfants
     desc:
       en: Kindergarten
       pt: Jardins de infância
       es: Jardines de infancia
+      fr: Jardins d'enfants
   college:
     name:
       en: College
       pt: Faculdades
       es: Facultades
+      fr: Établissements d'enseignement supérieur
     desc:
       en: College
       pt: Faculdades
       es: Facultades
+      fr: Établissements d'enseignement supérieur
   childcare:
     name:
       en: Childcare
       pt: Creches
       es: Guarderías
+      fr: Crèches
     desc:
       en: Childcare
       pt: Creches
       es: Guarderías
+      fr: Crèches
   driving-school:
     name:
       en: Driving Schools
       pt: Autoescolas
       es: Autoescuelas
+      fr: Auto-écoles
     desc:
       en: Driving Schools
       pt: Autoescolas
       es: Autoescuelas
+      fr: Auto-écoles
   music-school:
     name:
       en: Music Schools
       pt: Escolas de música
       es: Escuelas de música
+      fr: Écoles de musique
     desc:
       en: Music Schools
       pt: Escolas de música
       es: Escuelas de música
+      fr: Écoles de musique
   language-school:
     name:
       en: Language Schools
       pt: Escolas de idiomas
       es: Escuelas de idiomas
+      fr: Écoles de langues
     desc:
       en: Language Schools
       pt: Escolas de idiomas
       es: Escuelas de idiomas
+      fr: Écoles de langues
   research-institute:
     name:
       en: Research Institutes
       pt: Institutos de pesquisa
       es: Institutos de investigación
+      fr: Instituts de recherche
     desc:
       en: Research Institutes
       pt: Institutos de pesquisa
       es: Institutos de investigación
+      fr: Instituts de recherche
   hotels:
     name:
       en: Hotels
       pt: Hotéis
       es: Hoteles
+      fr: Hôtels
     desc:
       en: Hotels
       pt: Hotéis
       es: Hoteles
+      fr: Hôtels
   motels:
     name:
       en: Motels
       pt: Motéis
       es: Moteles
+      fr: Motels
     # tourism=motel spans two regional meanings (roadside motor lodge vs the Brazilian/
     # Latin American short-stay motel); keep the description neutral across locales.
     desc:
       en: Short-stay lodging
       pt: Hospedagem de curta permanência
       es: Alojamiento de estancia corta
+      fr: Hébergement de courte durée
   attractions:
     name:
       en: Attractions
       pt: Atrações
       es: Atracciones
+      fr: Attractions
     desc:
       en: Attractions
       pt: Atrações
       es: Atracciones
+      fr: Attractions
   viewpoints:
     name:
       en: Viewpoints
       pt: Mirantes
       es: Miradores
+      fr: Points de vue
     desc:
       en: Viewpoints
       pt: Mirantes
       es: Miradores
+      fr: Points de vue
   campsites:
     name:
       en: Campsites
       pt: Áreas de acampamento
       es: Zonas de acampada
+      fr: Campings
     desc:
       en: Campsites
       pt: Áreas de acampamento
       es: Zonas de acampada
+      fr: Campings
   alpine-huts:
     name:
       en: Alpine Huts
       pt: Refúgios alpinos
       es: Refugios alpinos
+      fr: Refuges alpins
     desc:
       en: Alpine Huts
       pt: Refúgios alpinos
       es: Refugios alpinos
+      fr: Refuges alpins
   caravan-sites:
     name:
       en: Caravan Sites
       pt: Áreas para trailers
       es: Áreas para caravanas
+      fr: Aires pour camping-cars
     desc:
       en: Caravan Sites
       pt: Áreas para trailers
       es: Áreas para caravanas
+      fr: Aires pour camping-cars
   wilderness-huts:
     name:
       en: Wilderness Huts
       pt: Abrigos em áreas naturais
       es: Refugios en zonas naturales
+      fr: Refuges non gardés
     desc:
       en: Wilderness Huts
       pt: Abrigos em áreas naturais
       es: Refugios en zonas naturales
+      fr: Refuges non gardés
   chalets:
     name:
       en: Chalets
       pt: Chalés
       es: Chalés
+      fr: Chalets
     desc:
       en: Chalets
       pt: Chalés
       es: Chalés
+      fr: Chalets
   cinemas:
     name:
       en: Cinemas
       pt: Cinemas
       es: Cines
+      fr: Cinémas
     desc:
       en: Cinemas
       pt: Cinemas
       es: Cines
+      fr: Cinémas
   monuments:
     name:
       en: Monuments
       pt: Monumentos
       es: Monumentos
+      fr: Monuments
     desc:
       en: Monuments
       pt: Monumentos
       es: Monumentos
+      fr: Monuments
   arts-centre:
     name:
       en: Arts Centre
       pt: Centro cultural
       es: Centro cultural
+      fr: Centre culturel
     desc:
       en: Arts Centre
       pt: Centro cultural
       es: Centro cultural
+      fr: Centre culturel
   gallery:
     name:
       en: Gallery
       pt: Galeria
       es: Galería
+      fr: Galerie
     desc:
       en: Gallery
       pt: Galeria
       es: Galería
+      fr: Galerie
   memorials:
     name:
       en: Memorials
       pt: Memoriais
       es: Monumentos conmemorativos
+      fr: Mémoriaux
     desc:
       en: Memorials
       pt: Memoriais
       es: Monumentos conmemorativos
+      fr: Mémoriaux
   museums:
     name:
       en: Museums
       pt: Museus
       es: Museos
+      fr: Musées
     desc:
       en: Museums
       pt: Museus
       es: Museos
+      fr: Musées
   theatres:
     name:
       en: Theatres
       pt: Teatros
       es: Teatros
+      fr: Théâtres
     desc:
       en: Theatres
       pt: Teatros
       es: Teatros
+      fr: Théâtres
   social-facility:
     name:
       en: Social Facility
       pt: Instalação de assistência social
       es: Instalación de asistencia social
+      fr: Établissements d'action sociale
     desc:
       en: Social Facility
       pt: Instalação de assistência social
       es: Instalación de asistencia social
+      fr: Établissements d'action sociale
   community-centre:
     name:
       en: Community Centre
       pt: Centro comunitário
       es: Centro comunitario
+      fr: Centre communautaire
     desc:
       en: Community Centre
       pt: Centro comunitário
       es: Centro comunitario
+      fr: Centre communautaire
   town-halls:
     name:
       en: Town Halls
       pt: Prefeituras
       es: Ayuntamientos
+      fr: Mairies
     desc:
       en: Town Halls
       pt: Prefeituras
       es: Ayuntamientos
+      fr: Mairies
   senior-centers:
     name:
       en: Senior Centers
       pt: Centros para idosos
       es: Centros de mayores
+      fr: Centres pour personnes âgées
     desc:
       en: Senior Centers
       pt: Centros para idosos
       es: Centros de mayores
+      fr: Centres pour personnes âgées
   government-office:
     name:
       en: Government Office
       pt: Repartição pública
       es: Oficina gubernamental
+      fr: Administrations publiques
     desc:
       en: Government Office
       pt: Repartição pública
       es: Oficina gubernamental
+      fr: Administrations publiques
   courts:
     name:
       en: Courts
       pt: Tribunais
       es: Juzgados
+      fr: Tribunaux
     desc:
       en: Courts
       pt: Tribunais
       es: Juzgados
+      fr: Tribunaux
   police-stations:
     name:
       en: Police Stations
       pt: Delegacias
       es: Comisarías
+      fr: Commissariats
     desc:
       en: Police Stations
       pt: Delegacias
       es: Comisarías
+      fr: Commissariats
   prisons:
     name:
       en: Prisons
       pt: Presídios
       es: Prisiones
+      fr: Prisons
     desc:
       en: Prisons
       pt: Presídios
       es: Prisiones
+      fr: Prisons
   fire-stations:
     name:
       en: Fire Stations
       pt: Corpos de bombeiros
       es: Parques de bomberos
+      fr: Casernes de pompiers
     desc:
       en: Fire Stations
       pt: Corpos de bombeiros
       es: Parques de bomberos
+      fr: Casernes de pompiers
   ambulance-stations:
     name:
       en: Ambulance Stations
       pt: Postos de ambulância
       es: Bases de ambulancias
+      fr: Bases d'ambulances
     desc:
       en: Ambulance Stations
       pt: Postos de ambulância
       es: Bases de ambulancias
+      fr: Bases d'ambulances
   emergency-phones:
     name:
       en: Emergency Phones
       pt: Telefones de emergência
       es: Teléfonos de emergencia
+      fr: Téléphones d'urgence
     desc:
       en: Emergency Phones
       pt: Telefones de emergência
       es: Teléfonos de emergencia
+      fr: Téléphones d'urgence
   fire-hydrants:
     name:
       en: Fire Hydrants
       pt: Hidrantes
       es: Hidrantes
+      fr: Bouches d'incendie
     desc:
       en: Fire Hydrants
       pt: Hidrantes
       es: Hidrantes
+      fr: Bouches d'incendie
   defibrillators:
     name:
       en: Defibrillators
       pt: Desfibriladores
       es: Desfibriladores
+      fr: Défibrillateurs
     desc:
       en: Public access defibrillators (AEDs)
       pt: Desfibriladores de acesso público (DEAs)
       es: Desfibriladores de acceso público (DEA)
+      fr: Défibrillateurs en accès public (DAE)
   waterfall:
     name:
       en: Waterfall
       pt: Cachoeiras
       es: Cascadas
+      fr: Cascades
     desc:
       en: Waterfall
       pt: Cachoeiras
       es: Cascadas
+      fr: Cascades
   dam:
     name:
       en: Dam
       pt: Barragens
       es: Presas
+      fr: Barrages
     desc:
       en: Dam
       pt: Barragens
       es: Presas
+      fr: Barrages
   recycling:
     name:
       en: Recycling
       pt: Coleta seletiva
       es: Reciclaje
+      fr: Recyclage
     desc:
       en: Recycling
       pt: Coleta seletiva
       es: Reciclaje
+      fr: Recyclage
   waste-disposal:
     name:
       en: Waste Disposal
       pt: Descarte de resíduos
       es: Eliminación de residuos
+      fr: Élimination des déchets
     desc:
       en: Waste Disposal
       pt: Descarte de resíduos
       es: Eliminación de residuos
+      fr: Élimination des déchets
   waste-basket:
     name:
       en: Waste Baskets
       pt: Lixeiras
       es: Papeleras
+      fr: Poubelles
     desc:
       en: Waste Baskets
       pt: Lixeiras
       es: Papeleras
+      fr: Poubelles
   bottle-return:
     name:
       en: Bottle Return Machines
       pt: Máquinas de retorno de garrafas
       es: Máquinas de retorno de botellas
+      fr: Machines de consigne de bouteilles
     desc:
       en: Bottle Return Machines
       pt: Máquinas de retorno de garrafas
       es: Máquinas de retorno de botellas
+      fr: Machines de consigne de bouteilles
   benches:
     name:
       en: Benches
       pt: Bancos
       es: Bancos
+      fr: Bancs
     desc:
       en: Benches
       pt: Bancos
       es: Bancos
+      fr: Bancs
   telephones:
     name:
       en: Telephones
       pt: Telefones públicos
       es: Teléfonos públicos
+      fr: Téléphones publics
     desc:
       en: Telephones
       pt: Telefones públicos
       es: Teléfonos públicos
+      fr: Téléphones publics
   supermarkets:
     name:
       en: Supermarkets
       pt: Supermercados
       es: Supermercados
+      fr: Supermarchés
     desc:
       en: Supermarkets
       pt: Supermercados
       es: Supermercados
+      fr: Supermarchés
   bakeries:
     name:
       en: Bakeries
       pt: Padarias
       es: Panaderías
+      fr: Boulangeries
     desc:
       en: Bakeries
       pt: Padarias
       es: Panaderías
+      fr: Boulangeries
   convenience:
     name:
       en: Convenience
       pt: Lojas de conveniência
       es: Tiendas de conveniencia
+      fr: Supérettes
     desc:
       en: Convenience
       pt: Lojas de conveniência
       es: Tiendas de conveniencia
+      fr: Supérettes
   butchers:
     name:
       en: Butchers
       pt: Açougue
       es: Carnicerías
+      fr: Boucheries
     desc:
       en: Butchers
       pt: Açougue
       es: Carnicerías
+      fr: Boucheries
   greengrocers:
     name:
       en: Greengrocers
       pt: Hortifrúti
       es: Fruterías
+      fr: Primeurs
     desc:
       en: Greengrocers
       pt: Hortifrúti
       es: Fruterías
+      fr: Primeurs
   department-stores:
     name:
       en: Department Stores
       pt: Lojas de departamento
       es: Grandes almacenes
+      fr: Grands magasins
     desc:
       en: Department Stores
       pt: Lojas de departamento
       es: Grandes almacenes
+      fr: Grands magasins
   shopping-malls:
     name:
       en: Shopping Malls
       pt: Shoppings
       es: Centros comerciales
+      fr: Centres commerciaux
     desc:
       en: Shopping Malls
       pt: Shoppings
       es: Centros comerciales
+      fr: Centres commerciaux
   clothes:
     name:
       en: Clothes
       pt: Lojas de roupas
       es: Tiendas de ropa
+      fr: Magasins de vêtements
     desc:
       en: Clothes
       pt: Lojas de roupas
       es: Tiendas de ropa
+      fr: Magasins de vêtements
   chemist:
     name:
       en: Chemist
       pt: Farmácia
       es: Farmacia
+      fr: Drogueries
     desc:
       en: Chemist
       pt: Farmácia
       es: Farmacia
+      fr: Drogueries
   fuel:
     name:
       en: Fuel
       pt: Postos de combustível
       es: Estaciones de servicio
+      fr: Stations-service
     desc:
       en: Fuel
       pt: Postos de combustível
       es: Estaciones de servicio
+      fr: Stations-service
   hardware:
     name:
       en: Hardware
       pt: Lojas de ferragens
       es: Ferreterías
+      fr: Quincailleries
     desc:
       en: Hardware
       pt: Lojas de ferragens
       es: Ferreterías
+      fr: Quincailleries
   diy:
     name:
       en: Diy
       pt: Lojas de construção
       es: Tiendas de bricolaje
+      fr: Magasins de bricolage
     desc:
       en: Diy
       pt: Lojas de construção
       es: Tiendas de bricolaje
+      fr: Magasins de bricolage
   furniture:
     name:
       en: Furniture
       pt: Móveis
       es: Muebles
+      fr: Meubles
     desc:
       en: Furniture
       pt: Móveis
       es: Muebles
+      fr: Meubles
   electronics:
     name:
       en: Electronics
       pt: Eletrônicos
       es: Electrónicos
+      fr: Électronique
     desc:
       en: Electronics
       pt: Eletrônicos
       es: Electrónicos
+      fr: Électronique
   mobile-phone:
     name:
       en: Mobile Phone
       pt: Celulares
       es: Teléfonos móviles
+      fr: Téléphones mobiles
     desc:
       en: Mobile Phone
       pt: Celulares
       es: Teléfonos móviles
+      fr: Téléphones mobiles
   shoes:
     name:
       en: Shoes
       pt: Calçados
       es: Calzado
+      fr: Chaussures
     desc:
       en: Shoes
       pt: Calçados
       es: Calzado
+      fr: Chaussures
   jewelry:
     name:
       en: Jewelry
       pt: Joalherias
       es: Joyerías
+      fr: Bijouteries
     desc:
       en: Jewelry
       pt: Joalherias
       es: Joyerías
+      fr: Bijouteries
   restaurants:
     name:
       en: Restaurants
       pt: Restaurantes
       es: Restaurantes
+      fr: Restaurants
     desc:
       en: Restaurants
       pt: Restaurantes
       es: Restaurantes
+      fr: Restaurants
   cafes:
     name:
       en: Cafes
       pt: Cafés
       es: Cafeterías
+      fr: Cafés
     desc:
       en: Cafes
       pt: Cafés
       es: Cafeterías
+      fr: Cafés
   fast-food:
     name:
       en: Fast Food
       pt: Fast food
       es: Comida rápida
+      fr: Restauration rapide
     desc:
       en: Fast Food
       pt: Fast food
       es: Comida rápida
+      fr: Restauration rapide
   bars:
     name:
       en: Bars
       pt: Bares
       es: Bares
+      fr: Bars
     desc:
       en: Bars
       pt: Bares
       es: Bares
+      fr: Bars
   pubs:
     name:
       en: Pubs
       pt: Pubs
       es: Pubs
+      fr: Pubs
     desc:
       en: Pubs
       pt: Pubs
       es: Pubs
+      fr: Pubs
   ice-cream:
     name:
       en: Ice Cream
       pt: Sorveterias
       es: Heladerías
+      fr: Marchands de glaces
     desc:
       en: Ice Cream
       pt: Sorveterias
       es: Heladerías
+      fr: Marchands de glaces
   food-court:
     name:
       en: Food Courts
       pt: Praças de alimentação
       es: Patios de comidas
+      fr: Aires de restauration
     desc:
       en: Food Courts
       pt: Praças de alimentação
       es: Patios de comidas
+      fr: Aires de restauration
   food-vending:
     name:
       en: Food & Drink Vending
       pt: Vending machines de alimentos
       es: Máquinas expendedoras de alimentos
+      fr: Distributeurs de nourriture et boissons
     desc:
       en: Food & Drink Vending
       pt: Vending machines de alimentos
       es: Máquinas expendedoras de alimentos
+      fr: Distributeurs de nourriture et boissons
   parks:
     name:
       en: Parks
       pt: Parques
       es: Parques
+      fr: Parcs
     desc:
       en: Parks
       pt: Parques
       es: Parques
+      fr: Parcs
   playgrounds:
     name:
       en: Playgrounds
       pt: Playgrounds
       es: Parques infantiles
+      fr: Aires de jeux
     desc:
       en: Playgrounds
       pt: Playgrounds
       es: Parques infantiles
+      fr: Aires de jeux
   gardens:
     name:
       en: Gardens
       pt: Jardins
       es: Jardines
+      fr: Jardins
     desc:
       en: Gardens
       pt: Jardins
       es: Jardines
+      fr: Jardins
   fitness-centers:
     name:
       en: Fitness Centers
       pt: Academias
       es: Gimnasios
+      fr: Salles de sport
     desc:
       en: Fitness Centers
       pt: Academias
       es: Gimnasios
+      fr: Salles de sport
   swimming-pools:
     name:
       en: Swimming Pools
       pt: Piscinas
       es: Piscinas
+      fr: Piscines
     desc:
       en: Swimming Pools
       pt: Piscinas
       es: Piscinas
+      fr: Piscines
   sports-centres:
     name:
       en: Sports Centres
       pt: Centros esportivos
       es: Centros deportivos
+      fr: Centres sportifs
     desc:
       en: Sports Centres
       pt: Centros esportivos
       es: Centros deportivos
+      fr: Centres sportifs
   stadiums:
     name:
       en: Stadiums
       pt: Estádios
       es: Estadios
+      fr: Stades
     desc:
       en: Stadiums
       pt: Estádios
       es: Estadios
+      fr: Stades
   pitches:
     name:
       en: Pitches
       pt: Campos esportivos
       es: Campos deportivos
+      fr: Terrains de sport
     desc:
       en: Pitches
       pt: Campos esportivos
       es: Campos deportivos
+      fr: Terrains de sport
   golf-courses:
     name:
       en: Golf Courses
       pt: Campos de golfe
       es: Campos de golf
+      fr: Terrains de golf
     desc:
       en: Golf Courses
       pt: Campos de golfe
       es: Campos de golf
+      fr: Terrains de golf
   tracks:
     name:
       en: Tracks
       pt: Pistas de atletismo
       es: Pistas de atletismo
+      fr: Pistes d'athlétisme
     desc:
       en: Tracks
       pt: Pistas de atletismo
       es: Pistas de atletismo
+      fr: Pistes d'athlétisme
   fitness-stations:
     name:
       en: Fitness Stations
       pt: Estações de ginástica
       es: Estaciones de ejercicio
+      fr: Aires de fitness
     desc:
       en: Fitness Stations
       pt: Estações de ginástica
       es: Estaciones de ejercicio
+      fr: Aires de fitness
   ice-rinks:
     name:
       en: Ice Rinks
       pt: Pistas de gelo
       es: Pistas de hielo
+      fr: Patinoires
     desc:
       en: Ice Rinks
       pt: Pistas de gelo
       es: Pistas de hielo
+      fr: Patinoires
   nature-reserves:
     name:
       en: Nature Reserves
       pt: Reservas naturais
       es: Reservas naturales
+      fr: Réserves naturelles
     desc:
       en: Nature Reserves
       pt: Reservas naturais
       es: Reservas naturales
+      fr: Réserves naturelles
   marinas:
     name:
       en: Marinas
       pt: Marinas
       es: Marinas
+      fr: Ports de plaisance
     desc:
       en: Marinas
       pt: Marinas
       es: Marinas
+      fr: Ports de plaisance
   dog-parks:
     name:
       en: Dog Parks
       pt: Parques para cães
       es: Parques para perros
+      fr: Parcs canins
     desc:
       en: Dog Parks
       pt: Parques para cães
       es: Parques para perros
+      fr: Parcs canins
   urban-trees:
     name:
       en: Urban Trees
       pt: Árvores urbanas
       es: Árboles urbanos
+      fr: Arbres urbains
     desc:
       en: Urban Trees
       pt: Árvores urbanas
       es: Árboles urbanos
+      fr: Arbres urbains
   street-trees:
     name:
       en: Street Trees
       pt: Árvores de rua
       es: Árboles callejeros
+      fr: Arbres d'alignement
     desc:
       en: Street Trees
       pt: Árvores de rua
       es: Árboles callejeros
+      fr: Arbres d'alignement
   managed-green:
     name:
       en: Managed Green
       pt: Áreas verdes planejadas
       es: Áreas verdes planificadas
+      fr: Espaces verts aménagés
     desc:
       en: Managed Green
       pt: Áreas verdes planejadas
       es: Áreas verdes planificadas
+      fr: Espaces verts aménagés
   natural-vegetation:
     name:
       en: Natural Vegetation
       pt: Vegetação natural
       es: Vegetación natural
+      fr: Végétation naturelle
     desc:
       en: Natural Vegetation
       pt: Vegetação natural
       es: Vegetación natural
+      fr: Végétation naturelle
   forests:
     name:
       en: Forests
       pt: Florestas
       es: Bosques
+      fr: Forêts
     desc:
       en: Forests
       pt: Florestas
       es: Bosques
+      fr: Forêts
   woods:
     name:
       en: Woods
       pt: Bosques
       es: Bosques
+      fr: Bois
     desc:
       en: Woods
       pt: Bosques
       es: Bosques
+      fr: Bois
   orchards:
     name:
       en: Orchards
       pt: Pomares
       es: Huertos
+      fr: Vergers
     desc:
       en: Orchards
       pt: Pomares
       es: Huertos
+      fr: Vergers
   grasslands:
     name:
       en: Grasslands
       pt: Pastagens
       es: Pastizales
+      fr: Prairies naturelles
     desc:
       en: Grasslands
       pt: Pastagens
       es: Pastizales
+      fr: Prairies naturelles
   wetlands:
     name:
       en: Wetlands
       pt: Áreas úmidas
       es: Humedales
+      fr: Zones humides
     desc:
       en: Wetlands
       pt: Áreas úmidas
       es: Humedales
+      fr: Zones humides
   beaches:
     name:
       en: Beaches
       pt: Praias
       es: Playas
+      fr: Plages
     desc:
       en: Beaches
       pt: Praias
       es: Playas
+      fr: Plages
   peaks:
     name:
       en: Peaks
       pt: Picos
       es: Picos
+      fr: Sommets
     desc:
       en: Peaks
       pt: Picos
       es: Picos
+      fr: Sommets
   cliffs:
     name:
       en: Cliffs
       pt: Penhasco
       es: Acantilados
+      fr: Falaises
     desc:
       en: Cliffs
       pt: Penhasco
       es: Acantilados
+      fr: Falaises
   caves:
     name:
       en: Caves
       pt: Cavernas
       es: Cuevas
+      fr: Grottes
     desc:
       en: Caves
       pt: Cavernas
       es: Cuevas
+      fr: Grottes
   water:
     name:
       en: Water
       pt: Água
       es: Agua
+      fr: Eau
     desc:
       en: Water
       pt: Água
       es: Agua
+      fr: Eau
   coastlines:
     name:
       en: Coastlines
       pt: Linha costeira
       es: Litorales
+      fr: Littoral
     desc:
       en: Coastlines
       pt: Linha costeira
       es: Litorales
+      fr: Littoral
   springs:
     name:
       en: Springs
       pt: Nascentes
       es: Fuentes
+      fr: Sources
     desc:
       en: Springs
       pt: Nascentes
       es: Fuentes
+      fr: Sources
   hot-springs:
     name:
       en: Hot Springs
       pt: Fontes termais
       es: Aguas termales
+      fr: Sources chaudes
     desc:
       en: Hot Springs
       pt: Fontes termais
       es: Aguas termales
+      fr: Sources chaudes
   geyser:
     name:
       en: Geyser
       pt: Gêiseres
       es: Géiseres
+      fr: Geysers
     desc:
       en: Geyser
       pt: Gêiseres
       es: Géiseres
+      fr: Geysers
   glaciers:
     name:
       en: Glaciers
       pt: Geleiras
       es: Glaciares
+      fr: Glaciers
     desc:
       en: Glaciers
       pt: Geleiras
       es: Glaciares
+      fr: Glaciers
   natural-surfaces:
     name:
       en: Natural Surfaces
       pt: Superfícies naturais
       es: Superficies naturales
+      fr: Surfaces naturelles
     desc:
       en: Natural Surfaces
       pt: Superfícies naturais
       es: Superficies naturales
+      fr: Surfaces naturelles
   scrub:
     name:
       en: Scrub
       pt: Vegetação rasteira
       es: Matorral
+      fr: Broussailles
     desc:
       en: Scrub
       pt: Vegetação rasteira
       es: Matorral
+      fr: Broussailles
   heath:
     name:
       en: Heath
       pt: Charneca
       es: Brezal
+      fr: Lande
     desc:
       en: Heath
       pt: Charneca
       es: Brezal
+      fr: Lande
   fell:
     name:
       en: Fell
       pt: Colina
       es: Monte
+      fr: Pelouse alpine
     desc:
       en: Fell
       pt: Colina
       es: Monte
+      fr: Pelouse alpine
   rock:
     name:
       en: Rock
       pt: Rocha
       es: Roca
+      fr: Roche
     desc:
       en: Rock
       pt: Rocha
       es: Roca
+      fr: Roche
   stone:
     name:
       en: Stone
       pt: Pedra
       es: Piedra
+      fr: Pierre
     desc:
       en: Stone
       pt: Pedra
       es: Piedra
+      fr: Pierre
   sand:
     name:
       en: Sand
       pt: Areia
       es: Arena
+      fr: Sable
     desc:
       en: Sand
       pt: Areia
       es: Arena
+      fr: Sable
   shingle:
     name:
       en: Shingle
       pt: Cascalho
       es: Guijarros
+      fr: Galets
     desc:
       en: Shingle
       pt: Cascalho
       es: Guijarros
+      fr: Galets
   mud:
     name:
       en: Mud
       pt: Lama
       es: Barro
+      fr: Boue
     desc:
       en: Mud
       pt: Lama
       es: Barro
+      fr: Boue
   street-lamps:
     name:
       en: Street Lamps
       pt: Postes de iluminação
       es: Farolas
+      fr: Lampadaires
     desc:
       en: Street Lamps
       pt: Postes de iluminação
       es: Farolas
+      fr: Lampadaires
   surveillance:
     name:
       en: Surveillance
       pt: Câmeras de vigilância
       es: Cámaras de vigilancia
+      fr: Caméras de surveillance
     desc:
       en: Surveillance
       pt: Câmeras de vigilância
       es: Cámaras de vigilancia
+      fr: Caméras de surveillance
   tailings-pond:
     name:
       en: Tailings Pond
       pt: Barragem de rejeitos
       es: Balsa de residuos mineros
+      fr: Bassin de résidus miniers
     desc:
       en: Mining tailings storage infrastructure
       pt: Infraestrutura de armazenamento de rejeitos de mineração
       es: Infraestructura de almacenamiento de residuos mineros
+      fr: Infrastructure de stockage de résidus miniers
   tower:
     name:
       en: Tower
       pt: Torres
       es: Torres
+      fr: Tours
     desc:
       en: Tower
       pt: Torres
       es: Torres
+      fr: Tours
   communications-tower:
     name:
       en: Communications Tower
       pt: Torre de comunicações
       es: Torre de comunicaciones
+      fr: Tour de télécommunications
     desc:
       en: Communications Tower
       pt: Torre de comunicações
       es: Torre de comunicaciones
+      fr: Tour de télécommunications
   water-tower:
     name:
       en: Water Tower
       pt: Caixa d'água
       es: Depósito de agua
+      fr: Château d'eau
     desc:
       en: Water Tower
       pt: Caixa d'água
       es: Depósito de agua
+      fr: Château d'eau
   storage-tanks:
     name:
       en: Storage Tanks
       pt: Tanques de armazenamento
       es: Depósitos
+      fr: Réservoirs de stockage
     desc:
       en: Storage Tanks
       pt: Tanques de armazenamento
       es: Depósitos
+      fr: Réservoirs de stockage
   chimney:
     name:
       en: Chimney
       pt: Chaminés
       es: Chimeneas
+      fr: Cheminées
     desc:
       en: Chimney
       pt: Chaminés
       es: Chimeneas
+      fr: Cheminées
   pipeline:
     name:
       en: Pipeline
       pt: Dutos
       es: Tuberías
+      fr: Canalisations
     desc:
       en: Pipeline
       pt: Dutos
       es: Tuberías
+      fr: Canalisations
   mast:
     name:
       en: Mast
       pt: Mastros
       es: Mástiles
+      fr: Mâts
     desc:
       en: Mast
       pt: Mastros
       es: Mástiles
+      fr: Mâts
   water-works:
     name:
       en: Water Works
       pt: Estação de tratamento de água
       es: Estación de tratamiento de agua
+      fr: Station de traitement de l'eau
     desc:
       en: Water Works
       pt: Estação de tratamento de água
       es: Estación de tratamiento de agua
+      fr: Station de traitement de l'eau
   wastewater-plant:
     name:
       en: Wastewater Plant
       pt: Estação de tratamento de esgoto
       es: Estación de tratamiento de aguas residuales
+      fr: Station d'épuration
     desc:
       en: Wastewater Plant
       pt: Estação de tratamento de esgoto
       es: Estación de tratamiento de aguas residuales
+      fr: Station d'épuration
   pumping-station:
     name:
       en: Pumping Station
       pt: Estação de bombeamento
       es: Estación de bombeo
+      fr: Station de pompage
     desc:
       en: Pumping Station
       pt: Estação de bombeamento
       es: Estación de bombeo
+      fr: Station de pompage
   utility-pole:
     name:
       en: Utility Pole
       pt: Postes de rede
       es: Postes de servicios
+      fr: Poteaux de réseau
     desc:
       en: Utility Pole
       pt: Postes de rede
       es: Postes de servicios
+      fr: Poteaux de réseau
   roads:
     name:
       en: Roads
       pt: Vias
       es: Carreteras
+      fr: Routes
     desc:
       en: Roads
       pt: Vias
       es: Carreteras
+      fr: Routes
   footways:
     name:
       en: Footways
       pt: Calçadas e trilhas
       es: Aceras y senderos
+      fr: Trottoirs et sentiers
     desc:
       en: Footways
       pt: Calçadas e trilhas
       es: Aceras y senderos
+      fr: Trottoirs et sentiers
   cycleways:
     name:
       en: Cycleways
       pt: Ciclovias
       es: Carriles bici
+      fr: Pistes cyclables
     desc:
       en: Cycleways
       pt: Ciclovias
       es: Carriles bici
+      fr: Pistes cyclables
   bridges:
     name:
       en: Bridges
       pt: Pontes
       es: Puentes
+      fr: Ponts
     desc:
       en: Bridges
       pt: Pontes
       es: Puentes
+      fr: Ponts
   tunnels:
     name:
       en: Tunnels
       pt: Túneis
       es: Túneles
+      fr: Tunnels
     desc:
       en: Tunnels
       pt: Túneis
       es: Túneles
+      fr: Tunnels
   crossings:
     name:
       en: Crossings
       pt: Faixas de pedestres
       es: Pasos de peatones
+      fr: Passages piétons
     desc:
       en: Crossings
       pt: Faixas de pedestres
       es: Pasos de peatones
+      fr: Passages piétons
   traffic-signs:
     name:
       en: Traffic Signs
       pt: Placas de trânsito
       es: Señales de tráfico
+      fr: Panneaux de signalisation
     desc:
       en: Traffic Signs
       pt: Placas de trânsito
       es: Señales de tráfico
+      fr: Panneaux de signalisation
   traffic-lights:
     name:
       en: Traffic Lights
       pt: Semáforos
       es: Semáforos
+      fr: Feux de circulation
     desc:
       en: Traffic Lights
       pt: Semáforos
       es: Semáforos
+      fr: Feux de circulation
   speed-cameras:
     name:
       en: Speed Cameras
       pt: Radares
       es: Radares
+      fr: Radars
     desc:
       en: Speed Cameras
       pt: Radares
       es: Radares
+      fr: Radars
   traffic-calming:
     name:
       en: Traffic Calming
       pt: Medidas de acalmamento de tráfego
       es: Pacificación de tráfico
+      fr: Modération du trafic
     desc:
       en: Traffic Calming
       pt: Medidas de acalmamento de tráfego
       es: Pacificación de tráfico
+      fr: Modération du trafic
   apartments:
     name:
       en: Apartments
       pt: Apartamentos
       es: Apartamentos
+      fr: Appartements
     desc:
       en: Apartments
       pt: Apartamentos
       es: Apartamentos
+      fr: Appartements
   houses:
     name:
       en: Houses
       pt: Casas
       es: Casas
+      fr: Maisons
     desc:
       en: Houses
       pt: Casas
       es: Casas
+      fr: Maisons
   residential:
     name:
       en: Residential
       pt: Área residencial
       es: Zona residencial
+      fr: Zone résidentielle
     desc:
       en: Residential
       pt: Área residencial
       es: Zona residencial
+      fr: Zone résidentielle
   dormitories:
     name:
       en: Dormitories
       pt: Alojamentos
       es: Residencias estudiantiles
+      fr: Résidences étudiantes
     desc:
       en: Dormitories
       pt: Alojamentos
       es: Residencias estudiantiles
+      fr: Résidences étudiantes
   hotel-guesthouse:
     name:
       en: Hotel Guesthouse
       pt: Hotéis e pousadas
       es: Hoteles y hostales
+      fr: Hôtels et maisons d'hôtes
     desc:
       en: Hotel Guesthouse
       pt: Hotéis e pousadas
       es: Hoteles y hostales
+      fr: Hôtels et maisons d'hôtes
   football:
     name:
       en: Football
       pt: Futebol
       es: Fútbol
+      fr: Football
     desc:
       en: Football
       pt: Futebol
       es: Fútbol
+      fr: Football
   basketball:
     name:
       en: Basketball
       pt: Basquete
       es: Baloncesto
+      fr: Basket-ball
     desc:
       en: Basketball
       pt: Basquete
       es: Baloncesto
+      fr: Basket-ball
   tennis:
     name:
       en: Tennis
       pt: Tênis
       es: Tenis
+      fr: Tennis
     desc:
       en: Tennis
       pt: Tênis
       es: Tenis
+      fr: Tennis
   swimming:
     name:
       en: Swimming
       pt: Natação
       es: Natación
+      fr: Natation
     desc:
       en: Swimming
       pt: Natação
       es: Natación
+      fr: Natation
   golf:
     name:
       en: Golf
       pt: Golfe
       es: Golf
+      fr: Golf
     desc:
       en: Golf
       pt: Golfe
       es: Golf
+      fr: Golf
   skiing:
     name:
       en: Skiing
       pt: Esqui
       es: Esquí
+      fr: Ski
     desc:
       en: Skiing
       pt: Esqui
       es: Esquí
+      fr: Ski
   baseball:
     name:
       en: Baseball
       pt: Beisebol
       es: Béisbol
+      fr: Baseball
     desc:
       en: Baseball
       pt: Beisebol
       es: Béisbol
+      fr: Baseball
   athletics:
     name:
       en: Athletics
       pt: Atletismo
       es: Atletismo
+      fr: Athlétisme
     desc:
       en: Athletics
       pt: Atletismo
       es: Atletismo
+      fr: Athlétisme
   gymnasiums:
     name:
       en: Gymnasiums
       pt: Ginásios
       es: Gimnasios
+      fr: Gymnases
     desc:
       en: Gymnasiums
       pt: Ginásios
       es: Gimnasios
+      fr: Gymnases
   shooting:
     name:
       en: Shooting
       pt: Tiro esportivo
       es: Tiro deportivo
+      fr: Tir sportif
     desc:
       en: Shooting
       pt: Tiro esportivo
       es: Tiro deportivo
+      fr: Tir sportif
   archery:
     name:
       en: Archery
       pt: Arco e flecha
       es: Tiro con arco
+      fr: Tir à l'arc
     desc:
       en: Archery
       pt: Arco e flecha
       es: Tiro con arco
+      fr: Tir à l'arc
   climbing:
     name:
       en: Climbing
       pt: Escalada
       es: Escalada
+      fr: Escalade
     desc:
       en: Climbing
       pt: Escalada
       es: Escalada
+      fr: Escalade
   equestrian:
     name:
       en: Equestrian
       pt: Equitação
       es: Hípica
+      fr: Équitation
     desc:
       en: Equestrian
       pt: Equitação
       es: Hípica
+      fr: Équitation
   fountains:
     name:
       en: Fountains
       pt: Fontes
       es: Fuentes
+      fr: Fontaines
     desc:
       en: Fountains
       pt: Fontes
       es: Fuentes
+      fr: Fontaines
   clocks:
     name:
       en: Clocks
       pt: Relógios públicos
       es: Relojes públicos
+      fr: Horloges publiques
     desc:
       en: Clocks
       pt: Relógios públicos
       es: Relojes públicos
+      fr: Horloges publiques
   information-boards:
     name:
       en: Wayfinding & Information
       pt: Sinalização e informação
       es: Señalización e información
+      fr: Signalétique et information
     desc:
       en: Wayfinding & Information
       pt: Sinalização e informação
       es: Señalización e información
+      fr: Signalétique et information
   places-of-worship:
     name:
       en: Places Of Worship
       pt: Locais de culto
       es: Lugares de culto
+      fr: Lieux de culte
     desc:
       en: Places Of Worship
       pt: Locais de culto
       es: Lugares de culto
+      fr: Lieux de culte
   walls:
     name:
       en: Walls
       pt: Muros
       es: Muros
+      fr: Murs
     desc:
       en: Walls
       pt: Muros
       es: Muros
+      fr: Murs
   fences:
     name:
       en: Fences
       pt: Cercas
       es: Vallas
+      fr: Clôtures
     desc:
       en: Fences
       pt: Cercas
       es: Vallas
+      fr: Clôtures
   hedges:
     name:
       en: Hedges
       pt: Cercas vivas
       es: Setos
+      fr: Haies
     desc:
       en: Hedges
       pt: Cercas vivas
       es: Setos
+      fr: Haies
   gates:
     name:
       en: Gates
       pt: Portões
       es: Portones
+      fr: Portails
     desc:
       en: Gates
       pt: Portões
       es: Portones
+      fr: Portails
   farmland:
     name:
       en: Farmland
       pt: Área agrícola
       es: Tierra agrícola
+      fr: Terres agricoles
     desc:
       en: Farmland
       pt: Área agrícola
       es: Tierra agrícola
+      fr: Terres agricoles
   farmyards:
     name:
       en: Farmyards
       pt: Pátios de fazenda
       es: Patios de granja
+      fr: Cours de ferme
     desc:
       en: Farmyards
       pt: Pátios de fazenda
       es: Patios de granja
+      fr: Cours de ferme
   meadows:
     name:
       en: Meadows
       pt: Prados
       es: Praderas
+      fr: Prés
     desc:
       en: Meadows
       pt: Prados
       es: Praderas
+      fr: Prés
   animal-keeping:
     name:
       en: Animal Keeping
       pt: Criação de animais
       es: Cría de animales
+      fr: Élevage d'animaux
     desc:
       en: Land use for animal keeping
       pt: Uso do solo para criação de animais
       es: Uso del suelo para cría de animales
+      fr: Terrains dédiés à l'élevage d'animaux
   feedlots:
     name:
       en: Feedlots
       pt: Currais de engorda
       es: Feedlots
+      fr: Parcs d'engraissement
     desc:
       en: Feedlot infrastructure
       pt: Infraestrutura de currais de engorda
       es: Infraestructura de feedlots
+      fr: Infrastructure de parcs d'engraissement
   stockyards:
     name:
       en: Stockyards
       pt: Currais de gado
       es: Corrales de ganado
+      fr: Parcs à bestiaux
     desc:
       en: Livestock handling infrastructure
       pt: Infraestrutura de manejo de gado
       es: Infraestructura de manejo de ganado
+      fr: Infrastructure de gestion du bétail
   poultry-yards:
     name:
       en: Poultry Yards
       pt: Avicultura
       es: Corrales de aves
+      fr: Élevages de volailles
     desc:
       en: Poultry farming infrastructure
       pt: Infraestrutura de avicultura
       es: Infraestructura de avicultura
+      fr: Infrastructure d'élevage de volailles
   dairy-yards:
     name:
       en: Dairy Yards
       pt: Laticínios
       es: Instalaciones lecheras
+      fr: Installations laitières
     desc:
       en: Dairy farming infrastructure
       pt: Infraestrutura de laticínios
       es: Infraestructura lechera
+      fr: Infrastructure d'élevage laitier
   barns:
     name:
       en: Barns
       pt: Celeiros
       es: Graneros
+      fr: Granges
     desc:
       en: Barns
       pt: Celeiros
       es: Graneros
+      fr: Granges
   agricultural-buildings:
     name:
       en: Agricultural Buildings
       pt: Construções agrícolas
       es: Edificios agrícolas
+      fr: Bâtiments agricoles
     desc:
       en: Agricultural Buildings
       pt: Construções agrícolas
       es: Edificios agrícolas
+      fr: Bâtiments agricoles
   farm-auxiliary:
     name:
       en: Farm Auxiliary
       pt: Instalações auxiliares de fazenda
       es: Instalaciones auxiliares de granja
+      fr: Installations agricoles auxiliaires
     desc:
       en: Farm Auxiliary
       pt: Instalações auxiliares de fazenda
       es: Instalaciones auxiliares de granja
+      fr: Installations agricoles auxiliaires
   greenhouses:
     name:
       en: Greenhouses
       pt: Estufas
       es: Invernaderos
+      fr: Serres
     desc:
       en: Greenhouses
       pt: Estufas
       es: Invernaderos
+      fr: Serres
   livestock-buildings:
     name:
       en: Livestock Buildings
       pt: Construções para criação de animais
       es: Edificios para ganado
+      fr: Bâtiments d'élevage
     desc:
       en: Livestock Buildings
       pt: Construções para criação de animais
       es: Edificios para ganado
+      fr: Bâtiments d'élevage
   cowsheds:
     name:
       en: Cowsheds
       pt: Estábulos para gado
       es: Establos para vacas
+      fr: Étables
     desc:
       en: Cowsheds
       pt: Estábulos para gado
       es: Establos para vacas
+      fr: Étables
   pig-sties:
     name:
       en: Pig Sties
       pt: Chiqueiros
       es: Porquerizas
+      fr: Porcheries
     desc:
       en: Pig Sties
       pt: Chiqueiros
       es: Porquerizas
+      fr: Porcheries
   stables:
     name:
       en: Stables
       pt: Estábulos
       es: Establos
+      fr: Écuries
     desc:
       en: Stables
       pt: Estábulos
       es: Establos
+      fr: Écuries
   silos:
     name:
       en: Silos
       pt: Silos
       es: Silos
+      fr: Silos
     desc:
       en: Silos
       pt: Silos
       es: Silos
+      fr: Silos
   bunker-silos:
     name:
       en: Bunker Silos
       pt: Silos tipo bunker
       es: Silos tipo búnker
+      fr: Silos-couloirs
     desc:
       en: Bunker Silos
       pt: Silos tipo bunker
       es: Silos tipo búnker
+      fr: Silos-couloirs
   agricultural-tanks:
     name:
       en: Agricultural Tanks
       pt: Tanques agrícolas
       es: Depósitos agrícolas
+      fr: Cuves agricoles
     desc:
       en: Agricultural Tanks
       pt: Tanques agrícolas
       es: Depósitos agrícolas
+      fr: Cuves agricoles
   slurry-basins:
     name:
       en: Slurry Basins
       pt: Bacias de esterco
       es: Balsas de purín
+      fr: Bassins à lisier
     desc:
       en: Agricultural slurry storage infrastructure
       pt: Infraestrutura de armazenamento de esterco
       es: Infraestructura de almacenamiento de purín
+      fr: Infrastructure de stockage de lisier
   slurry-tanks:
     name:
       en: Slurry Tanks
       pt: Tanques de esterco
       es: Depósitos de purín
+      fr: Cuves à lisier
     desc:
       en: Agricultural slurry storage infrastructure
       pt: Infraestrutura de armazenamento de esterco
       es: Infraestructura de almacenamiento de purín
+      fr: Infrastructure de stockage de lisier
   manure-storage:
     name:
       en: Manure Storage
       pt: Armazenamento de esterco
       es: Almacenamiento de estiércol
+      fr: Stockage de fumier
     desc:
       en: Manure storage infrastructure
       pt: Infraestrutura de armazenamento de esterco
       es: Infraestructura de almacenamiento de estiércol
+      fr: Infrastructure de stockage de fumier
   greenhouse-horticulture:
     name:
       en: Greenhouse Horticulture
       pt: Horticultura em estufa
       es: Horticultura en invernadero
+      fr: Horticulture sous serre
     desc:
       en: Greenhouse Horticulture
       pt: Horticultura em estufa
       es: Horticultura en invernadero
+      fr: Horticulture sous serre
   plant-nurseries:
     name:
       en: Plant Nurseries
       pt: Viveiros de plantas
       es: Viveros de plantas
+      fr: Pépinières
     desc:
       en: Plant Nurseries
       pt: Viveiros de plantas
       es: Viveros de plantas
+      fr: Pépinières
   trees-with-species:
     name:
       en: Trees With Species
       pt: Árvores com espécie identificada
       es: Árboles con especie identificada
+      fr: Arbres avec espèce identifiée
     desc:
       en: Trees With Species
       pt: Árvores com espécie identificada
       es: Árboles con especie identificada
+      fr: Arbres avec espèce identifiée
   irrigated-green:
     name:
       en: Irrigated Green
       pt: Áreas verdes irrigadas
       es: Áreas verdes regadas
+      fr: Espaces verts irrigués
     desc:
       en: Irrigated Green
       pt: Áreas verdes irrigadas
       es: Áreas verdes regadas
+      fr: Espaces verts irrigués
   vegetation-risk-context:
     name:
       en: Vegetation Risk Context
       pt: Contexto de vegetação para planejamento
       es: Contexto de vegetación para planificación
+      fr: Contexte de végétation pour la planification
     desc:
       en: Vegetation context for emergency planning
       pt: Contexto de vegetação para planejamento de emergência
       es: Contexto de vegetación para planificación de emergencias
+      fr: Contexte de végétation pour la planification d'urgence

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { SUPPORTED_LOCALES } from "@/lib/constants";
+import { AVAILABLE_LOCALES } from "@/i18n/constants";
 import { buildLocaleUrls } from "@/lib/utils";
 import { DEFAULT_SEO } from "@/lib/metadata";
 
@@ -15,7 +15,7 @@ const PUBLIC_ROUTES = ["/", "/about"];
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [];
 
-  for (const locale of SUPPORTED_LOCALES) {
+  for (const locale of AVAILABLE_LOCALES) {
     for (const route of PUBLIC_ROUTES) {
       staticPages.push({
         url: `${siteUrl}/${locale}${route}`,

--- a/src/i18n/constants.ts
+++ b/src/i18n/constants.ts
@@ -1,9 +1,10 @@
-export const AVAILABLE_LOCALES = ["en", "pt-BR", "es"] as const;
+export const AVAILABLE_LOCALES = ["en", "pt-BR", "es", "fr"] as const;
 
 export const LOCALE_DISPLAY_NAMES = {
   en: "English",
   "pt-BR": "Português (Brasil)",
   es: "Español",
+  fr: "Français",
 } as const;
 
 export type AvailableLocale = keyof typeof LOCALE_DISPLAY_NAMES;

--- a/src/lib/__tests__/metadata.test.ts
+++ b/src/lib/__tests__/metadata.test.ts
@@ -67,6 +67,7 @@ describe("getLocalizedMetadata", () => {
         en: `${siteUrl}/en/about`,
         "pt-BR": `${siteUrl}/pt-BR/about`,
         es: `${siteUrl}/es/about`,
+        fr: `${siteUrl}/fr/about`,
       });
     });
   });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,3 @@
-import { AVAILABLE_LOCALES } from "@/i18n/constants";
-
 export const GITHUB_REPO_URL = "https://github.com/osmforcities/osmforcities";
 
 /** Maximum number of datasets a user can save */
@@ -41,9 +39,6 @@ export const AREA_BOUNDS_MAX_SPAN_DEG = 0.25;
 
 /** Days before stored area info (name, bounds, center, countryCode) is refreshed on view */
 export const AREA_INFO_TTL_DAYS = 30;
-
-/** Supported locales for translations */
-export const SUPPORTED_LOCALES = AVAILABLE_LOCALES;
 
 /** Map app locale to YML file locale key (YML uses 'pt' not 'pt-BR') */
 export const YML_LOCALE_MAP: Record<string, string> = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { AVAILABLE_LOCALES } from "@/i18n/constants";
+
 export const GITHUB_REPO_URL = "https://github.com/osmforcities/osmforcities";
 
 /** Maximum number of datasets a user can save */
@@ -41,7 +43,7 @@ export const AREA_BOUNDS_MAX_SPAN_DEG = 0.25;
 export const AREA_INFO_TTL_DAYS = 30;
 
 /** Supported locales for translations */
-export const SUPPORTED_LOCALES = ["en", "pt-BR", "es", "fr"] as const;
+export const SUPPORTED_LOCALES = AVAILABLE_LOCALES;
 
 /** Map app locale to YML file locale key (YML uses 'pt' not 'pt-BR') */
 export const YML_LOCALE_MAP: Record<string, string> = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,11 +41,12 @@ export const AREA_BOUNDS_MAX_SPAN_DEG = 0.25;
 export const AREA_INFO_TTL_DAYS = 30;
 
 /** Supported locales for translations */
-export const SUPPORTED_LOCALES = ["en", "pt-BR", "es"] as const;
+export const SUPPORTED_LOCALES = ["en", "pt-BR", "es", "fr"] as const;
 
 /** Map app locale to YML file locale key (YML uses 'pt' not 'pt-BR') */
 export const YML_LOCALE_MAP: Record<string, string> = {
   "pt-BR": "pt",
   en: "en",
   es: "es",
+  fr: "fr",
 };

--- a/src/lib/email-i18n.ts
+++ b/src/lib/email-i18n.ts
@@ -8,7 +8,7 @@ import path from "path";
 import { createTranslator } from "use-intl/core";
 
 /** Supported locales for emails. */
-export type Locale = "en" | "pt-BR" | "es";
+export type Locale = "en" | "pt-BR" | "es" | "fr";
 
 /** Shared HTML style for email links. */
 export const EMAIL_LINK_STYLE = 'style="color: #007bff; text-decoration: none;"';

--- a/src/lib/email-i18n.ts
+++ b/src/lib/email-i18n.ts
@@ -6,9 +6,10 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { createTranslator } from "use-intl/core";
+import type { AvailableLocale } from "@/i18n/constants";
 
 /** Supported locales for emails. */
-export type Locale = "en" | "pt-BR" | "es" | "fr";
+export type Locale = AvailableLocale;
 
 /** Shared HTML style for email links. */
 export const EMAIL_LINK_STYLE = 'style="color: #007bff; text-decoration: none;"';

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import type { Locale } from "@/i18n/routing";
-import { SUPPORTED_LOCALES } from "./constants";
+import { AVAILABLE_LOCALES } from "@/i18n/constants";
 import { buildLocaleUrls } from "./utils";
 
 export interface PageMetadata {
@@ -54,7 +54,7 @@ export function getLocalizedMetadata(
       url,
       images,
       locale,
-      alternateLocale: SUPPORTED_LOCALES.filter((l) => l !== locale) as Locale[],
+      alternateLocale: AVAILABLE_LOCALES.filter((l) => l !== locale) as Locale[],
     },
     robots: {
       index: !noIndex,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,10 +6,10 @@ import { BboxSchema, type Bbox } from "@/types/geojson";
 import type { Area } from "@/types/area";
 import { toTitleCase, type MessageResolver } from "./tag-i18n";
 import {
-  SUPPORTED_LOCALES,
   AREA_BOUNDS_MAX_SPAN_DEG,
   DATASET_MAP_DEFAULT_ZOOM,
 } from "./constants";
+import { AVAILABLE_LOCALES } from "@/i18n/constants";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -214,7 +214,7 @@ export function getAreaCharacteristics(
  */
 export function buildLocaleUrls(siteUrl: string, path?: string): Record<string, string> {
   return Object.fromEntries(
-    SUPPORTED_LOCALES.map((locale) => [
+    AVAILABLE_LOCALES.map((locale) => [
       locale,
       path ? `${siteUrl}/${locale}${path}` : `${siteUrl}/${locale}`,
     ])

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -20,10 +20,12 @@ test.describe("SEO Implementation", () => {
       const enHreflang = await page.locator('link[rel="alternate"][hreflang="en"]').getAttribute("href");
       const ptBrHreflang = await page.locator('link[rel="alternate"][hreflang="pt-BR"]').getAttribute("href");
       const esHreflang = await page.locator('link[rel="alternate"][hreflang="es"]').getAttribute("href");
+      const frHreflang = await page.locator('link[rel="alternate"][hreflang="fr"]').getAttribute("href");
 
       expect(enHreflang).toMatch(/https:\/\/osmforcities\.org\/en\/?/);
       expect(ptBrHreflang).toMatch(/https:\/\/osmforcities\.org\/pt-BR\/?/);
       expect(esHreflang).toMatch(/https:\/\/osmforcities\.org\/es\/?/);
+      expect(frHreflang).toMatch(/https:\/\/osmforcities\.org\/fr\/?/);
     });
 
     test("should have structured data (JSON-LD) on home page", async ({ page }) => {
@@ -112,9 +114,11 @@ test.describe("SEO Implementation", () => {
       expect(text).toContain("Disallow: /en/dashboard");
       expect(text).toContain("Disallow: /pt-BR/dashboard");
       expect(text).toContain("Disallow: /es/dashboard");
+      expect(text).toContain("Disallow: /fr/dashboard");
       expect(text).toContain("Disallow: /en/preferences");
       expect(text).toContain("Disallow: /pt-BR/preferences");
       expect(text).toContain("Disallow: /es/preferences");
+      expect(text).toContain("Disallow: /fr/preferences");
 
       // Should reference sitemap
       expect(text).toContain("Sitemap:");
@@ -130,11 +134,13 @@ test.describe("SEO Implementation", () => {
       expect(text).toContain("<loc>https://osmforcities.org/en/</loc>");
       expect(text).toContain("<loc>https://osmforcities.org/pt-BR/</loc>");
       expect(text).toContain("<loc>https://osmforcities.org/es/</loc>");
+      expect(text).toContain("<loc>https://osmforcities.org/fr/</loc>");
 
       // Should include about page for all locales
       expect(text).toContain("<loc>https://osmforcities.org/en/about</loc>");
       expect(text).toContain("<loc>https://osmforcities.org/pt-BR/about</loc>");
       expect(text).toContain("<loc>https://osmforcities.org/es/about</loc>");
+      expect(text).toContain("<loc>https://osmforcities.org/fr/about</loc>");
     });
   });
 });


### PR DESCRIPTION
## Issue #452: feat(i18n): add French locale (fr)

Closes #452

**Problem:** The app supports en, pt-BR, es only. SotM Global 2026 is in Paris — the closing slide's QR code points at the homepage and the room is French-speaking.

**Acceptance Criteria:**
- [x] `fr` added to `AVAILABLE_LOCALES` / `LOCALE_DISPLAY_NAMES` and `SUPPORTED_LOCALES` / `YML_LOCALE_MAP`
- [x] `messages/fr.json` translated from `en.json` with ICU placeholders and plural forms preserved exactly
- [x] `fr` added under each template's `name`/`desc` in the templates i18n YML
- [x] `pnpm i18n:check` passes key parity for fr
- [x] Demo path driven in fr: French template names render without overflow

**Changes:**
- `messages/fr.json`: all 866 keys machine-translated (vouvoiement, OSM-FR terminology: "jeu de données", "attributs"); hand-reviewed on demo-path surfaces (navbar, homepage, search, dataset page, preferences)
- `prisma/templates.i18n.yml`: fr name/desc for all 241 templates; loads via `sync-templates`
- Locale wiring beyond the issue's list: `Locale` union in `src/lib/email-i18n.ts`, Storybook locale toolbar in `.storybook/preview.tsx`
- Tests: fr hreflang/robots/sitemap assertions in `tests/seo.spec.ts`, fr entry in `metadata.test.ts` hreflang expectation
- Docs: locale list in `docs/features/translation-system.md`

Verified: i18n:check, type-check, unit tests, Playwright seo.spec.ts (7/7), and browser walkthrough of the fr demo path (Versailles → Écoles dataset with live Overpass data).

Post-release: run `sync-templates` on production so fr rows land in `TemplateTranslation`.